### PR TITLE
fix: deep-analysis bug triage (Phase 1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **CI green on main** — removed an unused `# type: ignore[method-assign]` in `integrations/langchain.py` that began failing mypy 1.8+. Suppressed a bandit B104 false positive on the localhost blocklist check in `network.py`. Main had been red since Feb 6; PR #7 restored all three test matrix versions plus the `security` job.
+- **Sensitive-parameter filter now catches compound names** (`user_password`, `my_api_key`, `aws_secret_key`, `session_cookie`, `db_token`, etc.). `_filter_sensitive_keys` previously used an exact-match frozenset lookup, letting custom-named parameters leak into debug logs. Fix: substring match against `SENSITIVE_PARAM_SUBSTRINGS`. Old `SENSITIVE_PARAM_NAMES` constant retained for backward compatibility.
+- **Capability gating now survives non-`functools.wraps` outer decorators.** `get_required_capabilities` now walks the `__wrapped__` chain (bounded to 32 hops) so that any outer decorator preserving `__wrapped__` continues to surface `__airlock_capabilities__`. Previously a naive wrapper that did not copy `__dict__` would cause `@requires` to silently degrade to `Capability.NONE` — a bypass. 7 TDD regression tests in `tests/test_deep_analysis_bugs.py`.
 
 ### Documentation
 - **April 2026 briefing pack** committed to tree: `ECOSYSTEM_STATE_2026-04.md`, `ROADMAP_2026.md`, `LAUNCH_PLAYBOOK_2026.md`, `DEEP_ANALYSIS.md`, `CROSS_PROJECT_SYNTHESIS.md`, `CLAUDE_PROMPT.md` (#8). Anchors the v0.5.0 roadmap in #6.

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -96,6 +96,26 @@ Phase 1.3 will write regression tests for the 5 strong-fit CVEs in `tests/cves/`
 
 ---
 
+## 2026-04-18 — Deep-analysis bug triage
+
+**Driver:** Roadmap [#6](https://github.com/sattyamjjain/agent-airlock/issues/6) Phase 1.8. The execution brief listed three claimed bugs: (1) sensitive-param filter misses custom names; (2) streaming sanitizer double-counts tokens on re-entry; (3) capability gating bypass when `@requires` stacked with `@functools.wraps`.
+
+**Sources consulted:** the source tree (`src/agent_airlock/core.py`, `streaming.py`, `capabilities.py`) and the Python `functools` module (for `functools.wraps` semantics — `WRAPPER_ASSIGNMENTS` + `WRAPPER_UPDATES = ('__dict__',)`).
+
+**Findings:**
+1. **Bug 1 is real.** `_filter_sensitive_keys` used `k.lower() not in SENSITIVE_PARAM_NAMES` — an exact-match frozenset check. Custom compound names (`user_password`, `my_api_key`, `aws_secret_key`, `session_cookie`, `db_token`) bypassed the filter and leaked to debug logs. Fix: substring match against a new `SENSITIVE_PARAM_SUBSTRINGS` tuple.
+2. **Bug 2 is UNVERIFIED.** I could not reproduce a double-count in `StreamingAirlock`. `wrap_generator` / `wrap_async_generator` call `self.reset()` before iterating, `create_streaming_wrapper` constructs one instance per decorated function but every call goes through `wrap_generator` (which resets), and `_sanitize_chunk` increments `sanitized_count` exactly once per chunk. Asserted the current (correct) behaviour with three regression tests so a future change that introduces a double-count trips the suite. Flagged UNVERIFIED rather than silently fabricating a fix.
+3. **Bug 3 claim is mis-stated; underlying bug is real.** `functools.wraps` merges the wrapped function's `__dict__` into the wrapper's, which PRESERVES `__airlock_capabilities__`. The real failure mode is an OUTER decorator that does NOT use `functools.wraps` — such a wrapper drops the attribute, and `get_required_capabilities` (using a plain `getattr`) returned `Capability.NONE`, allowing a bypass. Fix: `get_required_capabilities` now walks the `__wrapped__` chain (bounded to 32 hops to avoid pathological cycles) so that any decorator that preserves `__wrapped__` still surfaces the capability.
+
+**Conclusion:**
+- `src/agent_airlock/core.py`: `_filter_sensitive_keys` now uses substring matching. The old `SENSITIVE_PARAM_NAMES` frozenset remains for backward compatibility but is no longer used inside the filter.
+- `src/agent_airlock/capabilities.py`: `get_required_capabilities` walks the `__wrapped__` chain.
+- `tests/test_deep_analysis_bugs.py`: 15 new tests. 7 failed before the fixes (TDD per the brief) and pass after; 8 cover the UNVERIFIED streaming claim and adjacent correct paths.
+
+**Retrieval date:** 2026-04-18.
+
+---
+
 *Template for future entries:*
 
 ```

--- a/src/agent_airlock/capabilities.py
+++ b/src/agent_airlock/capabilities.py
@@ -273,13 +273,37 @@ def requires(*capabilities: Capability) -> Callable[[F], F]:
 def get_required_capabilities(func: Callable[..., Any]) -> Capability:
     """Get the capabilities required by a function.
 
+    Walks the `__wrapped__` chain that `functools.wraps` (and well-behaved
+    manual decorators) set, so an outer wrapper that does not itself copy
+    `__airlock_capabilities__` cannot silently drop it. If neither the
+    outermost callable nor any wrapped inner callable has the attribute,
+    returns `Capability.NONE`.
+
     Args:
         func: Function to check.
 
     Returns:
         Capability flags required by the function, or NONE if not decorated.
     """
-    return getattr(func, "__airlock_capabilities__", Capability.NONE)
+    caps = getattr(func, "__airlock_capabilities__", None)
+    if caps is not None:
+        return caps  # type: ignore[no-any-return]
+
+    # Walk the __wrapped__ chain (bounded depth to avoid infinite loops on
+    # pathological cycles).
+    seen: set[int] = set()
+    current = func
+    for _ in range(32):
+        inner = getattr(current, "__wrapped__", None)
+        if inner is None or id(inner) in seen:
+            break
+        seen.add(id(inner))
+        inner_caps = getattr(inner, "__airlock_capabilities__", None)
+        if inner_caps is not None:
+            return inner_caps  # type: ignore[no-any-return]
+        current = inner
+
+    return Capability.NONE
 
 
 def _capability_flag_names(caps: Capability) -> list[str]:

--- a/src/agent_airlock/core.py
+++ b/src/agent_airlock/core.py
@@ -98,40 +98,55 @@ R = TypeVar("R")
 # Type alias for policy resolver functions
 PolicyResolver = Callable[[AirlockContext[Any]], SecurityPolicy | None]
 
-# Parameter names that should not appear in debug logs
-SENSITIVE_PARAM_NAMES = frozenset(
-    {
-        "password",
-        "passwd",
-        "pwd",
-        "secret",
-        "token",
-        "key",
-        "api_key",
-        "apikey",
-        "auth",
-        "authorization",
-        "credential",
-        "credentials",
-        "private_key",
-        "privatekey",
-        "access_token",
-        "refresh_token",
-        "session",
-        "cookie",
-        "ssn",
-        "credit_card",
-        "card_number",
-    }
+# Substrings that indicate a parameter name is sensitive and must not
+# appear in debug logs. Any key whose lowercase form CONTAINS any of
+# these substrings is filtered. This catches both exact matches
+# (`password`) and compound variants (`user_password`, `my_api_key`,
+# `aws_secret_key`, `session_cookie`, `db_token`, ...) that a previous
+# exact-match implementation leaked.
+SENSITIVE_PARAM_SUBSTRINGS: tuple[str, ...] = (
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "authorization",
+    "auth",
+    "credential",
+    "private_key",
+    "privatekey",
+    "access_token",
+    "refresh_token",
+    "session",
+    "cookie",
+    "ssn",
+    "credit_card",
+    "card_number",
 )
+
+# Legacy exact-match set kept for backward compatibility with any
+# downstream code that imported SENSITIVE_PARAM_NAMES before v0.5.0.
+# New code should rely on the substring check in _filter_sensitive_keys.
+SENSITIVE_PARAM_NAMES = frozenset(SENSITIVE_PARAM_SUBSTRINGS) | {"key"}
 
 
 def _filter_sensitive_keys(keys: list[str]) -> list[str]:
     """Filter out sensitive parameter names from a list of keys.
 
-    SECURITY: Prevents leaking sensitive parameter names to logs.
+    SECURITY: Prevents leaking sensitive parameter names to logs. Uses
+    substring matching so that compound names (`user_password`,
+    `my_api_key`, `aws_secret_key`, `session_cookie`) are caught in
+    addition to exact matches.
     """
-    return [k for k in keys if k.lower() not in SENSITIVE_PARAM_NAMES]
+    filtered: list[str] = []
+    for k in keys:
+        lowered = k.lower()
+        if any(s in lowered for s in SENSITIVE_PARAM_SUBSTRINGS):
+            continue
+        filtered.append(k)
+    return filtered
 
 
 # Parameter names that typically contain file paths

--- a/tests/test_deep_analysis_bugs.py
+++ b/tests/test_deep_analysis_bugs.py
@@ -1,0 +1,220 @@
+"""Regression tests for three bug claims in the April 2026 deep analysis.
+
+Two of the three are real bugs that this PR fixes; the third is documented
+as UNVERIFIED and asserted to match the current (correct) behaviour so a
+future regression would still trip the suite.
+
+Tracked in `docs/research-log.md#2026-04-18-—-deep-analysis-bug-triage`.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Generator
+from typing import Any
+
+from agent_airlock.capabilities import Capability, get_required_capabilities, requires
+from agent_airlock.config import AirlockConfig
+from agent_airlock.core import _filter_sensitive_keys
+from agent_airlock.streaming import StreamingAirlock
+
+# =============================================================================
+# Bug 1: sensitive-param filter misses custom names — REAL BUG
+# =============================================================================
+
+
+class TestSensitiveParamFilterCustomNames:
+    """`_filter_sensitive_keys` must catch compound names like `my_api_key`.
+
+    Previously the filter did an exact lookup in a hard-coded frozenset, so
+    `my_api_key`, `user_password`, `db_token`, `aws_secret_key`, and
+    `session_cookie` all leaked to debug logs. The fix scans for any
+    registered sensitive substring.
+    """
+
+    def test_exact_match_still_filters(self) -> None:
+        """The original behaviour — exact matches — is preserved."""
+        assert _filter_sensitive_keys(["password", "normal"]) == ["normal"]
+
+    def test_filters_custom_prefix_name(self) -> None:
+        """`user_password` — `password` appears as a substring."""
+        assert "user_password" not in _filter_sensitive_keys(["user_password", "normal"])
+
+    def test_filters_custom_suffix_name(self) -> None:
+        """`my_api_key` — `api_key` appears as a substring."""
+        assert "my_api_key" not in _filter_sensitive_keys(["my_api_key", "normal"])
+
+    def test_filters_aws_secret_key(self) -> None:
+        assert "aws_secret_key" not in _filter_sensitive_keys(["aws_secret_key", "normal"])
+
+    def test_filters_session_cookie(self) -> None:
+        assert "session_cookie" not in _filter_sensitive_keys(["session_cookie", "normal"])
+
+    def test_filters_case_insensitive_custom(self) -> None:
+        """Uppercase variant of a compound name is also filtered."""
+        assert "MyApiKey" not in _filter_sensitive_keys(["MyApiKey", "normal"])
+
+    def test_non_sensitive_passthrough(self) -> None:
+        """Names without any sensitive substring stay in the list."""
+        passthrough = ["path", "url", "query", "limit", "offset"]
+        assert _filter_sensitive_keys(passthrough) == passthrough
+
+
+# =============================================================================
+# Bug 2: streaming sanitizer double-counts tokens on re-entry — UNVERIFIED
+# =============================================================================
+#
+# The claim in the deep-analysis brief was "streaming sanitizer double-counts
+# tokens on re-entry." I could not reproduce a double-count by any path I
+# traced through `StreamingAirlock`:
+#
+# - `wrap_generator` calls `self.reset()` before iterating, clearing state.
+# - `create_streaming_wrapper` constructs ONE `StreamingAirlock` per decorated
+#   function but every call to the wrapper goes through `wrap_generator`,
+#   which resets.
+# - `_sanitize_chunk` increments `sanitized_count` once per chunk; no
+#   internal path re-invokes it on the same chunk.
+#
+# The regression below asserts the CURRENT (correct) behaviour so that a
+# future change that accidentally introduces a double-count trips the
+# suite. Flagged UNVERIFIED in docs/research-log.md.
+
+
+class TestStreamingSanitizerNoDoubleCount:
+    """Re-entry does not double-count sanitization detections."""
+
+    def _make_streamer(self) -> StreamingAirlock:
+        return StreamingAirlock(
+            AirlockConfig(sanitize_output=True, mask_pii=True),
+            tool_name="t",
+        )
+
+    def test_single_stream_with_pii(self) -> None:
+        """One stream containing 2 emails → sanitized_count == 2."""
+        streamer = self._make_streamer()
+
+        def gen() -> Generator[str, None, None]:
+            yield "chunk one has foo@example.com"
+            yield "chunk two has bar@example.com"
+
+        list(streamer.wrap_generator(gen()))
+        assert streamer.state.sanitized_count == 2
+
+    def test_reuse_streamer_instance(self) -> None:
+        """Second wrap_generator call resets — counts do not accumulate."""
+        streamer = self._make_streamer()
+
+        def gen_a() -> Generator[str, None, None]:
+            yield "first foo@example.com"
+
+        def gen_b() -> Generator[str, None, None]:
+            yield "second bar@example.com"
+            yield "third baz@example.com"
+
+        list(streamer.wrap_generator(gen_a()))
+        assert streamer.state.sanitized_count == 1
+
+        list(streamer.wrap_generator(gen_b()))
+        # State was reset before the second call; only counts from gen_b.
+        assert streamer.state.sanitized_count == 2
+
+    def test_zero_pii_stream_zero_count(self) -> None:
+        streamer = self._make_streamer()
+
+        def gen() -> Generator[str, None, None]:
+            yield "boring chunk one"
+            yield "boring chunk two"
+
+        list(streamer.wrap_generator(gen()))
+        assert streamer.state.sanitized_count == 0
+
+
+# =============================================================================
+# Bug 3: capability-gating bypass with non-wraps outer decorators — REAL BUG
+# =============================================================================
+#
+# The original claim was framed around `@functools.wraps`. On inspection,
+# `functools.wraps` actually PRESERVES `__airlock_capabilities__` via its
+# `WRAPPER_UPDATES = ('__dict__',)` merge. The real bug is when an outer
+# decorator wraps `@requires` WITHOUT using `functools.wraps`. The fix makes
+# `get_required_capabilities` walk the `__wrapped__` chain so that any
+# intermediate wrapper — whether it uses `functools.wraps` or not —
+# still surfaces the capability attribute.
+
+
+def _naive_outer(func: Any) -> Any:
+    """A decorator that does NOT use functools.wraps (the failure mode)."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    # Preserve __wrapped__ so get_required_capabilities can walk to `func`.
+    wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+    return wrapper
+
+
+def _wraps_outer(func: Any) -> Any:
+    """A decorator that DOES use functools.wraps (the success mode)."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class TestCapabilityWrappingOrder:
+    """Capability attribute survives intermediate wrappers."""
+
+    def test_wraps_decorator_preserves_capability(self) -> None:
+        """`functools.wraps` merges __dict__; capability survives."""
+
+        @_wraps_outer
+        @requires(Capability.FILESYSTEM_READ)
+        def tool_a(path: str) -> str:
+            return path
+
+        assert get_required_capabilities(tool_a) == Capability.FILESYSTEM_READ
+
+    def test_naive_wrapper_preserves_via_unwrap_chain(self) -> None:
+        """A naive decorator (no functools.wraps) MUST still surface the capability."""
+
+        @_naive_outer
+        @requires(Capability.FILESYSTEM_READ)
+        def tool_b(path: str) -> str:
+            return path
+
+        # Before the fix, this returned Capability.NONE because the naive
+        # wrapper didn't copy `__airlock_capabilities__`. After the fix,
+        # `get_required_capabilities` walks `__wrapped__` to find it.
+        assert get_required_capabilities(tool_b) == Capability.FILESYSTEM_READ
+
+    def test_requires_stacked_on_wraps_decorator(self) -> None:
+        """`@requires` on top of a functools.wraps decorator works."""
+
+        @requires(Capability.FILESYSTEM_READ)
+        @_wraps_outer
+        def tool_c(path: str) -> str:
+            return path
+
+        assert get_required_capabilities(tool_c) == Capability.FILESYSTEM_READ
+
+    def test_combined_capabilities_survive_naive_wrap(self) -> None:
+        """Combined flags (|) also survive the chain walk."""
+
+        @_naive_outer
+        @requires(Capability.FILESYSTEM_READ, Capability.NETWORK_HTTPS)
+        def tool_d(path: str, url: str) -> str:
+            return path + url
+
+        got = get_required_capabilities(tool_d)
+        expected = Capability.FILESYSTEM_READ | Capability.NETWORK_HTTPS
+        assert got == expected
+
+    def test_no_capability_on_plain_function(self) -> None:
+        """A function with no `@requires` still returns NONE."""
+
+        def plain(path: str) -> str:
+            return path
+
+        assert get_required_capabilities(plain) == Capability.NONE


### PR DESCRIPTION
## Summary

Phase 1.8 of the April 2026 roadmap (#6). TDD per the execution brief — **7 failing tests first**, then the fixes.

| Bug | Status | Fix |
|---|---|---|
| 1. Sensitive-param filter missed compound names | **real** | Substring match against `SENSITIVE_PARAM_SUBSTRINGS` |
| 2. Streaming sanitizer double-counts on re-entry | **UNVERIFIED** | Documented; 3 regression tests assert current correct behaviour |
| 3. Capability-gating bypass with non-`functools.wraps` outer decorators | **real** (claim mis-stated) | `get_required_capabilities` walks `__wrapped__` chain (bounded 32 hops) |

Full research in [`docs/research-log.md#2026-04-18-deep-analysis-bug-triage`](docs/research-log.md).

## Bug 1 detail

`_filter_sensitive_keys` in `core.py` did `k.lower() not in SENSITIVE_PARAM_NAMES` — exact-match frozenset. This let every compound name slip through:

```python
>>> _filter_sensitive_keys(["my_api_key", "user_password", "aws_secret_key", "db_token"])
# BEFORE: ["my_api_key", "user_password", "aws_secret_key", "db_token"]  # ALL leak
# AFTER:  []                                                             # correctly filtered
```

Fix: new `SENSITIVE_PARAM_SUBSTRINGS` tuple scanned with `any(s in lowered for s in ...)`. The legacy `SENSITIVE_PARAM_NAMES` constant is retained for backward compatibility.

## Bug 2 — why UNVERIFIED

The claim in the execution brief was "streaming sanitizer double-counts tokens on re-entry." I traced every path through `StreamingAirlock`:

- `wrap_generator` / `wrap_async_generator` call `self.reset()` before iterating.
- `create_streaming_wrapper` shares one `StreamingAirlock` per decorated function, but every invocation enters via `wrap_generator` (which resets).
- `_sanitize_chunk` increments `sanitized_count` exactly once per chunk; no code path re-invokes it on the same chunk.

**I could not reproduce a double-count.** Rather than fabricate a fix for a bug I can't find, this PR adds three regression tests (`TestStreamingSanitizerNoDoubleCount`) that assert the current (correct) behaviour. If a future change accidentally introduces a double-count, the suite trips.

## Bug 3 — claim was inverted

The prompt framed this as "`@functools.wraps` causes a bypass." `functools.wraps` actually **preserves** `__airlock_capabilities__` — it has `WRAPPER_UPDATES = ('__dict__',)`, so the wrapper's `__dict__` is merged with the wrapped function's (which has the attribute).

The **real** bug: an OUTER decorator that does NOT use `functools.wraps` drops the attribute, and `get_required_capabilities` (plain `getattr`) returns `Capability.NONE`, silently degrading `@requires`. That's a capability-gating bypass waiting to happen.

Fix: `get_required_capabilities` walks the `__wrapped__` chain (bounded to 32 hops to guard against pathological cycles). Any decorator that preserves `__wrapped__` — via `functools.wraps` or manual assignment — now correctly surfaces the capability.

## Test Plan

Local, Python 3.12.7, `[all]` extras:

- [x] `pytest tests/ -q --cov=agent_airlock --cov-fail-under=79` → **1212 passed, 33 skipped, coverage 80.17%** (+15 tests).
- [x] `pytest tests/test_deep_analysis_bugs.py -v` → 15 passed (7 of them were failing before the fixes).
- [x] `ruff check src/ tests/` → clean.
- [x] `ruff format --check src/ tests/` → clean.

## Notes for reviewer

- **Backward compatibility.** Old `SENSITIVE_PARAM_NAMES` frozenset still exported from `core.py`; the filter just no longer uses it. Anyone who imported that constant directly is unaffected.
- **Capability chain walk is bounded.** 32 hops is generous for real-world decorator stacks and defends against infinite loops from self-referential `__wrapped__` values.
- **UNVERIFIED flag is deliberate.** Per the execution brief's rule #2: "Never invent version numbers, CVE IDs, or API signatures. If a search returns no authoritative result, flag it `UNVERIFIED:` ... rather than guessing." I'm applying the same discipline to bug claims.

Ref #6 (Phase 1.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)