### PR TITLE
chore: CODE_OF_CONDUCT + CVE-rule-request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cve_rule_request.md
+++ b/.github/ISSUE_TEMPLATE/cve_rule_request.md
@@ -1,0 +1,78 @@
+---
+name: CVE rule request
+about: Request an agent-airlock rule, policy preset, or regression test for a disclosed CVE
+title: "CVE rule request: CVE-YYYY-NNNNN"
+labels: ["cve-rule-request"]
+assignees: []
+---
+
+<!--
+Use this template ONLY for CVEs that are already publicly disclosed (NVD,
+vendor advisory, or GHSA). For undisclosed vulnerabilities in agent-airlock
+itself, follow SECURITY.md instead.
+
+Primary-source link is required so maintainers can verify the class of bug
+and write a regression test that stays green against future versions.
+-->
+
+## CVE
+
+**CVE ID:** CVE-YYYY-NNNNN
+**Primary source:** <!-- NVD URL, vendor advisory, or GHSA link -->
+**Affected component:** <!-- e.g. anthropics/mcp-server-git, Azure MCP Server, mcp-atlassian -->
+**Affected versions:** <!-- e.g. < 2025.12.18 -->
+**Fixed in:** <!-- upstream fix version, if any -->
+
+## Class of bug
+
+<!-- Tick one or more -->
+
+- [ ] Path traversal / filesystem escape
+- [ ] Argument injection (CLI, SQL, shell)
+- [ ] SSRF / unsafe URL fetch
+- [ ] Authentication bypass at transport layer
+- [ ] Prompt injection leading to tool misuse
+- [ ] Token leak (query string, logs, audit)
+- [ ] Other: <!-- describe -->
+
+## Vulnerable tool-call pattern
+
+<!--
+Provide the minimal reproducer: what tool name, what argument shape, what
+boundary the attacker crosses. Example:
+
+Tool: `git_diff`
+Argument: `ref="--output=/tmp/pwn"`
+Boundary: ref value starting with a hyphen is interpreted as a git CLI option.
+-->
+
+```text
+Tool:
+Arguments:
+Boundary crossed:
+```
+
+## Proposed airlock defence
+
+<!-- Tick one or more -->
+
+- [ ] `SafePath` / filesystem boundary validator
+- [ ] `SafeURL` / `EndpointPolicy` (SSRF block-list)
+- [ ] Pydantic strict type for the arg (e.g. ref must match `[a-z0-9._/-]+`)
+- [ ] Network egress control (`NetworkPolicy`)
+- [ ] Capability gating (`@requires(...)`)
+- [ ] New policy preset
+- [ ] Regression test only (existing primitive already covers it)
+
+## Out-of-scope rationale (if applicable)
+
+<!--
+Some CVEs are transport-layer or HTTP-auth bugs that airlock can't block
+because we sit in front of tool execution, not the HTTP layer. If that's the
+case here, explain so we can document it in `tests/cves/README.md` rather
+than writing a misleading test.
+-->
+
+## Extra context
+
+<!-- Links to write-ups, PoC repositories, tweets, etc. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,112 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the
+agent-airlock project a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Scope
+
+This Code of Conduct applies within all community spaces (GitHub issues, pull
+requests, discussions, Discord, and any future community venues) and also
+applies when an individual is officially representing the community in public
+spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at
+[platform.dev@attri.ai](mailto:platform.dev@attri.ai). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for considering contributing to Agent-Airlock! It's people 
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by our commitment to providing a welcoming and inclusive environment. By participating, you are expected to uphold this standard.
+This project and everyone participating in it is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Report unacceptable behavior to [platform.dev@attri.ai](mailto:platform.dev@attri.ai).
 
 ## How Can I Contribute?
 


### PR DESCRIPTION
## Summary

Missing community-health files spotted while auditing Phase 3 of the v0.5.0 April 2026 roadmap (#6).

- \`CODE_OF_CONDUCT.md\` — Contributor Covenant v2.1, enforcement contact \`platform.dev@attri.ai\`
- \`.github/ISSUE_TEMPLATE/cve_rule_request.md\` — structured template with primary-source link, affected component, bug class, vulnerable tool-call pattern, proposed airlock defence
- \`CONTRIBUTING.md\` — CoC section now links the new file and the enforcement contact

## Test Plan

- [x] \`pytest tests/ -q --cov=agent_airlock --cov-fail-under=79\` → 1362 passed, 33 skipped, coverage 81.36%
- [x] \`ruff check src/ tests/\` → All checks passed
- [x] \`ruff format --check src/ tests/\` → 102 files already formatted

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)