### PR TITLE
release: cut v0.5.0 "April 2026" + align coverage gate docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+(no entries yet)
+
+---
+
+## [0.5.0] - 2026-04-18 — "April 2026"
+
+First release of the April 2026 roadmap (#6). Turns agent-airlock into a
+runtime-compliant MCP 2025-11-25 defender: ships the CVE regression suite,
+2026 policy presets, Google Model Armor adapter, A2A protocol middleware,
+Claude Agent SDK extra, and fixes two real defence-in-depth bugs caught in
+deep analysis.
+
 ### Added
 - **MCP 2025-11-25 spec compliance helpers** (`agent_airlock.mcp_spec`): OAuth 2.1 + PKCE S256 utilities (PKCE generate/verify with RFC 7636 test vector, redirect URI allow-list, Bearer + `WWW-Authenticate` header parsers, RFC 8707 resource-URI canonicalisation, Authorization Server + Protected Resource Metadata Pydantic models enforcing `S256` in `code_challenge_methods_supported`, JWT audience validator), Tasks primitive (SEP-1686) Pydantic models (`Task`, `TaskStatus`, `TaskGetRequest`, `TaskCancelRequest`, five-state lifecycle), and Streamable HTTP transport validators (`MCP-Protocol-Version: 2025-11-25` header enforcement, rejects access tokens in query string, Content-Type / Accept rules, `WWW-Authenticate` on 401). 81 conformance tests. DPoP deliberately deferred — spec lists it as SEP-draft only.
 - **Claude Agent SDK** (`claude-agent-sdk`) as an optional extra: install with `pip install "agent-airlock[claude-agent]"`. Renamed from Claude Code SDK in Sept 2025 ([anthropics/claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python)). `examples/anthropic_integration.py` Example 7 already uses the new import path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@
 - V0.3.0: Filesystem validation, network egress control, honeypot deception, framework vaccination
 - V0.4.0: Circuit breaker, cost tracking, retry policies, OpenTelemetry observability, capability gating
 
-**Stats:** ~25,900 lines of code | 1157 tests | 79%+ coverage (enforced in CI)
-**Version:** 0.4.0 "Enterprise"
+**Stats:** ~27,400 lines of code | 1362 tests | 81%+ coverage (enforced at 80% in CI)
+**Version:** 0.5.0 "April 2026"
 
 <!-- END AUTO-MANAGED -->
 
@@ -197,7 +197,7 @@ Key security additions:
 - Always run `pytest tests/ -v` after code changes to verify nothing breaks
 - Run `mypy src/` and `ruff check src/ tests/` before committing
 - Use `python3 -m py_compile <file>` to verify syntax after writing Python
-- Keep coverage above 79% (CI enforced via `--cov-fail-under=79`)
+- Keep coverage above 80% (CI enforced via `--cov-fail-under=80`)
 - New modules should follow the layered architecture pattern (validation → policy → execution → sanitization)
 - Security-sensitive code must include structured logging via structlog
 - Custom exceptions should store details as attributes and call `super().__init__()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",
 ]
-fail_under = 79
+fail_under = 80
 show_missing = true
 skip_covered = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.4.1"
+version = "0.5.0"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -304,7 +304,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 __all__ = [
     # Core


### PR DESCRIPTION
## Summary

Prepares v0.5.0 release off current main. No code changes — metadata + docs only.

- \`pyproject.toml\` and \`src/agent_airlock/__init__.py\` — version 0.4.1 → 0.5.0
- \`CHANGELOG.md\` — promote \`[Unreleased]\` to \`[0.5.0] - 2026-04-18 — \"April 2026\"\` with a one-paragraph summary, open a new empty \`[Unreleased]\` heading
- \`CLAUDE.md\` — fix the 79/80 mismatch. CI has been enforcing \`--cov-fail-under=80\` for a while; CLAUDE.md previously said 79 in two places. Both lines now say 80, matching CI. Stats line also updated to reflect 1362 tests and v0.5.0 marker. **Gate is not being lowered** — actual coverage is 81.36%.

## Test Plan

- [x] \`pytest tests/ -q --cov=agent_airlock --cov-fail-under=80\` → 1362 passed, 33 skipped, coverage 81.36%
- [x] \`ruff check src/ tests/\` → clean
- [x] Runtime \`import agent_airlock; agent_airlock.__version__\` → \`\"0.5.0\"\`

## Not doing in this PR

- PyPI upload — that's a manual \`twine upload\` after merge
- Tag \`v0.5.0\` — cut from \`main\` after this PR merges
- Phase 3 docs bundle / Phase 2 benchmarks / etc. — separate PRs

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)