### PR TITLE
docs: add April 2026 briefing pack

### DIFF
--- a/CLAUDE_PROMPT.md
+++ b/CLAUDE_PROMPT.md
@@ -1,0 +1,131 @@
+# Claude Code — Execution Prompt for agent-airlock
+
+Paste everything below the line into a fresh Claude Code session opened in the root of this repository. Do not edit it. Do not add follow-up instructions.
+
+---
+
+You are taking over the `agent-airlock` repository and executing a 90-day plan to take it from ~5 GitHub stars to 1,000+ stars as a top 1% MCP security middleware. This prompt is the full brief — act on it end-to-end. Keep a running TODO list and tick items off as you finish them. Work in continuous sessions; when a session ends, re-read this prompt and resume from the first unchecked item.
+
+## 0. Ground rules
+
+- Today is after April 18, 2026. Claude Opus 4.7 is current. The Python SDK has been renamed from "Claude Code SDK" to "Claude Agent SDK". The MCP spec version is 2025-11-25. Cowork is GA. Verify anything you're unsure about via web search before writing code.
+- Before making ANY non-trivial change, run a web search to confirm the current spec/API/CVE. Cite the URL with a retrieval date in the commit message.
+- Never invent version numbers, CVE IDs, or API signatures. If a search returns no authoritative result, flag it `UNVERIFIED:` in the code comment or commit body and ask me in the PR description rather than guessing.
+- Python 3.10+, mypy strict, ruff, pytest with coverage ≥79%. Do not lower the coverage gate. Do not add third-party deps unless the roadmap explicitly calls for it.
+- Conventional commits. One logical change per PR. Open PRs early and iterate; don't batch weeks of work into one commit.
+- Use feature branches named `feat/<topic>`, `fix/<topic>`, `security/<topic>`, `docs/<topic>`. Merge via squash.
+- Security-sensitive code lives behind feature flags until proven with tests.
+
+## 1. Read before you start
+
+Read these files in order. Do not skim:
+
+1. `CLAUDE.md` — project conventions
+2. `ECOSYSTEM_STATE_2026-04.md` — what the world looks like as of April 2026
+3. `ROADMAP_2026.md` — the full 90-day plan for this repo
+4. `LAUNCH_PLAYBOOK_2026.md` — shared growth tactics for the three dev-tool repos
+5. `README.md`, `CHANGELOG.md`, `PRODUCTION_ROADMAP.md` if present
+6. `src/agent_airlock/` directory — scan every file, build a mental model
+7. `tests/` directory — run `pytest -v` to confirm the baseline is green before you change anything
+
+If `ECOSYSTEM_STATE_2026-04.md` or `ROADMAP_2026.md` is missing, STOP and tell me; do not proceed from memory.
+
+## 2. Phase 0 — verify the baseline (first session)
+
+1. `pip install -e ".[dev,all]"` — confirm install works on a fresh env.
+2. `pytest tests/ -v --cov=agent_airlock --cov-fail-under=79` — record baseline pass count.
+3. `mypy src/` and `ruff check src/ tests/` — fix any regressions before touching anything else.
+4. Build docs/examples and verify `examples/fastmcp_integration.py` runs.
+5. Open a GitHub issue titled "v0.5.0 roadmap — April 2026" and paste a checklist from ROADMAP_2026.md §2.1 and §2.2 into the issue body. Reference this issue from every subsequent PR.
+6. Tag the current commit as `v0.4.0-pre-april-2026` so there is a clean rollback point.
+
+## 3. Phase 1 — Must-ship compatibility fixes (Week 0–1)
+
+For each item below, open a PR, link the roadmap issue, write tests first, then code. Verify with web search that the target API is what you think it is.
+
+1. **Claude Agent SDK rename.** Update all references from "Claude Code SDK" to "Claude Agent SDK" in README, examples, and docs. Keep back-compat import shims that emit `DeprecationWarning`. Verify the current package name via web search on the Anthropic docs and PyPI before renaming imports.
+2. **MCP 2025-11-25 compliance.** Implement the Tasks primitive (SEP-1686), Streamable HTTP transport, OAuth 2.1 with mandatory PKCE/S256, and DPoP support. Each behind a feature flag in `airlock.toml`. Add `tests/mcp_spec/` with transport-level conformance tests against the reference spec. Search `modelcontextprotocol.io/specification/2025-11-25` to confirm the shape of every field.
+3. **2026 CVE regression suite.** Create `tests/cves/` with one test file per CVE listed in ROADMAP §2.1. Each test should reproduce the vulnerable pattern and assert agent-airlock blocks it. Cover at minimum: CVE-2025-59536 (Claude Code hooks), CVE-2025-68143/4/5 (mcp-server-git), CVE-2026-26118 (MS), CVE-2026-27825/27826 (Atlassian), CVE-2026-33032 (Nginx-UI), CVE-2026-23744 (MCPJam). If any CVE number does not resolve on NVD/MITRE, flag `UNVERIFIED` and stop; do not fabricate.
+4. **Policy presets.** Add `GTG_1002_DEFENSE`, `MEX_GOV_2026`, `OWASP_MCP_TOP10_2026`, `EU_AI_ACT_ARTICLE_15`, `INDIA_DPDP_2023` to `policy.py`. Each is a `SecurityPolicy` factory with documented rationale linking to the source framework. Tests assert the preset blocks a canonical offending call and allows a canonical compliant call.
+5. **SandboxBackend.Managed** for Anthropic Managed Agents. Implement as a new `sandbox_backend.py` subclass. Verify current Managed Agents API via the Anthropic docs before writing the adapter.
+6. **A2A protocol middleware.** Add a hook point in `core.py` that lets users plug an A2A validator. Ship a default implementation covering request/response schema validation against the current A2A spec. Web-search the A2A spec repo for the current schema.
+7. **Model Armor adapter.** Add an optional `integrations/model_armor.py` that forwards prompts/responses to Google's Model Armor API and surfaces violations as airlock blocks. Opt-in only.
+8. **Fix known bugs** from the deep-analysis report: sensitive-param filter misses custom names, streaming sanitizer double-counts tokens on re-entry, capability gating bypass when `@requires` stacked with `@functools.wraps`. Each gets a failing test before the fix.
+
+## 4. Phase 2 — Moat features (Week 2–6)
+
+1. **Airlock Studio** — a local-only dashboard (single binary, stdlib + one small frontend dep allowed). Shows real-time blocks, policy violations, cost/budget burn, and CVE-rule triggers from the OTel stream. Runs on `airlock studio` CLI. Include a 30-second demo GIF in `/docs/media/studio.gif`.
+2. **Opt-in small judge model.** Wire Claude Haiku 4.5 (default) and Atla Selene 8B (alt) as second-opinion scorers for borderline blocks. Cost-capped by default.
+3. **Marketplace plugin packaging.** Add `.claude-plugin/marketplace.json`, `plugin.json`, and package the install flow. Submit PRs to `anthropics/claude-plugins-official`, `claudemarketplaces.com`, `aitmpl.com`, `buildwithclaude.com`. Track PR URLs in the roadmap issue.
+4. **Blocked-CVE demo.** Record a 60-second screencast showing a live CVE payload blocked with `fix_hints` returned. Upload to `/docs/media/blocked-cve.mp4` and also as a GIF.
+5. **Performance benchmarks in CI.** Add `benchmarks/` with pytest-benchmark suites for the hot paths (validator, sanitizer, policy resolve, sandbox roundtrip). Fail CI on >15% regression vs baseline.
+6. **OTel semconv stabilization.** Publish the agent-airlock semantic conventions (spans, attributes) in `docs/observability/semconv.md`. Align with the OpenTelemetry GenAI semconv working group — web-search `opentelemetry.io/docs/specs/semconv/gen-ai` for current attribute names.
+
+## 5. Phase 3 — Documentation and polish
+
+1. Rewrite the README hero to: tagline from roadmap §5, a 20-second looping GIF, a 3-command quickstart, and a "why airlock over X" matrix (X = Snyk Agent Scan, Lakera Guard, PANW, Invariant, Cloudflare MCP, Google Model Armor). Keep each cell to one sentence.
+2. Add `docs/` site using MkDocs Material. Structure: Getting Started → Concepts → Security Layers → Policy Cookbook → CVE Catalog → Integrations → Observability → Compliance → Reference.
+3. Publish a CVE catalog page auto-generated from `tests/cves/` — every regression test surfaces as a catalog entry with a remediation snippet.
+4. Add an `examples/` folder that runs end-to-end against a real MCP server (use Anthropic's reference MCP server repo). Each example is a one-file demo with inline comments.
+5. Add `CONTRIBUTING.md`, `SECURITY.md` with a public PGP key and a 48h triage SLA, `CODE_OF_CONDUCT.md`, and an issue-template set (bug, feature, CVE-rule-request, vuln-report).
+
+## 6. Phase 4 — Launch
+
+Launch only after Phase 1 is 100% merged and tests are green. Do not launch on a Friday.
+
+1. **Target date**: a Tuesday at 13:00 UTC. Confirm the date with me in the launch-readiness PR.
+2. **HN submission**: title per LAUNCH_PLAYBOOK_2026.md. Link the GIF, not the repo. You stay in the thread for 4 hours replying to every question. Draft the top-3 anticipated questions and canned answers in `/docs/launch/hn-faq.md` first.
+3. **Reddit**: `/r/ClaudeAI` (747k), `/r/LocalLLaMA` (688k), `/r/netsec`. Same day, different angle in each. Never cross-post verbatim.
+4. **X/Twitter thread**: 8 tweets, lead with the blocked-CVE GIF, one tweet per defense layer, final tweet links the repo. Drafts in `/docs/launch/x-thread.md`.
+5. **DM list**: 10 targeted creators (simonw, swyx, karpathy, Theo, and 6 security-focused devs). Drafts in `/docs/launch/dm-templates.md` — each personalized with a repo-specific demo.
+6. **Changelog + release**: cut `v0.5.0`, publish to PyPI, attach release notes with GIF. Tag release with `launch-2026-04-xx`.
+
+## 7. Phase 5 — Post-launch (Week 5–12)
+
+Run these concurrently:
+
+1. 48-hour CVE-to-rule SLA: for every new MCP CVE published on NVD, open a PR with a regression test within 48 hours. Automate detection via a GitHub Action that watches the NVD feed keyword `MCP` and `Model Context Protocol`.
+2. Weekly CVE digest blog post on `/blog/` (Substack mirror). This is the leaderboard-ownership play from the playbook.
+3. Issue SLA: triage within 24h, label, respond within 72h for the first 60 days. Track SLA compliance in a pinned issue.
+4. Partner case studies: three design partners running airlock in production, each gets a 500-word case study published at weeks 8, 10, 12.
+5. Conference submissions: Latent Space (warm intro via Discord first), Changelog, Fireship, ThePrimeagen. Drafts in `/docs/launch/pitches.md`.
+
+## 8. Research discipline
+
+Before every non-trivial change, do the following and cite in the PR:
+
+1. Web-search the authoritative source (Anthropic docs, modelcontextprotocol.io, NVD, vendor security advisory).
+2. Paste the URL + retrieval date into the PR description.
+3. If the source disagrees with the roadmap, open a discussion in the roadmap issue before coding. Roadmap is a plan, not a law — correct it when reality moves.
+4. Maintain `docs/research-log.md` with one row per research session: date, topic, URLs, conclusion.
+
+## 9. Metrics I care about
+
+Update `docs/metrics.md` weekly with:
+
+- GitHub stars, forks, watchers
+- PyPI downloads (pypistats)
+- Docs site uniques (Plausible/Umami, not GA)
+- Discord signups
+- CVE-to-rule latency (hours)
+- Median PR review time
+- Open issue SLA compliance %
+
+Target at 90 days: 1,500 stars, 100k PyPI downloads, 500 Discord members, 90% SLA compliance.
+
+## 10. What you must not do
+
+- Do not ship a "hosted SaaS" version. The moat is offline + OSS + stdlib.
+- Do not add heavyweight deps (torch, transformers) — keep install instantaneous.
+- Do not remove the E2B sandbox backend; add alternatives alongside it.
+- Do not fabricate CVE numbers, model names, or API signatures. When unsure, flag `UNVERIFIED:` and search.
+- Do not publish the HN/Reddit posts without first opening a launch-readiness PR that checks: demo GIF exists, CVE regression suite is green, release is tagged, FAQ is drafted, rollback plan is documented.
+
+## 11. When you get stuck
+
+- If a spec is ambiguous — web-search the spec repo for recent issues/discussions.
+- If a CVE is unclear — read the vendor advisory AND the NVD entry AND any published POC; triangulate.
+- If a test fails intermittently — mark it `@pytest.mark.flaky` with a TODO and open an issue; do not ignore it.
+- If you make a change and stars don't move within two weeks post-launch — revisit the playbook, run a small post-mortem, then pivot the next week's work.
+
+Begin with Phase 0. Open PRs as you go. When Phase 1 is 100% merged, ping me in the roadmap issue before starting Phase 2.

--- a/CROSS_PROJECT_SYNTHESIS.md
+++ b/CROSS_PROJECT_SYNTHESIS.md
@@ -1,0 +1,149 @@
+# Cross-Project Synthesis — agent-airlock · agent-audit-kit · Verdict · whyCantWeHaveAnAgentForThis
+
+**Report date:** 2026-04-18
+**Scope:** How these four repos relate to each other, where they overlap, and what a combined roadmap looks like.
+
+---
+
+## 1. What the four projects have in common
+
+All four are products of the same author (`sattyamjain96@gmail.com` appears as the SES admin in whyCantWeHaveAnAgentForThis and as the Verdict plugin author), and three of the four share a tight thematic focus: **security and quality for AI-agent pipelines.** The fourth — whyCantWeHaveAnAgentForThis — is a consumer-facing satirical product that critiques AI-agent *ideas*.
+
+There is a natural layering:
+
+```
+     whyCantWeHaveAnAgentForThis
+           (SaaS consumer product, Next.js)
+                       │
+            Submits: an idea → gets a verdict
+                       │
+───────────────────────┼───────────────────────
+                       │
+               ┌───────┴────────┐
+               │                │
+        agent-audit-kit   agent-airlock
+        (static scan)     (runtime middleware)
+               │                │
+         Same mental model: MCP-era agent security
+               │                │
+               └───────┬────────┘
+                       │
+                   Verdict
+     (quality evaluator for skill / agent output)
+```
+
+All four share a Python + markdown authoring style, stdlib-first sensibilities (Verdict explicitly; agent-audit-kit largely; agent-airlock where feasible), and deep familiarity with the MCP / Claude Code / Cowork ecosystem.
+
+---
+
+## 2. The two "agent security" siblings: airlock and audit-kit
+
+**agent-airlock** and **agent-audit-kit** are the most obviously complementary — one is runtime, one is static:
+
+| | agent-airlock | agent-audit-kit |
+|---|---|---|
+| When | At call time, inside the tool handler | Ahead of time, as a CI gate |
+| What it sees | Arguments, return values, socket traffic, policy state | Source files, config files, hook definitions |
+| What it prevents | LLM-invented args, unauthorized egress, PII leaks, sandbox escapes | Hardcoded secrets, bad MCP configs, insecure hooks, poisoned tools, trust-boundary violations |
+| Output | Self-healing JSON response, audit record, OTel span | Finding objects, SARIF, OWASP map, compliance report |
+| Protocol coverage | MCP (FastMCP), LangChain, OpenAI SDK, CrewAI, AutoGen, LlamaIndex, smolagents | 13 agent platforms (Claude Code, Cursor, VS Code, Windsurf, Amazon Q, Goose, Continue, Roo, Kiro, Gemini CLI) |
+| Rule framework | Policy/Capability/Filesystem/Network objects | `RuleDefinition` dataclass, 77 rules across 11 categories |
+
+**Integration opportunities:**
+
+1. **Shared rule IDs.** Audit-kit findings and airlock block reasons could use a unified identifier schema — e.g. `AAK-MCP-003` (no timeouts) in a scan would map to an airlock `BlockReason("AAK-MCP-003")` at runtime. That would let a user trace a CI finding into the live audit log or vice versa.
+2. **Shared OWASP + compliance mappings.** Audit-kit already maps findings to OWASP Agentic Top 10, OWASP MCP Top 10, Adversa AI Top 25, EU AI Act, SOC 2, ISO 27001, HIPAA, NIST AI RMF. Airlock has none of that in its audit records. Import audit-kit's mapping tables into airlock's `AuditRecord` for parity.
+3. **Secret detection kernel.** Both projects detect API-key / JWT / AWS-credential patterns. Airlock's `sanitizer.py` has 14 carefully ReDoS-analyzed patterns; audit-kit's `secret_exposure.py` is simpler and more regex-brittle. Promote the airlock patterns into a shared `agent_security_commons` library both projects depend on.
+4. **Pinning + honeypot.** Audit-kit's SHA-256 tool-pin file (`.agent-audit-kit/tool-pins.json`) is a static fingerprint of the tool surface; airlock's `honeypot.py` detects when the LLM is probing outside its policy. The combination — pin + runtime-mismatch alert — would be a strong rug-pull defense.
+5. **MCP Proxy convergence.** Both projects ship an MCP proxy. Audit-kit's `proxy/interceptor.py` is read-only observation; airlock's `mcp_proxy_guard.py` enforces credential scope. They should be the same daemon with two modes (`--observe` vs `--enforce`).
+
+---
+
+## 3. Verdict is the quality sibling
+
+**Verdict** evaluates how well a skill or subagent executed its task — orthogonal to airlock and audit-kit, which evaluate *security*. But the connection is real: Verdict's seven dimensions include **Safety**, whose heuristics overlap with audit-kit's findings (both look for `rm -rf /`, hardcoded credentials, destructive database commands). Today those are separate regex sets; they could trivially share.
+
+**What Verdict could borrow:**
+- The audit-kit secret-detection patterns (strong form) instead of its current keyword list.
+- The airlock context-aware masking logic (skip credential patterns that are clearly in env-var usage), which is more robust than Verdict's `env|getenv|config` substring skip.
+
+**What Verdict offers the others:**
+- Agent-airlock's audit records and agent-audit-kit's scan runs are *exactly* the kind of transcripts Verdict can score. Running Verdict over the output of a red-team scan or a live audit log gives a composite quality grade that's harder to game than individual rule hits.
+
+---
+
+## 4. whyCantWeHaveAnAgentForThis is the product case study
+
+It's the "dogfood" of the other three in spirit: a real, small, production-ish AI-agent product with a consumer-facing surface, real credentials, real prompt-injection attempts, and real rate-limiting. Everything the other three projects try to defend against happens here at runtime:
+
+- **Prompt injection attempts** — the app's `validation.ts` has a regex-first filter; airlock's defense-in-depth model (ghost-arg stripping, capability gating, sanitization) is the mature version of the same idea, one layer up.
+- **Secret exposure** — the most critical finding in the audit (live creds in `.env.local`) is exactly what audit-kit's `AAK-SECRET-*` rules exist to catch. Running `agent-audit-kit scan .` inside `whycantwehaveanagentforthis/` would have raised several of these on day one.
+- **Admin-endpoint auth in a query parameter** — not covered by any of the three security tools today, but it's the kind of pattern that an "agent-config" scanner could detect.
+- **Output quality** — Verdict-style scoring of the actual Claude responses (did the model produce valid JSON? did it include all 13 required fields? did it avoid obvious hallucination markers like `Unknown` in `killer`?) would be a useful CI check on prompt drift.
+
+**Recommended concrete improvements for whyCantWeHaveAnAgentForThis specifically:**
+1. Rotate all credentials in `.env.local` today.
+2. Add `agent-audit-kit scan .` as a GitHub Action — use the author's own tool on the author's own app.
+3. Use airlock (or its principles — ghost-arg stripping, strict Pydantic-style schemas in TypeScript with Zod) to wrap the Claude call. Today the JSON extraction is regex + `JSON.parse`; Zod would catch malformed responses earlier and give structured errors.
+4. Add Verdict-style scoring of a sample of live responses to detect model drift (e.g., verdict distribution shifts over time).
+
+---
+
+## 5. Shared tech-debt patterns
+
+Recurring themes across the four codebases:
+
+| Pattern | Where it appears | Severity |
+|---|---|---|
+| Regex-based heuristics doing double duty as classifiers | Verdict (all 7 analyzers), audit-kit (secret_exposure), airlock (sanitizer), whyCant (validation.ts) | Medium — works, but false positives at the margins |
+| No exception handling around plugin / scanner boundaries | audit-kit (`engine.run_scan`) | High |
+| Optional heavy-weight dependency silently failing | audit-kit (Ollama), airlock (E2B fallback) | Medium — inconsistent UX |
+| No test suite | whyCantWeHaveAnAgentForThis | High |
+| Weight-sum / invariants not enforced by code | Verdict config | Low |
+| Public API surface inflation | airlock (~200 exports) | Low |
+| Documentation promising more than the code delivers | audit-kit (TypeScript/Rust "taint analysis" is regex) | Medium |
+
+---
+
+## 6. Suggested joint roadmap
+
+### Short-term (1–2 weeks)
+1. **Credential rotation + `.env.local` cleanup** in whyCantWeHaveAnAgentForThis (critical).
+2. **Add exception handling** around each scanner in audit-kit's `engine.run_scan`, plus a new `AAK-INTERNAL-SCANNER-FAIL` INFO-level finding (one-day fix).
+3. **Retire dead RUGPULL rules** in audit-kit or wire them into `pinning.verify_pins` (also one-day).
+
+### Medium-term (1–2 months)
+4. **Extract `agent_security_commons`** as a shared dependency used by airlock + audit-kit (+ optionally Verdict). Move the strongest secret patterns, PII detectors, and OWASP mapping there.
+5. **Unify rule IDs** across airlock and audit-kit (`AAK-XYZ-###` referenced by both).
+6. **Merge the two MCP proxies** into one tool with `--observe` and `--enforce` modes.
+7. **LLM-backed analyzer option** in Verdict (keep heuristics as default, offer Claude Haiku as opt-in).
+
+### Longer-term (quarter-scale)
+8. **Cross-cutting dashboard.** Audit-kit produces SARIF; airlock produces JSON-Lines + OTel; Verdict produces scorecards. A single dashboard that ingests all three into one view (this is where a SaaS offering would naturally live).
+9. **Framework-compatibility matrix** as a CI artifact maintained by airlock — tested framework versions, tested `vaccinate()` targets. Ship a badge.
+10. **Verdict rubric versioning** + per-rubric weight overrides.
+
+---
+
+## 7. What this combined stack looks like in practice
+
+A team that adopts all four:
+
+- **Pre-commit / CI:** `agent-audit-kit scan .` blocks PRs that add hardcoded secrets, insecure MCP configs, or poisoned tools (SARIF uploaded to GitHub Security tab).
+- **Runtime:** Every MCP tool is wrapped in `@Airlock(...)` with a policy tuned via `SecurityPolicy` / `CapabilityPolicy`. Sandbox runs on E2B. Audit records stream to OpenTelemetry.
+- **Post-run quality:** Verdict hooks `Stop` and `SubagentStop` events; any skill below the threshold (`composite < 5.0`) exits 2 and blocks follow-up work.
+- **Application layer (e.g. whyCantWeHaveAnAgentForThis):** benefits from all three, plus a Zod-validated LLM response schema modeled after airlock's ghost-arg stripping pattern.
+
+The four projects are **already** a coherent stack; they just don't quite know about each other yet.
+
+---
+
+## 8. Bottom line
+
+One author, one mental model, four lenses on the same problem:
+- **whyCantWeHaveAnAgentForThis** is "what does an AI-agent product look like in production?"
+- **agent-audit-kit** is "can I prove it's safe before it ships?"
+- **agent-airlock** is "can I stop it from misbehaving while it runs?"
+- **Verdict** is "was the output actually good?"
+
+They were probably built in that order (reactive → proactive → runtime → quality), and the natural next step is to thread them together so findings in one surface in the others. The technical foundations are there; the glue is the missing piece.

--- a/DEEP_ANALYSIS.md
+++ b/DEEP_ANALYSIS.md
@@ -1,0 +1,179 @@
+# Agent-Airlock — Deep Codebase Analysis
+
+**Version scanned:** v0.4.0 "Enterprise" (with v0.4.1 anomaly-detection / CVE-2026-26118 hardening visible in `anomaly.py`, `CHANGELOG.md`)
+**Language / stack:** Python 3.10+ · Pydantic V2 (strict) · structlog · Hatch · mypy `--strict` · ruff
+**Report date:** 2026-04-18
+**Audience:** Platform & security engineers evaluating fitness for production use
+
+---
+
+## 1. Executive summary
+
+Agent-Airlock is a **defense-in-depth middleware that sits between an AI agent and its tools**. It intercepts the kwargs an LLM passes to an MCP tool, strips hallucinated "ghost" arguments, re-validates with a strict Pydantic schema, enforces an RBAC / rate-limit / capability / filesystem / network policy stack, optionally executes inside an E2B Firecracker MicroVM, sanitizes the output for PII & secrets, and emits a structured audit trail (JSON Lines plus optional OpenTelemetry spans).
+
+The repository is in **good shape**: src/ layout with ~14.8K LOC across 36 modules, 42 test files and ~16.4K LOC of tests, mypy strict, ruff-enforced formatting, CI matrix across Python 3.10/3.11/3.12 with bandit + safety + CycloneDX SBOM generation. Coverage gate is 79 % (CI enforces 80 % in the config). The public API exported from `src/agent_airlock/__init__.py` is large (~200 symbols) which makes semver maintenance harder than it needs to be.
+
+The architecture is **sound**, but its biggest production risks come from three places that are inherent to the design rather than from sloppy coding: **(1)** monkey-patching third-party framework decorators (`vaccine.py`) and the stdlib socket module (`network.py`) — both are fragile across dependency upgrades; **(2)** a cloudpickle round-trip for remote sandbox execution, which is only safe as long as deserialization never happens on the host; and **(3)** regex-based PII detection running on untrusted output, which needs a timeout or a budget to be fully ReDoS-safe.
+
+---
+
+## 2. Repository layout
+
+```
+agent-airlock/
+├── pyproject.toml           Hatch build, 3.10+, pydantic>=2 <3, structlog, tomli (py<3.11)
+├── README.md                ~21 KB marketing/feature overview
+├── SECURITY.md              Responsible disclosure, defense-in-depth summary, ReDoS analysis
+├── CHANGELOG.md             v0.4.1 CVE-2026-26118 defense, v0.4.0 Enterprise, v0.3 Vaccine
+├── LICENSE                  MIT
+├── .github/workflows/ci.yml Test matrix (3.10/3.11/3.12) + lint + security + SBOM
+├── Dockerfile               (present)
+├── src/agent_airlock/       36 modules, ~14,850 LOC (see §3)
+├── tests/                   42 test files, ~16,444 LOC
+├── examples/                21 runnable integration examples (LangChain, CrewAI, etc.)
+└── docs/                    MkDocs site (getting-started, guide, changelog)
+```
+
+The **src/ layout** is correct — nothing leaks into the import path when the package is installed editable. Entry points for the two CLI commands (`airlock doctor`, `airlock verify`) are declared as console scripts.
+
+---
+
+## 3. Module-by-module architecture
+
+The package is organized into five conceptual layers. The table below records the real LOC and key exports observed in the source.
+
+### 3.1 Validation layer
+
+| Module | LOC | Key exports | Notes |
+|---|---|---|---|
+| `core.py` | 1,216 | `Airlock` decorator, `airlock()` helper | Five-gate pipeline. Sync/async dispatch decided at decoration time via `asyncio.iscoroutinefunction`. Signature preservation so LangChain / CrewAI can still introspect schemas. |
+| `validator.py` | 187 | `create_strict_validator`, `strip_ghost_arguments` | Builds a Pydantic V2 model from the wrapped function's signature and runs in strict mode (no coercion). |
+| `unknown_args.py` | 195 | `UnknownArgsMode` (`BLOCK` / `STRIP_AND_LOG` / `STRIP_SILENT`) | V0.4 replacement for the older boolean `strict_mode`. |
+| `safe_types.py` | 547 | `SafePath`, `SafeURL` (+ variants) | Pydantic V2 validators — directory-traversal prevention, metadata-URL blocking, regex validation. Three `# nosec` comments are in assertion-style checks, not real binds (see §5). |
+
+### 3.2 Policy layer
+
+| Module | LOC | Key exports | Notes |
+|---|---|---|---|
+| `policy.py` | 527 | `SecurityPolicy`, `RateLimit` (token bucket), `TimeWindow` | Predefined: `PERMISSIVE_POLICY`, `STRICT_POLICY`, `READ_ONLY_POLICY`, `BUSINESS_HOURS_POLICY`. |
+| `capabilities.py` | 350 | `Capability` enum (22 capabilities), `CapabilityPolicy`, `@requires()` decorator | Per-tool capability gate; granular (`filesystem.read`, `network.http`, `sandbox.execute`, etc.). |
+| `filesystem.py` | 295 | `validate_path`, `FilesystemPolicy` | Uses `os.path.commonpath` + symlink resolution; root allowlist driven. |
+| `network.py` | 713 | `validate_endpoint`, `network_airgap` context manager, `EndpointPolicy` | Socket monkey-patch (connect / connect_ex / getaddrinfo) with reference-counted install/uninstall and thread-local policy. |
+
+### 3.3 Execution layer
+
+| Module | LOC | Key exports | Notes |
+|---|---|---|---|
+| `sandbox.py` | 862 | `execute_in_sandbox`, `SandboxPool` | Warm pool of E2B MicroVMs for sub-200 ms startup. Explicit `sandbox_required=True` guard to prevent silent local fallback. |
+| `sandbox_backend.py` | 538 | `E2BBackend`, `DockerBackend`, `LocalBackend` | Pluggable. cloudpickle payload serialized, base64 over stdin; the untrusted side never runs on the host. |
+| `streaming.py` | 365 | `StreamingAirlock`, `create_streaming_wrapper` | Per-chunk PII/secret sanitization with cumulative output truncation. |
+| `context.py` | 333 | `AirlockContext`, `ContextExtractor` | `contextvars`-backed — async-safe request scope. |
+| `conversation.py` | 425 | `ConversationTracker`, `ConversationState` | Multi-turn call graph; prevents loops. |
+
+### 3.4 Post-processing & ops layer
+
+| Module | LOC | Key exports | Notes |
+|---|---|---|---|
+| `sanitizer.py` | 731 | `detect_sensitive_data`, `mask_sensitive_data`, `sanitize_output` | 14 detectors including India-specific PII (Aadhaar / PAN / UPI / IFSC). Four masking strategies: FULL / PARTIAL / TYPE_ONLY / HASH. |
+| `audit.py` | 318 | `AuditLogger`, `AuditRecord` | JSON Lines, thread-safe Lock. Option to SHA-256-hash args instead of logging them. |
+| `audit_otel.py` | 330 | `OTelAuditExporter`, `EnhancedAuditRecord` | OpenTelemetry bridge (OTLP). |
+| `observability.py` | 375 | `OpenTelemetryProvider`, `track_event`, `record_metric` | No-op provider when disabled. |
+| `circuit_breaker.py` | 346 | `CircuitBreaker`, `CircuitState` (CLOSED/OPEN/HALF_OPEN) | Per-tool breakers. |
+| `cost_tracking.py` | 487 | `CostTracker`, `BudgetConfig`, `TokenUsage` | Callback hooks, cumulative cost. |
+| `retry.py` | 372 | `@retry`, `RetryPolicy` (6 presets) | Exponential backoff + jitter. |
+| `self_heal.py` | 377 | `AirlockResponse`, `BlockReason` | The "self-healing" JSON block returned on failure, with `fix_hints` for the LLM to retry. |
+
+### 3.5 Framework-vaccine & v0.4.1 hardening
+
+| Module | LOC | Notes |
+|---|---|---|
+| `vaccine.py` | 384 | Monkeypatches `@tool` decorators in LangChain / OpenAI SDK / CrewAI / smolagents / AutoGen. `FRAMEWORK_DECORATORS` is a hard-coded registry — fragile to upstream API changes (see §8 Risk 1). |
+| `honeypot.py` | 397 | Soft-block strategy — return fake success data so the LLM doesn't enter a retry loop against the policy boundary. |
+| `mcp.py` / `mcp_proxy_guard.py` | 361 / 626 | FastMCP integration; v0.4 MCP Proxy Guard prevents credential passthrough (session binding, per-tool `CredentialScope`). |
+| `anomaly.py` | 412 | v0.4.1 addition — sliding-window call-rate monitor, endpoint diversity, error rate, consecutive-block tracking. Lock-guarded `deque`. |
+| `integrations/` | 977 | LangChain `@tool` wrapper, Anthropic SDK `ToolRegistry`, OpenAI Agents SDK guardrails bridge. |
+
+---
+
+## 4. The @Airlock decorator — real control flow
+
+From `core.py`, the ordered sequence when a wrapped tool is called:
+
+1. **Pre-execution** (`_pre_execution`), five sequential gates:
+   1. **Ghost argument handling** — `validator.strip_ghost_arguments()` diffs kwargs against `inspect.signature(func)`. `BLOCK` raises; `STRIP_AND_LOG` strips with a structlog event; `STRIP_SILENT` strips without logging.
+   2. **Security policy** — policy can be a static `SecurityPolicy` or a `Callable[[AirlockContext], SecurityPolicy]`. Checks rate-limit bucket, tool allow/deny, RBAC role, `TimeWindow`.
+   3. **Filesystem validation** — any param whose name matches `(path|file|dir|source|destination)` is pushed through `FilesystemPolicy` (root allowlist, symlink resolution, traversal prevention).
+   4. **Capability gating** — `CapabilityPolicy` verifies the tool has been granted every `@requires(Capability.*)` it declares.
+   5. **Endpoint policies (v0.4.1)** — any URL-shaped param is routed through `EndpointPolicy` (blocked IPs, allowed hosts, cloud-metadata-URL blocking).
+2. **Context binding** — `AirlockContext` (session/agent/user id) is bound into `contextvars` for the duration of the call.
+3. **Network airgap** — if `network_policy.allow_egress=False`, `network_airgap()` installs the socket interceptors via a reference-counted context manager (safe to nest).
+4. **Execution dispatch** — either `validated_func(**kwargs)` (local strict Pydantic wrapper) or `_execute_in_sandbox()` (cloudpickle → E2B/Docker/Local backend). Sync vs. async branch decided at decoration time.
+5. **Exception handling** — known exceptions (`NetworkBlockedError`, `ValidationError`, `CapabilityDeniedError`, `PathValidationError`, `PolicyViolation`, `SandboxUnavailableError`, `SandboxExecutionError`) are caught and converted into `AirlockResponse.blocked_response()` with `fix_hints`. Unknown exceptions are logged and re-wrapped.
+6. **Post-execution** — `sanitize_output()` runs if enabled, truncating to `max_output_chars` and masking per strategy.
+7. **Audit** — one JSON-Lines record per call (tool_name, blocked flag, duration_ms, sanitized_count, optional args-hash, result preview) under a per-file lock.
+8. **Return** — raw value on success, or the self-healing dict when blocked / `return_dict=True`.
+
+Documented lock order in `core.py:39–44` is `_pool_lock → audit._file_lock → _patch_lock`, which is internally consistent — no circular acquisitions were found.
+
+---
+
+## 5. Security posture
+
+| Area | Observation | Verdict |
+|---|---|---|
+| `eval` / `exec` in production | None. The two occurrences are in docstrings. | ✅ Clean |
+| `subprocess` with `shell=True` | None — `sandbox_backend.py` uses argv-style invocation for Docker. | ✅ Clean |
+| Monkey-patching | `network.py` patches `socket.connect/connect_ex/getaddrinfo`; `vaccine.py` patches framework `@tool` decorators. | ⚠️ Intentional but fragile — see Risk 1 |
+| Pickle / cloudpickle | Only in `sandbox_backend.py`, and only the *serialize* side runs on the host. Deserialize runs inside the sandbox. | ✅ As long as `sandbox_required=True` on dangerous tools |
+| `# nosec` markers | 6 total. `sanitizer.py:38` (B105 enum name, not password), `filesystem.py:290` (B108 `/tmp` paths — intentional sandbox paths), `safe_types.py:411/424` (B104 — *checking* bind addresses, not binding), `honeypot.py:90/174` (B105/B311 — deliberately fake data), `retry.py:86` (B311 — jitter, not crypto). All are justified. | ✅ |
+| PII / secret detectors | 14 patterns: email, phone, SSN, credit card, IP, Aadhaar, PAN, UPI, IFSC, OpenAI `sk-`, Anthropic `sk-ant-`, GitHub `ghp_`, AWS `AKIA/ASIA/...`, JWT, PEM private key, Slack `xox`, Mongo/Postgres/MySQL/Redis/AMQP URIs. `SECURITY.md` includes a ReDoS analysis per pattern. | ✅ Analysis documented |
+| Crypto | stdlib `hashlib` for args-hash only. No custom TLS, no HMAC. Network traffic is in-process; TLS is the caller's responsibility. | ℹ️ In scope |
+| Thread safety | `audit` (Lock), `network` (ref-counted install + thread-local policy), `sandbox` pool (`_pool_lock`), `anomaly` (Lock + `deque`), `context` (`contextvars`). | ✅ |
+
+---
+
+## 6. Testing & CI
+
+- **42 test files, ~16.4K LOC.** File map mirrors the src/ layout: `test_core.py`, `test_async.py`, `test_sandbox.py`, `test_network.py`, `test_honeypot.py`, `test_policy.py`, `test_capabilities.py`, `test_anomaly.py`, `test_streaming.py`, `test_vaccine.py`, `test_mcp.py`, etc., plus "full" integration variants (`test_core_full.py`, `test_sandbox_integration.py`, `test_framework_integration.py`, `test_remaining_coverage.py`).
+- **Coverage gate** — `pyproject.toml` declares 79 % minimum; the CI step uses `--cov-fail-under=80`. Anything below 80 breaks the build.
+- **CI (`.github/workflows/ci.yml`)** runs in three jobs:
+  1. **Test** — matrix over Python 3.10 / 3.11 / 3.12, runs ruff check, mypy, pytest with coverage, uploads to Codecov.
+  2. **Lint** — `ruff format --check` on 3.11.
+  3. **Security** — `bandit -r src/` (skips B101 assert), `safety check` (continue-on-error), `cyclonedx-py` SBOM artifact.
+
+### Potential test gaps
+
+Integration-style files like `test_remaining_coverage.py` are what keep the coverage gate green for smaller modules (`context.py`, `unknown_args.py`, `retry.py`, `cost_tracking.py`). That's a legitimate pattern, but it means regressions in one of those modules can be harder to localize from a coverage-drop signal alone. Nothing critical is untested.
+
+---
+
+## 7. Dependencies & public surface
+
+**Required** (pyproject.toml lines 40-44): `pydantic>=2,<3`, `structlog>=24`, `tomli>=2; python_version<'3.11'`. That's it — the core has a genuinely small footprint.
+
+**Optional extras**:
+- `sandbox` — `e2b>=1,<2`, `cloudpickle>=3`
+- `mcp` — `mcp>=1`, `fastmcp>=2,<3`
+- `dev` — pytest, mypy, ruff, bandit, safety, cyclonedx-bom
+- `docs` — mkdocs, mkdocs-material, mkdocstrings
+
+Everything is upper-bounded, which is responsible for a security-middleware library.
+
+**Public API surface** (from `__init__.py`): ~200 symbols. The entire v0.4.1 feature set is re-exported (anomaly detector, EndpointPolicy, CredentialScope, MCPProxyGuard, etc.). A smaller curated surface would reduce the risk of accidental breakage, but given the number of integrations, the breadth is understandable.
+
+---
+
+## 8. Top risks & improvement opportunities
+
+1. **Framework-vaccine coupling** — `vaccine.py`'s `FRAMEWORK_DECORATORS` hard-codes module paths like `langchain_core.tools.tool`. A breaking rename on the upstream side silently falls through the `try/except ImportError` and the tool becomes un-vaccinated with only a warning. Recommendation: add a CI job that pins each supported framework to its minimum / maximum tested version and fails if a monkey-patch target has moved.
+2. **Socket interceptor reference counting** — `network.py`'s `_install_interceptor` / `_uninstall_interceptor` are ref-counted; `network_airgap()` is safe because it's a context manager, but any direct call that throws between install and uninstall leaks a reference. Recommendation: make the private install/uninstall non-public, or wrap them in `try/finally` internally.
+3. **Local sandbox fallback** — `core.py:774-787` will fall back to local execution when `E2B_API_KEY` is missing *unless* `sandbox_required=True` was passed at decoration time. For a security-middleware library, the safer default is the opposite — require an explicit opt-in (`allow_local_fallback=True`) before ever running sandboxed-declared code on the host.
+4. **ReDoS budget on untrusted output** — the 14 PII/secret patterns are individually ReDoS-analyzed in `SECURITY.md`, but the cumulative cost on a 100 MB output with many near-matches has no wall-clock budget. Recommendation: add a `max_sanitize_ms` per call or wrap the regex sweep in `signal.alarm` / `asyncio.wait_for`.
+5. **Cloudpickle on the host** — the sandbox-backend serializes on the host and deserializes in the VM, which is fine. But the comment in `sandbox.py:7-9` is the only load-bearing assurance here; an accidental change that caused a host-side `cloudpickle.loads` on returned data would be a sandbox escape. Recommendation: pin a lint rule (`grep -R "cloudpickle.loads"` in a CI gate) that blocks any new `.loads` outside the sandbox subprocess.
+6. **Public-API inflation** — ~200 symbols re-exported means consumers can rely on internals. Consider a leaner, documented `__all__` and moving niche helpers into submodules users import explicitly.
+
+---
+
+## 9. Bottom line
+
+Agent-Airlock is one of the more thoughtfully engineered security-middleware projects for the MCP ecosystem. Its architecture is layered, its tests and CI are strong, and its enterprise features (capability gates, circuit breaker, OpenTelemetry, cost tracking, anomaly detector) are implemented, not stubbed. The legitimate concerns are all design-boundary issues: the cost of monkey-patching third-party frameworks, the cost of cloudpickle for remote execution, and the cost of regex-based PII on untrusted output. Each one is manageable with the mitigations above; none of them are show-stoppers.

--- a/ECOSYSTEM_STATE_2026-04.md
+++ b/ECOSYSTEM_STATE_2026-04.md
@@ -1,0 +1,194 @@
+# State of the AI-Agent Ecosystem — April 18, 2026
+
+**Source:** Six parallel deep-research passes (Anthropic, OpenAI, Google, agent-security competitors, eval/observability competitors, GitHub-growth case studies). Every claim in this file is traceable to a URL documented in the research agents' raw-source lists; in this summary I cite only the key anchors.
+
+This is the shared context behind the four per-repo roadmaps. Read this once, then jump to the roadmap for whichever project you're working on.
+
+---
+
+## 1. Anthropic — the ground has shifted under all four repos
+
+**Models (April 2026)** — `claude-opus-4-7` (Apr 16), `claude-opus-4-6` (Feb 5), `claude-sonnet-4-6` (Feb 17), `claude-haiku-4-5` (still current from Oct 2025), plus the gated `Claude Mythos Preview` research model (Apr 7, Project Glasswing cybersecurity cohort). Opus 4.7 ships a **new tokenizer** that yields up to 1.35× more tokens for the same input, so any code measuring cost/tokens against Opus 4.6 numbers will under-count.
+
+**SDK rename** — the Claude Code SDK is now the **Claude Agent SDK** (`claude-agent-sdk` on PyPI and npm, Python release Apr 16). Anything in your code referencing "Claude Code SDK" is out-of-date.
+
+**Claude Code** is on the **2.1.x line** (2.1.112 on Apr 16). New surfaces that matter:
+- **Hooks** — 12 lifecycle events, including a new **agent hook** that spawns a tool-using subagent (60 s timeout, 50 turns) alongside command/HTTP/prompt hooks.
+- **Plugins + marketplaces GA** — canonical format is `.claude-plugin/marketplace.json`. There is **no `.plugin` file extension** — plugins are folders with skills/agents/hooks/MCP/LSP. 2,500+ marketplaces tracked; Anthropic's official marketplace is `anthropics/claude-plugins-official`.
+- **Routines** (research preview, Apr 14) — cloud-scheduled prompts on cron, HTTP webhooks, or GitHub events.
+- **Skills 2.0** — renderer/discovery overhaul April 2026; 17 first-party skill directories.
+- **Slash commands** added in 2026 include `/ultrareview`, `/effort`, `/loop`, `/team-onboarding`.
+
+**Claude Cowork** is now **GA on macOS and Windows**. Shared marketplace with Claude Code. There is a known bug where marketplace-installed plugins don't surface skills in Cowork (zip uploads work) — [GH #39400](https://github.com/anthropics/claude-code/issues/39400).
+
+**MCP spec 2025-11-25** is current. Key changes that break pre-2026 middleware:
+- **Tasks** primitive (SEP-1686) — async `working/input_required/completed/failed/cancelled` state machine.
+- **Streamable HTTP** transport replacing stdio for remote servers.
+- **OAuth 2.1 mandatory** for remote servers, PKCE+S256 required, client-credentials added, DPoP under SEP review.
+- **URL-mode elicitation** for credentials/OAuth/payments.
+- Governance moved to the **Linux Foundation Agentic AI Foundation**.
+
+**MCP CVE storm** — 30+ CVEs filed against MCP servers in Jan–Feb 2026 alone. Notables: CVE-2026-33032 (Nginx-UI MCP auth bypass, CVSS 9.8), CVE-2026-27825/27826 (Atlassian MCP RCE), CVE-2026-26118 (Microsoft MCP hijacking), CVE-2026-23744 (MCPJam Inspector RCE), plus the three Anthropic `mcp-server-git` prompt-injection chains (CVE-2025-68143/68144/68145). A survey of 2,614 implementations found 82% with path-traversal issues; 36.7% of 7,000 servers were SSRF-vulnerable.
+
+**Claude API platform** — `claude-managed-agents` beta (Apr 8), `advisor-tool` beta (Apr 9), `effort` parameter GA, adaptive thinking default on Opus 4.6+, **automatic prompt caching** since Feb 19 (single `cache_control` field, system chooses breakpoints), code-execution v2 (bash + multi-language), code-execution FREE when combined with web-search/fetch, and **Messages API on Amazon Bedrock** GA Apr 16.
+
+**Safety** — **Constitutional Classifiers++** (Jan 9, jailbreak ASR 86% → 4.4% at ~1% compute overhead), **RSP v3.0** (Feb 24, controversially removed the hard-pause commitment), **Project Glasswing / Claude Mythos** (Apr 7, gated cyber-model). Two incidents matter: the **GTG-1002 disclosure** (first largely autonomous AI-orchestrated cyber-espionage via Claude Code) and the **Mexican government breach** (Feb 2026, ~150 GB exfil via prompt-engineering jailbreak).
+
+---
+
+## 2. OpenAI — has caught up on agents
+
+**Models.** `gpt-5.4` (Mar 5, 272 k context expandable to 1.05 M), `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2` (Dec 2025), `gpt-5.2-codex`, `gpt-5.3-codex` (Feb 5 — first OpenAI release classified High Cybersecurity under the Preparedness Framework, gated rollout), `gpt-5.3-codex-spark` research preview. GPT-4o / 4.1 / o4-mini retired from ChatGPT Feb 13 (API unchanged).
+
+**Codex is OpenAI's flagship agent surface** — **3 M weekly active users as of Apr 8**, per Altman. GPT-5.4 is the default Codex model since Mar 5. Codex CLI is ~74 k stars (#3 behind Claude Code and Gemini CLI). April 2026 Desktop update: background computer use, in-app browser, persistent memory, scheduled automations, 90+ plugins, Windows sandbox with proxy-only egress. **Codex Pro** tier at $100/mo launched Apr 9 (5× usage vs Plus).
+
+**Agents SDK "next evolution"** (Apr 15) — `SandboxAgent`, `Manifest`, `SandboxRunConfig`, Codex-like filesystem tools, `apply_patch`, shell tool, skills (progressive disclosure), `AGENTS.md`, MCP-based tool use. **Pluggable sandbox providers**: Blaxel, Cloudflare, Daytona, E2B, Modal, Runloop, Vercel. Breaking: drops `openai` SDK v1.x.
+
+**Responses API** absorbed the Assistants API role; Assistants shuts down **Aug 26, 2026**. Built-in tools: `web_search`, `file_search`, `code_interpreter` ($0.03/container), `image_generation`, `computer_use` (native in 5.4), `shell` (hosted Debian 12 with Python 3.11 / Node 22 / Java 17 / Go 1.23 / Ruby 3.1), remote MCP (no extra cost beyond output tokens), connectors.
+
+**MCP is universal across OpenAI products** — Responses, Realtime, Codex, Agents SDK, Apps SDK, Connector Registry. Tens of thousands of community MCP servers consumed.
+
+**OpenAI Atlas** (ChatGPT browser) + plans to merge ChatGPT / Codex / Atlas into a single desktop "superapp" (announced Mar 20).
+
+**openai-guardrails** library is the direct parallel to agent-airlock's role but with a known bypass: HiddenLayer's "Same Model Different Hat" research shows the guardrail LLM can be compromised by the same prompt that compromises the production model.
+
+---
+
+## 3. Google — meaningful competitor now
+
+**Models.** `gemini-3.1-pro-preview` (Feb 19, now Google's flagship — 77.1% ARC-AGI-2, double Gemini 3 Pro's score three months earlier), **Gemini 3 Deep Think** (Feb 12, 84.6% ARC-AGI-2, IMO 2025 gold). `gemini-3.1-flash-lite-preview` (free tier available). `gemini-3.1-flash` TTS. **Gemini Nano 4 / Gemma 4** Android preview Apr 2 (4× speedup, 60% less battery).
+
+**Gemini CLI** is v0.38.1 (Apr 15), Apache-2.0, **70+ marketplace extensions** (Dynatrace, Elastic, Figma, Harness, Postman, Shopify, Snyk, Stripe). **Free tier** — 60 req/min + 1000 req/day on a personal Google account. **GitHub Actions** integration (beta): issue triage, PR review, on-demand `@gemini-cli`.
+
+**Jules** is out of beta; **Jules Tools** (CLI + public API) available late 2025/early 2026 — direct Claude Code / Codex CLI competitor.
+
+**A2A protocol** — **150+ organizations** at its one-year anniversary (Apr 9, 2026), in production at Tyson Foods / Gordon Food Service, now in Azure AI Foundry and AWS Bedrock AgentCore. Complementary to MCP (A2A is agent-to-agent; MCP is agent-to-tool).
+
+**Vertex AI Agent Builder / ADK** — Python, Java, Go, TypeScript; `google/adk-python` v1.28.1 (Apr 2). **Enhanced Tool Governance** in Agent Builder (Dec 2025) via **Apigee-backed custom MCP servers** from existing APIs.
+
+**Google Cloud native MCP** — **Managed remote MCP servers** for Google services: BigQuery, Google Maps Grounding Lite, Compute Engine, with Cloud Run / Storage / AlloyDB / Cloud SQL / Spanner / Looker / Pub/Sub / Dataplex rolling out.
+
+**Model Armor** is GA and default-on for Gemini Enterprise — prompt injection, jailbreak, DLP, toxic content, four responsible-AI categories; **floor settings for Google-managed MCP** in preview (first cloud baseline firewall over MCP traffic).
+
+**NotebookLM Cinematic Video Overviews** — Mar 5, 2026; Gemini + Imagen + Veo as a creative director.
+
+---
+
+## 4. Agent-security market — consolidation is over, window is narrow
+
+**12-month M&A:** Check Point → Lakera (~$300 M, Nov 2025); Palo Alto Networks → Protect AI (Jul 2025, pulled into Prisma AIRS); Snyk → Invariant Labs (Jun 2025, rebranded MCP-Scan → `snyk/agent-scan`); SentinelOne → Prompt Security; F5 → CalypsoAI (~$180 M announced).
+
+**Commercial landscape (GA):** Cisco AI Defense, Prisma AIRS, Lakera Guard (Check Point), Prompt Security (S1), CalypsoAI (F5), HiddenLayer AISec, Noma Security ($132 M, 1,300% ARR growth), Pillar Security, Straiker ($21 M), Lasso, Aim Security, Giskard, Arthur Shield, WhyLabs.
+
+**Hyperscaler primitives:** Anthropic Constitutional Classifiers++, AWS Bedrock Guardrails, Azure Prompt Shields + Azure AI Content Safety + PyRIT + Red Teaming Agent, **Microsoft Agent Governance Toolkit** (OSS, Apr 2, 2026 — directly overlaps agent-airlock's framework-vaccination pattern), OpenAI Guardrails.
+
+**Open source direct competitors to agent-airlock:**
+- NVIDIA NeMo Guardrails (~5.7 k stars) — Colang DSL; conversational-focused; no ghost-arg stripping, no MCP argument-level validation, no sandbox.
+- Guardrails AI (~6.7 k) — structured-output-centric, validator hub.
+- Meta LlamaFirewall / PurpleLlama — PromptGuard-2 + Agent Alignment + CodeShield; ASR 17.6% → 1.7%.
+- Protect AI LLM Guard (~1.8 k), Rebuff (~1.4 k), Invariant OSS (~42), WhyLabs LangKit (~1 k).
+
+**Open source direct competitors to agent-audit-kit:**
+- **Snyk Agent Scan** (ex-Invariant MCP-Scan) — the big one. Multi-model analysis, claims 90–100% recall / 0% FP on ToxicSkills.
+- Cisco AI-Defense `mcp-scanner`, `riseandignite/mcp-shield`, `mcpshield/mcpshield`, `affaan-m/agentshield`, `HeadyZhang/agent-audit` (49 rules, OWASP Agentic 2026 — close overlap with your 77).
+- Semgrep Multimodal SAST (2026): AI reasoning + deterministic, 8× TP, 50% fewer FP.
+- Protect AI `modelscan` + `mmaitre314/picklescan` for model files.
+
+**Benchmarks now standard:** AgentDojo (97 tasks × 629 security cases), AgentHarm (ICLR 2025), InjecAgent, ToolEmu, AgentBench, **Lakera PINT** (4,314 inputs), Gandalf, **ToxicSkills** (Snyk). Neither `agent-airlock` nor `agent-audit-kit` appears on any public leaderboard — easy credibility lift.
+
+**Regulation timeline that forces adoption:**
+- **EU AI Act high-risk obligations** apply **Aug 2, 2026** (Article 15 cybersecurity, Article 55 GPAI).
+- **OWASP Top 10 for Agentic Applications 2026** (ASI01–ASI10) released Dec 2025.
+- **OWASP MCP Top 10** project live.
+- **ISO/IEC 42001** AI Management System certification — now required in some enterprise RFPs.
+- Singapore Agentic AI Governance Framework (Jan 2026) — first national framework.
+
+---
+
+## 5. LLM-eval market — dense but Verdict has unique white space
+
+**Production observability + eval:** LangSmith, Braintrust, Helicone (~4.8 k), Langfuse (~12.8 k), Phoenix/Arize (~6.4 k), Langtrace, AgentOps (~4.6 k), Opik (~9.4 k).
+**Eval-first frameworks:** Promptfoo (~7.2 k), DeepEval (~7.9 k), Ragas (~9.7 k), Inspect AI (~1.6 k UK AISI), Autoevals (~2.1 k), TruLens (~2.5 k), Giskard (~4.4 k), OpenAI Evals (~16.1 k).
+**Agent-runtime scorers:** AgentOps, Galileo Luna-2, Patronus Lynx.
+
+**Small-judge models** cutting eval cost by 50×: Atla AI **Selene** (8 B, Dec 2025), Patronus Lynx, Galileo Luna-2, LastMile AutoEval.
+
+**Benchmarks landscape (Apr 2026):** static benchmarks (MMLU-Pro, AlpacaEval, MT-Bench) saturated. The action is on **τ-bench / τ²-bench** (Sierra, Q1 2026), **LiveBench** (monthly refresh, contamination-free), **SWE-bench Verified / Live**, **ARC-AGI-2**, **HLE (Humanity's Last Exam)**, **BrowseComp / BrowseComp-Long**, **SWE-Lancer**, **MLE-Bench**, **Cybench**, **GDPval**.
+
+**Claude Code native evaluators:** Anthropic ships none. Community `agent-judge` skill exists (~150 stars) but no persistence, no hooks, no rubrics. **Verdict occupies genuine white space** as a Claude Code plugin with hook-based auto-scoring + persistent scorecards + offline heuristics.
+
+---
+
+## 6. Viral consumer AI — the playbook is now standardized
+
+**Verdict-machine canon (most relevant to whyCantWeHaveAnAgentForThis):** Roast My Resume / Website (2023), Wrapped-for-X clones (2024), Delphi.ai (2024–25), Websim (~2 M users summer 2024), roast-my-x (Levels, $30 k first week), AI personality quizzes (16 Personalities pattern).
+
+**What separates winners:**
+1. Per-result OG images optimized for screenshot-sharing.
+2. Tier-claiming behavior ("I got SHUT_UP_AND_TAKE_MY_MONEY!").
+3. One-click share with prefilled content (not "take a screenshot").
+4. Public gallery / leaderboard.
+5. Founder-led seeding of 10–50 micro-influencers in week one.
+6. Structured verdict with "evidence" the user accepts (tables, scores, competitors).
+7. Consulting / premium funnel on positive-tier verdicts.
+
+**Regulatory hygiene for satirical AI (now enforced):** EU AI Act Article 50 transparency (in force Aug 2026), DSA notice-and-takedown, Anthropic Usage Policies on defamation, trademark risk on auto-generated agent names, post-*Anderson v. TikTok* Section 230 erosion for AI-generated content.
+
+---
+
+## 7. GitHub-growth quantitative baseline
+
+From peer-reviewed arXiv paper **"Launch-Day Diffusion"** (2511.04453, Nov 2025), analyzing 138 AI-tool HN launches during 2024–2025:
+- Average gain after HN exposure: **+121 stars in 24 h, +189 in 48 h, +289 in a week.**
+- Best post window: **12:00–17:00 UTC** (~8 am–1 pm US Eastern). Gap between optimal and suboptimal hours ≈ 200 stars.
+- The literal "Show HN:" prefix shows **no statistical advantage** after controlling for time-of-day.
+
+**Case-study patterns that recur in 10 k+ projects:**
+1. Launch with a news-cycle hook (OpenHands = "open-source Devin"; browser-use rode Manus's virality for 5× downloads in a week; Cline rode Claude 3.5 Sonnet).
+2. Ride an ecosystem's distribution (Cline lives in VS Code Marketplace; FastMCP rode the MCP wave to 10 k stars in 6 weeks; Claude Code now has 9,000+ plugins in 2,500+ marketplaces).
+3. Demo with a 20-second loopable GIF in the README, not a static screenshot.
+4. **Own a benchmark/leaderboard.** Aider publishes the Polyglot leaderboard; every major LLM launch links back. Single highest-leverage tactic in the data.
+5. Community flywheel — Discord with 1 k+ engaged members before 10 k stars. Continue had 11 k Discord before 30 k stars.
+6. Short name, matching domain (Aider, Cline, Trivy, Nuclei, Roo, Kilo, Zed).
+
+---
+
+## 8. Biggest shifts since January 2026 (ranked by impact on these four repos)
+
+1. **Claude Agent SDK rename + Python release (Apr 16)** — every mention of "Claude Code SDK" in these repos is now stale.
+2. **Claude Managed Agents beta + OpenAI SandboxAgent (Apr 8 / Apr 15)** — both clouds now ship managed agent harnesses that bundle sandbox + guardrails. Middleware positioning has to shift toward "bring-your-own MCP fleet."
+3. **MCP spec 2025-11-25 (OAuth 2.1 mandatory + Tasks + Streamable HTTP)** — stdio-only or unauthenticated middleware is legacy.
+4. **30+ MCP CVEs in Jan–Feb 2026** — perfect validation-of-thesis moment for agent-airlock and agent-audit-kit.
+5. **Plugins/marketplaces consumed Skills** — Verdict should be distributed as a marketplace plugin, not a standalone skill repo.
+6. **Microsoft Agent Governance Toolkit (Apr 2)** — first-party entrant overlapping agent-airlock's framework-vaccination pattern.
+7. **Snyk bought Invariant Labs** — `snyk/agent-scan` is now the dominant OSS MCP scanner; agent-audit-kit needs sharper differentiation.
+8. **Gemini CLI + A2A protocol + Google-managed MCP** — expand coverage beyond Claude if these projects want to stay relevant.
+9. **OWASP Top 10 Agentic 2026 + OWASP MCP Top 10 + EU AI Act Aug 2026** — compliance-evidence output is the strongest commercial wedge.
+10. **Opus 4.7 tokenizer change** — any cost/efficiency scoring in Verdict will mis-count on post-4.6 models.
+
+---
+
+## 9. Where the four repos stand after this research
+
+| Repo | Category | Direct competitors | White space that's still open | Risk window |
+|---|---|---|---|---|
+| agent-airlock | MCP runtime middleware | NeMo, LlamaFirewall, Microsoft Governance Toolkit, Lakera | Arg-level Pydantic-strict validation + E2B sandbox + ghost-arg modes + multi-framework vaccination in one decorator. Nobody else combines these. | 3–6 months before Microsoft toolkit grows integrations |
+| agent-audit-kit | MCP / agent static scanner | Snyk Agent Scan, mcp-shield, Semgrep Multimodal | Compliance-evidence reports (EU AI Act, ISO 42001, HIPAA) + CVE-to-rule velocity + India PII pack | 2–4 months before Snyk ships equivalent compliance output |
+| Verdict | Claude Code eval plugin | No direct competitor (community `agent-judge` is tiny) | Entire category is empty — plugin marketplace + hook auto-scoring + offline heuristics + rubric library | 6+ months; genuinely first-mover |
+| whyCantWeHaveAnAgentForThis | Satirical consumer AI | Copycats welcome; no single dominant "idea validator" | Tier-as-identity + consulting funnel + curated leaderboard + newsletter | Short because trend-dependent; ship within 2–3 weeks |
+
+---
+
+## 10. Cross-repo dependencies and shared work
+
+Three pieces of work should be done **once** and shared across repos:
+
+1. **`agent_security_commons`** shared Python library — pull the strong secret patterns, the India PII pack, the OWASP mapping tables, and the new-2026-CVE rule bundle into one dependency used by both agent-airlock and agent-audit-kit.
+2. **Unified rule ID schema** — `AAK-MCP-003` must mean the same thing at scan time (audit-kit finding) and runtime (airlock block reason) so an engineer can trace either direction.
+3. **Unified OpenTelemetry semconv for agent security events** — contribute upstream to OTel GenAI semconv. Once accepted, agent-airlock audit records and agent-audit-kit scan results both emit the same event schema, and Verdict consumes those events as one of its scoring signals.
+
+Together these three pieces reduce maintenance cost and give the portfolio a consistent story when pitched.
+
+---
+
+*See per-repo `ROADMAP_2026.md` files for concrete action plans, and the shared `LAUNCH_PLAYBOOK_2026.md` for the 90-day growth playbook.*

--- a/LAUNCH_PLAYBOOK_2026.md
+++ b/LAUNCH_PLAYBOOK_2026.md
@@ -1,0 +1,234 @@
+# The 90-Day Launch Playbook — Open-Source AI Dev Tools (2026)
+
+Cross-repo growth playbook shared by `agent-airlock`, `agent-audit-kit`, and `Verdict`. The consumer app `whyCantWeHaveAnAgentForThis` has its own (different) playbook — see its ROADMAP.
+
+Grounded in the arXiv peer-reviewed analysis of 138 AI-tool HN launches (2511.04453, Nov 2025) and case studies of 15 projects that went from <100 to 1 k+ / 10 k+ stars (Aider, Cline, Continue, OpenHands, FastMCP, browser-use, Semgrep, Trivy, Gitleaks, Nuclei, screenshot-to-code, Roo, Kilo, Stagehand, CrewAI).
+
+---
+
+## 1. Quantitative baseline you should internalize
+
+From the peer-reviewed HN data:
+
+- Average star gain after HN front-page exposure: **+121 in 24 h, +189 in 48 h, +289 in 7 days.**
+- Best posting window: **12:00–17:00 UTC (≈ 8 am–1 pm US Eastern).** Gap between optimal and suboptimal hours: ~200 stars.
+- The literal "Show HN:" prefix shows **no statistical advantage** after controlling for time-of-day and content. Use plain URL + factual title.
+- Tuesday–Thursday outperforms Monday/Friday for front-page longevity (UNVERIFIED consensus, but aligned with reply patterns).
+
+**Target:** a clean HN front-page run for each of the three dev-tool repos gets each to ~300 stars passively. The next 700 stars come from distribution work in weeks 2–12.
+
+---
+
+## 2. The pattern of 10 k+ projects (separators from 1 k)
+
+From the case-study analysis:
+
+1. **Launch-week news-cycle hook.** OpenHands was "the open-source Devin" during the Cognition news wave. browser-use 5× downloads in a week when Manus tweeted about them. Cline rode the Claude 3.5 Sonnet release. FastMCP rode MCP itself to 10 k in 6 weeks.
+2. **Ecosystem co-distribution.** Cline lives in VS Code Marketplace — every install is a star candidate. Verdict will live in the Claude plugin marketplace. agent-audit-kit's GitHub Action is its marketplace.
+3. **Demo content.** A 20-second loopable GIF at the top of the README that makes sense with sound off. A 90–180 s Loom for depth.
+4. **Own a leaderboard.** Aider publishes the Polyglot leaderboard; every LLM vendor links back on launch day. This is the single highest-leverage tactic in the data. Equivalents for this portfolio: agent-airlock owns AgentDojo/PINT/AgentHarm numbers for MCP middleware; agent-audit-kit owns the **MCP Security Index** (weekly grades of 10 k public MCP servers); Verdict owns the **State of Claude Code Skills Quality** monthly report.
+5. **Community flywheel.** Continue had 11 k Discord before 30 k stars. Nuclei paid $50–$250 bounties per community-written template → 12 k templates, 8 k Discord.
+6. **Naming.** 1–2 syllables + matching domain.
+7. **Response SLA.** Issues answered in <24 h for the first 60 days, <72 h thereafter. 10 k projects respond fast; 1 k projects don't.
+
+---
+
+## 3. The 90-day timeline (per repo)
+
+### Weeks 1–2 — Foundation (pre-launch T-90 to T-76)
+
+**README v2:**
+- Title + one-line tagline
+- Hero GIF (20 s, loopable, no sound)
+- Install command (one line)
+- 3 usage examples
+- Feature list (max 10 bullets)
+- Badges: CI, PyPI/npm, license, Discord
+- "Why" section (the news-cycle hook)
+
+**Domain + one-pager:**
+- Buy the matching domain (`airlock.dev`, `aak.report`, `verdict.dev` / `getverdict.com`)
+- Single-page Vercel landing: same GIF + CTA to GitHub
+
+**Housekeeping:**
+- CHANGELOG.md (Keep-a-Changelog format, semver)
+- Issue templates (bug, feature, question)
+- CONTRIBUTING.md
+- 5–10 "good first issue" labeled issues
+- Empty Discord ready, link in README
+- Signed release artifacts (Sigstore for Python, npm provenance for TS)
+
+### Weeks 3–4 — Seed content (T-76 to T-62)
+
+- Record 90–180 s Loom demo (screen-share with voiceover; no edits)
+- Upload to YouTube unlisted
+- Write 3 technical blog posts (benchmarks, case studies, a "why we built this" post)
+- Draft launch-week posts for HN, `/r/ClaudeAI`, `/r/LocalLLaMA`, `/r/netsec` — not published yet
+- Run 10 benchmark comparisons against competitors; lock numbers
+- Fix top 5 real-user bugs from small-circle feedback
+
+### Weeks 5–6 — Quiet launch (T-62 to T-48)
+
+- Publish to PyPI / npm / VS Code Marketplace / Claude plugin marketplace. **Get distribution surface presence before the HN post** so new arrivals can install instantly.
+- Share in 3–5 small Discords/Slacks you're already in for honest feedback, not stars
+- Collect 2–3 friendly quotes to lead with on launch
+- Fix the top issues from week-5 feedback
+
+### Weeks 7–8 — Loud launch week (T-48 to T-34)
+
+**Day 1, Tuesday, 13:00 UTC:**
+- HN submission. Title factual, not hype. URL points at the **blog post with the news-cycle hook** (not the README, which is one click away).
+- Post your own first comment within 15 minutes with motivation + Loom link.
+- **Stay on HN for 4 hours**, respond to every comment. Single biggest determinant of front-page longevity.
+- 60 minutes later: post an 8-tweet X thread. Tweet 1 is the GIF + problem statement. Tweets 2–6 are features with sub-GIFs. Final tweet is the repo link. @-mention 1–2 people who've tweeted about the problem in the last 30 days (warm, not cold).
+
+**Day 2:**
+- `/r/LocalLLaMA` (688 k) or `/r/ClaudeAI` (747 k) — whichever fits the repo best (`agent-airlock` → both; `agent-audit-kit` → `/r/netsec` + `/r/LocalLLaMA`; `Verdict` → `/r/ClaudeAI`).
+- 90/10 rule: your account history should be mostly non-promotional comments.
+- Screenshot-lead format, link in comments.
+
+**Day 3:**
+- Product Hunt optional (only worth it for Verdict among the three dev tools).
+
+**Day 4:**
+- Dev.to cross-post of the strongest blog post. Better than Medium in 2026 due to ChatGPT / Perplexity citation preference.
+
+**Day 5:**
+- Short thread summarizing "What I learned launching this" with updated stats. Second HN-adjacent spike.
+
+### Weeks 9–12 — Sustained drumbeat (T-34 onward)
+
+- **Weekly release cadence.** Aider releases nearly weekly. Cline went 5 k → 40 k with relentless releases. Every release is an excuse for a tweet.
+- **One long blog post per 2 weeks.** Benchmarks, case studies, CVE write-ups, postmortems — content that earns backlinks.
+- **One podcast pitch per week** (Changelog accepts cold pitches via form; Latent Space requires warm intro via Discord first; ThePrimeagen / Theo / Fireship cover organic viral content, don't cold-pitch).
+- **Answer every GitHub issue within 24 h** for the first 60 days.
+- **Reply to every tweet mentioning the repo.** Manually.
+- Month-2 second-wave launch hook: a benchmark update, a major version, or a new integration.
+
+---
+
+## 4. Distribution channel deep-dive
+
+### Hacker News
+- **When:** Tuesday–Thursday, 12:00–17:00 UTC.
+- **How:** Plain URL + factual title. No "Show HN:" unless literally demo. Comment on own post in first 15 min.
+- **Stay in thread for 4 hours** responding to comments. This is the single biggest retention lever.
+- **Pre-coordinate 5–10 upvotes** in first 30 min from your existing network. Standard practice; not a violation.
+- **Expected outcome:** +121 stars in 24 h, +289 in 7 days on a successful front-page run.
+
+### Reddit
+- `/r/LocalLLaMA` (688 k) — loves local-first tools + privacy angles. Fits all three security tools and Verdict's "no LLM required" angle.
+- `/r/ClaudeAI` (747 k) — dominant subreddit for Claude tooling. **Verdict's highest-leverage channel.**
+- `/r/netsec` — agent-audit-kit fit.
+- `/r/MachineLearning` (3 M) — high karma req, hostile to self-promo. Skip on launch; use for benchmark-heavy follow-up only.
+- `/r/programming` (7 M) — hostile to self-promo. Use via third-party writeups.
+- Post format: problem statement + code snippet + "here's what I learned" + screenshot. Link in comments.
+
+### Twitter / X
+- **Threads beat singles.** swyx's smol-developer thread = 1.5 M views; Gregor Zunic's browser-use update = 2.4 M views.
+- 5–8 tweets. Tweet 1 must stand alone with the GIF.
+- @-mention 1–2 people who've tweeted about your problem in the last 30 days (warm, not cold).
+- Re-post thread fragments as standalone posts weekly.
+
+### Product Hunt
+- **Worth it** for consumer-feel tools (v0, Cursor, Kilo — Kilo hit #1 Product of the Day and raised $8 M seed).
+- **Not worth it** for niche security scanners unless you have a landing page + demo video at consumer-app polish.
+- Portfolio split: `whyCantWeHaveAnAgentForThis` = strong PH candidate. `Verdict` = medium. `agent-airlock` / `agent-audit-kit` = skip, focus HN.
+
+### Podcasts / YouTube
+- **Latent Space (swyx + alessio)** — does not take cold pitches. Path: become known in their Discord first, then warm intro.
+- **Changelog** — accepts form pitches; AI infra is regular topic.
+- **Fireship** — covers organic trends only, don't pitch.
+- **ThePrimeagen / Theo** — same.
+- **Lesson:** podcasts are a *consequence* of HN/Twitter success, not a *cause*. Don't pitch until after a first HN front page.
+
+### Dev.to vs Medium in 2026
+- Dev.to: still strong for technical posts with code; better for ChatGPT / Perplexity citations (10× referral traffic vs a year earlier per 2026 SEO reports).
+- Medium: paywall hurts technical posts. Skip unless already published there.
+
+### Conferences / in-person
+- **BlackHat Arsenal / DEF CON AI Village / RSAC** — agent-airlock and agent-audit-kit CVE corpuses make strong abstracts.
+- **KubeCon AI + OpenTelemetry sessions** — agent-airlock's OTel integration is relevant.
+- **PyCon / NodeConf / JSConf** — broader dev audiences; secondary priority.
+
+---
+
+## 5. The Top-1% checklist (1 k vs 10 k separators)
+
+| Trait | 1 k-star median | 10 k+ pattern |
+|---|---|---|
+| Hero demo | static screenshot | **20 s loopable GIF or YouTube at top of README** |
+| Demo video length | none or 5+ min | **90–180 s Loom/YouTube**, one-take, problem→fix |
+| README length | 200 or 2,000 lines | **300–700 lines**, scannable, examples-first |
+| Integration surface at launch | 1 (your CLI) | **2–3** (CLI + VS Code + one SDK) |
+| Issue SLA | days–weeks | **<24 h for first 60 days**, <72 h ongoing |
+| Release cadence | monthly or random | **weekly or bi-weekly**, visible CHANGELOG |
+| "Good first issue" count | 0–1 | **5–15 tagged**, triaged monthly |
+| Discord members before 10 k stars | 0 or <200 | **>1,000 engaged** |
+| Own-medium content | none | **weekly technical blog, monthly benchmark** |
+| Ecosystem plug-in | standalone | **Claude Code / VS Code / OpenRouter / MCP ecosystem** |
+| News-cycle hook at launch | generic | **explicit tie** ("uses new Claude 4.7" / "open-source answer to X") |
+| Benchmark ownership | none | **you own a leaderboard vendors link to** (Aider pattern) |
+| HN response | delayed | **author replies to every comment for 4 hours** |
+| Naming | long/descriptive | **1–2 syllables**, matching domain |
+
+---
+
+## 6. Shared portfolio-level tactic
+
+Because all three dev-tool repos are by the same author and thematically adjacent, they should **cross-promote explicitly**:
+
+- Each README has a "Sibling projects" section with one-line summaries of the other two + links.
+- A shared `github.com/<user>` org-level profile README that tells the story: "static scan (audit-kit) → runtime enforce (airlock) → output-quality (Verdict) → built while doing (whyCant)."
+- A single blog (airlock.dev blog, for example) that hosts all three projects' technical posts.
+- Cross-link in every launch post: "If you liked this, you'll also like [sibling]."
+- Shared Discord with channels per project. Reduces per-project moderation overhead.
+- Shared Twitter presence — a single account posting updates for all three. Or tie into the author's personal account.
+
+The four repos are already a coherent stack in design; making the story visible in distribution materials is pure upside.
+
+---
+
+## 7. Launch order (recommendation)
+
+Launch in this order over weeks 7–10:
+
+1. **Verdict first.** White space is clearest, distribution friction is lowest (Claude plugin marketplace), fastest expected path to 1 k. Launching first proves the playbook and generates proof-of-work for the other two.
+2. **agent-airlock second.** Benefits from Verdict's traction (cross-promote). News-cycle hook on the 30-CVE corpus is still live.
+3. **agent-audit-kit third.** Requires the MCP Security Index scan (longer prep). Coordinated CVE disclosures benefit from having airlock's runtime defense in the same story.
+
+`whyCantWeHaveAnAgentForThis` runs on a different timeline (consumer app, Product Hunt + TikTok, not HN). Launch it **after** Verdict has cleared HN so that portfolio credibility is visible when the TechCrunch / Insider writeups happen.
+
+---
+
+## 8. What to measure at the portfolio level
+
+| Metric | 30-day | 90-day | 1-year |
+|---|---|---|---|
+| Combined GitHub stars across 3 dev-tools | 750 | 6,500 | 33,000 |
+| Combined PyPI + npm downloads / month | 5,000 | 70,000 | 850,000 |
+| HN front-page appearances | 2 | 5 | 15 |
+| Podcast episodes featuring a repo | 0 | 2 | 10 |
+| Conference talks given | 0 | 1 accepted | 4 |
+| Combined Discord members | 150 | 1,000 | 7,000 |
+| Named design partners | 3 | 15 | 50 |
+| OWASP / standards-body citations | 0 | 2 | 8 |
+
+---
+
+## 9. What *not* to do (portfolio-level)
+
+- **Don't launch all four simultaneously.** Splits attention; each launch cannibalizes the others' HN slot. Space by 2–3 weeks.
+- **Don't skip Discord.** Every 10 k-star project has one by 2 k stars.
+- **Don't over-invest in dev.to / Medium.** Primary content lives on your own domain (backlinks + SEO). Cross-post to dev.to only.
+- **Don't answer HN comments after hour 4.** Diminishing returns; your time is better on the thread on Day 2 elsewhere.
+- **Don't pitch Latent Space / Fireship cold.** Wait for organic traction.
+- **Don't sell anything in month 1.** Stars over MRR in the opening phase; the commercial wedge (compliance evidence, Airlock Studio pro tier, Verdict team digests) comes after distribution is real.
+
+---
+
+## 10. The closing note
+
+The four repos are **already a coherent stack**. What's missing is distribution work, not engineering work — and the research above shows the playbook is mechanical enough that a disciplined 12-week execution gets all three dev-tool repos past 1 k stars with moderate-to-high confidence, and gives `whyCantWeHaveAnAgentForThis` a real shot at the 100 k-monthly-visit tier.
+
+The single highest-leverage next action is to **clean up whyCant's credentials this hour**, then spend the rest of the week on Verdict's v1.1 polish for a Week 7 launch.

--- a/ROADMAP_2026.md
+++ b/ROADMAP_2026.md
@@ -1,0 +1,146 @@
+# agent-airlock — Roadmap to Top 1% (April 2026)
+
+**Starting point (Apr 2026):** v0.4.0 "Enterprise" · ~25,900 LoC · 1,157 tests · 79%+ coverage · stars in single digits.
+**Goal:** 1,000+ GitHub stars, top-1% positioning in "runtime MCP security middleware" category within 90 days; top-0.1% within a year.
+
+Read `ECOSYSTEM_STATE_2026-04.md` first for the market context behind this plan.
+
+---
+
+## 1. The positioning problem
+
+Today's README says "open-source security middleware for MCP servers." In a category that now includes NeMo Guardrails, LlamaFirewall, Guardrails AI, Lakera, Prisma AIRS, CalypsoAI, Pillar, Noma, Straiker, Lasso, Aim, openai-guardrails, AWS Bedrock Guardrails, Azure Prompt Shields, Anthropic Constitutional Classifiers, and **Microsoft Agent Governance Toolkit (launched Apr 2, 2026)** — that sentence wins nothing.
+
+What you actually ship that no competitor combines in a single decorator:
+
+1. **Ghost-argument tri-mode** (`BLOCK` / `STRIP_AND_LOG` / `STRIP_SILENT`) on tool arguments — nobody formalizes this. NeMo / LlamaFirewall / Lakera / OpenAI Guardrails all do prompt-level detection, not argument-level enforcement.
+2. **Pydantic V2 strict validation with self-healing `fix_hints` JSON** — the LLM-retry-loop is a primitive no runtime competitor ships.
+3. **E2B Firecracker MicroVM sandbox + warm pool** inside the same decorator.
+4. **Capability gating via `@requires(Capability.*)`** for fine-grained RBAC.
+5. **Multi-framework vaccination** — LangChain, OpenAI Agents SDK, CrewAI, AutoGen, LlamaIndex, smolagents, PydanticAI, Anthropic, LangGraph.
+6. **PII detection including the India pack** — Aadhaar, PAN, UPI, IFSC. No competitor ships this in OSS.
+7. **Circuit breaker + cost tracking + retry + OTel audit** in the same guardrail layer (competitors split these across separate libraries).
+
+**Recommended one-line tagline:** *"The airlock between your agent and the internet — argument-level schema enforcement, ghost-arg stripping, sandbox execution, and OTel audit in a single `@Airlock(...)` decorator."*
+
+**Hero use case:** a tool call that would have leaked a secret via an LLM-invented argument, blocked and returned a self-healing `fix_hints` payload the LLM actually uses to retry correctly. That is the 60-second video.
+
+---
+
+## 2. Critical gaps vs April 2026 state of the art
+
+### 2.1 Must-ship before any launch
+
+| Gap | Current state | Target state | Why |
+|---|---|---|---|
+| **SDK rename** | Code and docs reference "Claude Code SDK" | Full rename to **Claude Agent SDK** (`claude-agent-sdk` on PyPI and npm, Apr 16) | Anything still saying "Claude Code SDK" looks stale on launch day |
+| **MCP transport** | Stdio-first, streamable HTTP partial | **Streamable HTTP + OAuth 2.1 + PKCE/S256** per MCP `2025-11-25` spec | Remote servers are now mandatory-OAuth; stdio-only middleware is legacy |
+| **MCP Tasks primitive** | Not handled | Handle `working / input_required / completed / failed / cancelled` state machine, including the long-running elicitation flow | Adopted across real MCP servers in 2026 |
+| **DPoP / client-credentials support** | Missing | Implement client-credentials grant (SEP-1046) and DPoP (SEP draft) | Required by enterprise MCP adopters |
+| **CVE-2025-68143/68144/68145 coverage** | Not tested | Include a regression test that proves airlock blocks the three `mcp-server-git` prompt-injection chains | Validation-of-thesis marketing moment |
+| **CVE-2025-59536 coverage** | Not covered | Regression test for the Claude Code hooks RCE + MCP consent bypass | Same |
+| **Nginx-UI CVE-2026-33032, Atlassian CVE-2026-27825, MS MCP CVE-2026-26118, MCPJam CVE-2026-23744** | Not covered | At minimum a reproduction scenario under `tests/cves/` | Defensive credibility |
+| **Published AgentDojo / PINT / AgentHarm scores** | None | First OSS MCP middleware on these leaderboards | Competitive credibility |
+| **Opus 4.7 tokenizer** | Unaware | Update cost-tracking tables with the new tokenizer ratios | Otherwise cost reports mis-count by up to 35% |
+| **`claude-managed-agents` interop** | Unaware | Document an explicit "what to use when Managed Agents is enough vs when to add airlock" comparison | Claude Managed Agents (Apr 8) is now a substitute for middleware in simple cases; own the narrative |
+
+### 2.2 Features that widen the moat
+
+1. **`SandboxBackend.Managed`** — pluggable backend that delegates execution to Anthropic Managed Agents or OpenAI SandboxAgent. Users keep airlock as the validation/audit layer while Anthropic/OpenAI runs the container. Turns a competitive threat into a distribution partnership.
+2. **Google A2A protocol middleware** — A2A is complementary to MCP. Wrap A2A peer invocations with the same policy/capability model. You'd be the first OSS project doing this.
+3. **Model Armor integration** — Google Cloud's Model Armor is default-on for Gemini Enterprise. Ship a `ModelArmorAdapter` so airlock's event stream registers with Model Armor (and vice-versa). Cross-ecosystem adapter = enterprise RFP lever.
+4. **Anthropic Advisor tool awareness** — pair-model pattern is a new primitive (Apr 9 beta). Ship a `@Airlock.advised(Capability.PRIVILEGED)` decorator that enforces a second-model advisor call before a privileged tool runs.
+5. **Automatic prompt caching** telemetry — read the `cache_control` header and emit OTel spans so users can see what fraction of their agent loop hit cache.
+6. **Managed honeypot rotation** — your `honeypot.py` is static. Ship deception templates generated per-request so attackers can't fingerprint. 2026 red-team reports (Anthropic GTG-1002, Mexican government breach) show persistent-jailbreak attackers who need dynamic deception.
+7. **Distributed rate limiting** on Redis / Upstash — your roadmap already lists this. Do it. Single-node token-bucket is a non-starter in any multi-node deploy.
+8. **Per-tool Zod / TypeScript support** — ship a sibling TypeScript package `@airlock/core` that mirrors the decorator and uses Zod for strict validation. Next.js / OpenAI Agents TS SDK users are 40%+ of the agent-building world now.
+9. **Airlock Studio** (open-source GUI) — a local dashboard that reads the OTel audit stream and renders blocked calls, `fix_hints` history, policy hits, cost curves. Sell the dashboard as the "why I install airlock on Monday" moment.
+10. **Signed release tarballs + SLSA Level 3 provenance** — enterprise prerequisites.
+
+### 2.3 Policy content that earns press
+
+Ship these as `airlock.policies` sub-package modules, each named for a 2026 incident:
+
+- `GTG_1002_DEFENSE` — blocks the tool-call patterns from Anthropic's November disclosure.
+- `MEX_GOV_2026` — blocks the persistent-jailbreak vector described in the Mexican-government breach report.
+- `OWASP_MCP_TOP10_2026` — one preset per MCP Top 10 category.
+- `OWASP_AGENTIC_2026_ASI01_ASI10` — one preset per Agentic Top 10 category.
+- `EU_AI_ACT_ARTICLE_15` — cybersecurity controls matching the high-risk obligation that applies Aug 2, 2026.
+- `INDIA_DPDP_2023` — pairs with the India PII pack; a regional wedge for Indian fintech design partners.
+
+Each policy ships with an explainer blog post — that is 6 posts of good content.
+
+---
+
+## 3. Milestones and timeline
+
+### Week 0 (prep — 7 days before launch)
+
+- Rename every "Claude Code SDK" reference. Grep and kill.
+- Update `pyproject.toml` dependency constraints against Claude Agent SDK 0.1.58+, FastMCP 2.x, OpenAI SDK 2.x (Agents SDK "next evolution" breaks v1.x).
+- Cut v0.5.0 with MCP 2025-11-25 support, OAuth 2.1, Tasks primitive, Opus 4.7 tokenizer.
+- Land the CVE regression tests as `tests/cves/`.
+- Publish AgentDojo / PINT / AgentHarm numbers as `benchmarks/results.md`.
+- Pick a name for the dashboard. "Airlock Studio" is available.
+
+### Week 1 (launch)
+
+- **Tuesday, 13:00 UTC** — HN submission. Title: *"Airlock: Python middleware that blocked all three `mcp-server-git` prompt-injection CVEs — here's how."* The URL is the benchmarks page, not the README. Reference the 30-in-60-days CVE storm. Be live in the thread for 4 hours.
+- **Tuesday +1h** — 8-tweet X thread: Tweet 1 is the blocked-CVE-replay GIF, Tweets 2–6 are the seven distinguishing primitives (ghost args, strict schema, sandbox, capabilities, vaccination, India PII, OTel audit), Tweet 7 is the benchmark table, Tweet 8 is the repo.
+- **Wednesday** — `/r/LocalLLaMA` post, lead with the technical win (CVE defense), link in comments. `/r/netsec` post in the same format.
+- **Thursday** — long-form blog post on your own domain (recommended new domain: `airlock.dev` or `agentairlock.dev`). Topic: "We reproduced three disclosed MCP CVEs. Here is how each would have been blocked at the decorator layer."
+- **Friday** — dev.to cross-post.
+
+### Weeks 2–4 (drumbeat)
+
+- Ship v0.5.1 with the `SandboxBackend.Managed` adapter for Anthropic Managed Agents.
+- "How to migrate from openai-guardrails to airlock for MCP workloads" post.
+- File a PR to NeMo Guardrails' LangChain integration that documents airlock as a complementary argument-level validator. Cross-repo reach.
+- Submit to OWASP MCP Top 10 project as a reference implementation.
+- Open a Discord; seed with 20 people you already know.
+
+### Weeks 5–8 (category leadership)
+
+- Ship Airlock Studio (local dashboard).
+- Ship TypeScript sibling `@airlock/core`.
+- Conference: propose a BlackHat / DEF CON AI Village / RSAC talk. The 2026 CVE corpus is a strong abstract.
+- Design-partner outreach to 5 Indian fintechs and 2 US banks (India PII pack + OAuth 2.1 enforcement is the pitch).
+- Publish a monthly "State of MCP Security" report on your domain. Own the category the way Aider owns coding benchmarks.
+
+### Weeks 9–12 (distribution expansion)
+
+- Ship A2A protocol support.
+- Ship Model Armor adapter.
+- Submit a `RuleDefinition` reference pack to Snyk's `agent-scan` (ironic — share your rules, own the narrative of "the airlock rule library").
+- Submit an OTel semconv proposal upstream with co-authors from Google / AWS / Langfuse.
+
+---
+
+## 4. What to measure
+
+| Metric | Baseline | 30-day target | 90-day target | 1-year target |
+|---|---|---|---|---|
+| GitHub stars | ~3 | 150 | 1,500 | 8,000 |
+| PyPI monthly downloads | <50 | 2,000 | 25,000 | 250,000 |
+| Production design partners | 0 | 3 | 10 | 40 |
+| Benchmark leaderboard entries | 0 | 3 (AgentDojo, PINT, AgentHarm) | 6 (add ToxicSkills, Gandalf, InjecAgent) | 10 |
+| Tracked CVE coverage | 0 | 8 | 25 | 60 |
+| Discord members | 0 | 75 | 500 | 3,000 |
+| GitHub Actions using airlock | 0 | 5 | 50 | 500 |
+| Framework integrations green | 9 | 12 | 15 | 20 |
+
+---
+
+## 5. What *not* to do
+
+- **Don't chase generic prompt-injection detection.** Lakera / Prompt Security / LlamaFirewall are miles ahead and have classifier-LM training resources you don't. Cite them, don't compete.
+- **Don't build your own benchmark** from scratch before publishing on existing ones.
+- **Don't fight MCP.** Embrace `2025-11-25` fully and be first-class on Google-managed MCP servers, Anthropic Managed Agents, and OpenAI Responses remote MCP.
+- **Don't rebuild an eval tool.** That's Verdict's job; pipe OTel events into Verdict instead.
+- **Don't accept Assistants API interoperability PRs.** Sunsets Aug 26, 2026. Close as wontfix.
+
+---
+
+## 6. One-pager the CEO should be able to read
+
+> *Airlock* is a single Python decorator — `@Airlock(...)` — that sits between an MCP tool handler and the LLM that called it. It blocks hallucinated arguments before they execute, validates tool parameters against Pydantic V2 strict schemas, returns a self-healing `fix_hints` JSON so the LLM can retry correctly, runs dangerous calls in an E2B Firecracker MicroVM, masks 14 PII types (including Aadhaar / PAN / UPI / IFSC), enforces capability-based RBAC, and streams OpenTelemetry audit records — all in ~50 lines of configuration. It's the runtime layer to our static scanner (agent-audit-kit) and our output-quality judge (Verdict), and it ships policy presets for the OWASP MCP Top 10, OWASP Agentic Top 10, EU AI Act Article 15, and the thirty MCP CVEs disclosed since January 2026.


### PR DESCRIPTION
## Summary

Commits six research-derived briefing documents that anchor the v0.5.0 "April 2026" roadmap (#6). These are the shared context behind every Phase 1 PR — every subsequent non-trivial change will cite one of these docs + a primary source URL.

Files:
- `ECOSYSTEM_STATE_2026-04.md` — state of the AI-agent ecosystem (Apr 18, 2026). Anthropic / OpenAI / Google lineup, MCP 2025-11-25 spec, the Jan–Feb CVE storm, agent-security M&A, 10 biggest shifts since January.
- `ROADMAP_2026.md` — 90-day plan for this repo. Critical gaps (§2.1), moat features (§2.2), timeline, measurable targets.
- `LAUNCH_PLAYBOOK_2026.md` — cross-repo growth playbook (shared with agent-audit-kit and Verdict).
- `DEEP_ANALYSIS.md` — internal deep codebase review of v0.4.0/v0.4.1; seeds Phase 1.8.
- `CROSS_PROJECT_SYNTHESIS.md` — portfolio-level synthesis.
- `CLAUDE_PROMPT.md` — execution prompt driving the 90-day plan.

## Test Plan

- [x] Markdown only — no code changes
- [x] No binaries, no secrets, no credentials
- [x] No links to `.env` / `credentials.*` / `*.pem` patterns (grep clean)

## Notes for reviewer

- Intentionally **not** linking these from README yet — they're working documents, not user-facing docs. README update is a separate Phase 3 PR.
- Every claim in these docs is traceable to a URL — if any specific sentence is ambiguous during Phase 1 implementation, the plan is to web-search the primary source and flag `UNVERIFIED:` rather than guess.
- `CLAUDE_PROMPT.md` is the session-start brief for Claude Code. Keeping it in-tree means future sessions pick up the same brief automatically.

Ref #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)