### PR TITLE
fix(ci): restore green CI for April 2026 roadmap Phase 0

### DIFF
--- a/src/agent_airlock/integrations/langchain.py
+++ b/src/agent_airlock/integrations/langchain.py
@@ -166,7 +166,7 @@ def wrap_langchain_tool(
         def secured_run(*args: Any, **kwargs: Any) -> Any:
             return airlock(original_run)(*args, **kwargs)
 
-        tool._run = secured_run  # type: ignore[method-assign]
+        tool._run = secured_run
 
     return tool
 

--- a/src/agent_airlock/network.py
+++ b/src/agent_airlock/network.py
@@ -246,7 +246,8 @@ def validate_endpoint(url: str, policy: EndpointPolicy) -> None:
         )
 
     # Check localhost aliases
-    if not policy.allow_private_ips and hostname in ("localhost", "0.0.0.0"):
+    # nosec B104 - "0.0.0.0" is being blocklisted here, not used as a bind address
+    if not policy.allow_private_ips and hostname in ("localhost", "0.0.0.0"):  # nosec B104
         raise NetworkBlockedError(
             f"Localhost blocked: {hostname}",
             operation="endpoint_validation",


### PR DESCRIPTION
## Summary

Two pre-existing failures have kept CI red on `main` since Feb 6, 2026. This PR fixes both so we can start Phase 0 of the v0.5.0 April 2026 roadmap (#6) from a green baseline.

### 1. `src/agent_airlock/integrations/langchain.py:169` — unused `# type: ignore`

On mypy 1.8+, the `# type: ignore[method-assign]` is no longer needed — mypy now correctly infers `tool._run = secured_run` in the LangChain `BaseTool._run` override. Removed the comment. CI mypy step now passes.

### 2. `src/agent_airlock/network.py:249` — bandit B104 false positive

The string literal `"0.0.0.0"` inside `validate_endpoint(...)` is in a *blocklist* membership test (`hostname in ("localhost", "0.0.0.0")`) that **rejects** these aliases when `allow_private_ips=False`. Bandit can't tell the difference between a blocklist check and a `socket.bind()` target. Added `# nosec B104` with a rationale comment so future readers don't re-trigger the warning.

## Test Plan

Local, Python 3.12.7, with `[all]` extras installed:

- [x] `pytest tests/ -q --cov=agent_airlock --cov-fail-under=79` → **1172 passed, 33 skipped, coverage 80.14%**
- [x] `ruff check src/ tests/` → **All checks passed**
- [x] `python3 -m mypy src/agent_airlock/integrations/langchain.py` → **Success: no issues found**
- [x] `bandit -r src/agent_airlock/ -f txt` → **0 issues at all severities** (7 skipped via existing `# nosec` comments)
- [x] `examples/fastmcp_integration.py` → starts FastMCP 2.14.7 stdio server cleanly

CI matrix covers Python 3.10/3.11/3.12 — expected green on all three after this merges.

## Notes for reviewer

- **Scope kept minimal.** This PR is a Phase 0 prerequisite; it does not rename anything, add features, or touch the roadmap items.
- Additional mypy errors are visible locally when `[all]` extras are installed (`capabilities.py:198`, `mcp_proxy_guard.py:573`, `streaming.py:127`, `core.py:717` + `:734`) but CI only installs `[dev]` so they don't block the pipeline today. They'll be cleaned up in a follow-up `fix/mypy-extras` PR.
- CI's `--cov-fail-under=80` vs. `CLAUDE.md`'s documented 79% is noted in #6; current coverage of 80.14% passes both gates but the margin is thin.

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)