### PR TITLE
feat: add claude-agent-sdk optional extra (Phase 1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Claude Agent SDK** (`claude-agent-sdk`) as an optional extra: install with `pip install "agent-airlock[claude-agent]"`. Renamed from Claude Code SDK in Sept 2025 ([anthropics/claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python)). `examples/anthropic_integration.py` Example 7 already uses the new import path.
+- **Research log** (`docs/research-log.md`) tracking primary-source verifications that back every non-trivial change in the April 2026 roadmap (#6).
+
+### Fixed
+- **CI green on main** — removed an unused `# type: ignore[method-assign]` in `integrations/langchain.py` that began failing mypy 1.8+. Suppressed a bandit B104 false positive on the localhost blocklist check in `network.py`. Main had been red since Feb 6; PR #7 restored all three test matrix versions plus the `security` job.
+
+### Documentation
+- **April 2026 briefing pack** committed to tree: `ECOSYSTEM_STATE_2026-04.md`, `ROADMAP_2026.md`, `LAUNCH_PLAYBOOK_2026.md`, `DEEP_ANALYSIS.md`, `CROSS_PROJECT_SYNTHESIS.md`, `CLAUDE_PROMPT.md` (#8). Anchors the v0.5.0 roadmap in #6.
+
+---
+
 ## [0.4.1] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ def handle_tool_call(name, inputs):
 | AutoGen | [`autogen_integration.py`](./examples/autogen_integration.py) | ConversableAgent |
 | smolagents | [`smolagents_integration.py`](./examples/smolagents_integration.py) | CodeAgent, E2B |
 | Anthropic | [`anthropic_integration.py`](./examples/anthropic_integration.py) | Direct API |
+| Claude Agent SDK | [`anthropic_integration.py`](./examples/anthropic_integration.py) (Example 7) | Agent SDK tools as in-process MCP servers |
 
 ---
 

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -1,0 +1,71 @@
+# Research Log
+
+Per [`CLAUDE_PROMPT.md`](../CLAUDE_PROMPT.md) §8: every non-trivial roadmap change must cite a primary-source verification. This log records each research session — date, topic, URLs consulted, and the conclusion that informed the change.
+
+Cite this file from PR descriptions via anchor (e.g. `docs/research-log.md#2026-04-18-claude-agent-sdk-rename`).
+
+---
+
+## 2026-04-18 — Claude Agent SDK rename
+
+**Driver:** Roadmap [#6](https://github.com/sattyamjjain/agent-airlock/issues/6) Phase 1.1. Prompt: *"Update all references from 'Claude Code SDK' to 'Claude Agent SDK' ... Verify the current package name via web search on the Anthropic docs and PyPI before renaming imports."*
+
+**Sources consulted:**
+- PyPI: https://pypi.org/project/claude-agent-sdk/ — latest `0.1.63`; requires Python ≥ 3.10.
+- PyPI JSON: https://pypi.org/pypi/claude-agent-sdk/json — confirmed release metadata.
+- GitHub: https://github.com/anthropics/claude-agent-sdk-python — active repo, Python entry point.
+- npm: https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk — TypeScript/JS equivalent.
+- Anthropic docs: https://platform.claude.com/docs/en/agent-sdk/overview — official SDK overview.
+- Migration guide: https://platform.claude.com/docs/en/agent-sdk/migration-guide — `from claude_code_sdk import query` → `from claude_agent_sdk import query`.
+
+**Findings:**
+1. Rename from `claude-code-sdk` → `claude-agent-sdk` is **stable** (first renamed ~Sept 29 2025, current version 0.1.63).
+2. The Python import path is `claude_agent_sdk` (underscore). The old `claude_code_sdk` path still exists on PyPI as a separate package but is frozen.
+3. **agent-airlock does not import `claude_code_sdk` anywhere in source** — only `examples/anthropic_integration.py` Example 7 references the SDK, and it already uses `from claude_agent_sdk import ClaudeAgentOptions`.
+
+**Conclusion:**
+- No code rename required in `src/` or `tests/`.
+- Added `[claude-agent]` optional extra in `pyproject.toml` pinned to `claude-agent-sdk>=0.1.58` so users can `pip install "agent-airlock[claude-agent]"`.
+- README integration matrix updated to list Claude Agent SDK explicitly.
+- No back-compat `claude_code_sdk` shim added: the agent-airlock package does not own that namespace and adding one would shadow a legitimate third-party install.
+
+**Retrieval date:** 2026-04-18.
+
+---
+
+## 2026-04-18 — CI baseline (mypy + bandit regressions on `main`)
+
+**Driver:** Phase 0 verification. CI on `main` had been red since 2026-02-06.
+
+**Sources consulted:**
+- GitHub Actions run logs for `sattyamjjain/agent-airlock` runs `23116590327`, `23094908660`, `21738421286`.
+- Bandit docs: https://bandit.readthedocs.io/en/1.9.4/plugins/b104_hardcoded_bind_all_interfaces.html — B104 plugin details (CWE-605).
+- Mypy changelog: `unused-ignore` flag behavior on mypy 1.8+.
+
+**Findings:**
+1. `test (3.11)` failed with single error: `src/agent_airlock/integrations/langchain.py:169: error: Unused "type: ignore" comment`.
+2. `security` job failed with single issue: `B104 hardcoded_bind_all_interfaces` at `src/agent_airlock/network.py:249:66` — false positive; the string `"0.0.0.0"` is in a **blocklist** `in` check (`hostname in ("localhost", "0.0.0.0")`) that *rejects* these aliases, not a `socket.bind()` target.
+
+**Conclusion:** Two minimal edits restore CI green. See PR #7.
+
+**Retrieval date:** 2026-04-18.
+
+---
+
+*Template for future entries:*
+
+```
+## YYYY-MM-DD — <topic>
+
+**Driver:** <issue/PR + roadmap section>
+
+**Sources consulted:**
+- <URL> — <one-line what it says>
+
+**Findings:**
+1. ...
+
+**Conclusion:** <action taken + any UNVERIFIED flags>
+
+**Retrieval date:** YYYY-MM-DD.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,14 @@ mcp = [
     "mcp>=1.0",
     "fastmcp>=2.0,<3.0",
 ]
+# Claude Agent SDK (renamed from Claude Code SDK in Sept 2025).
+# Install with: pip install "agent-airlock[claude-agent]"
+# See: https://pypi.org/project/claude-agent-sdk/
+claude-agent = [
+    "claude-agent-sdk>=0.1.58",
+]
 all = [
-    "agent-airlock[sandbox,mcp]",
+    "agent-airlock[sandbox,mcp,claude-agent]",
 ]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
## Summary

Phase 1.1 of the v0.5.0 April 2026 roadmap (#6). Adds the [Claude Agent SDK](https://pypi.org/project/claude-agent-sdk/) as a first-class optional extra and seeds `docs/research-log.md`.

**Key finding:** agent-airlock never imported `claude_code_sdk`. The only SDK reference in the repo (`examples/anthropic_integration.py` Example 7) already uses the new `claude_agent_sdk` import path. The rename is therefore metadata-only for this repo.

## Changes

- `pyproject.toml` — new `[claude-agent]` optional extra pinned `claude-agent-sdk>=0.1.58`. Included in `[all]`.
- `README.md` — integration matrix lists Claude Agent SDK alongside Anthropic Direct API.
- `CHANGELOG.md` — `[Unreleased]` records this PR + #7 + #8.
- `docs/research-log.md` — new file, primary-source verification log per [`CLAUDE_PROMPT.md`](../CLAUDE_PROMPT.md) §8. Seeded with two entries.

## Test Plan

Local, Python 3.12.7, with `[all]` extras installed:

- [x] `pytest tests/ -q --cov=agent_airlock --cov-fail-under=79` → **1172 passed, 33 skipped, coverage 80.14%**
- [x] `ruff check src/ tests/` → **clean**
- [x] `mypy src/agent_airlock/integrations/langchain.py` → **Success: no issues found**
- [x] `pip index versions claude-agent-sdk` → latest **0.1.63**, pin `>=0.1.58` is satisfiable.

## Notes for reviewer

- **Deliberately no back-compat shim.** The prompt says "Keep back-compat import shims that emit DeprecationWarning." For us that would mean shipping a `claude_code_sdk` module from our own package. That would shadow any user who has a legitimate install of the old (frozen) `claude-code-sdk` PyPI package — net harm. I've documented this decision in the commit message.
- **`[all]` now pulls claude-agent-sdk.** Users who want a lean install can still pick `[sandbox]`, `[mcp]`, or `[claude-agent]` individually.
- **Research log is the new primary-source audit trail.** Every Phase 1.x PR after this one should add a row.

Ref #6 (Phase 1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)