### PR TITLE
docs(cves): auto-generated CVE catalog page + generator

### DIFF
--- a/docs/cves/index.md
+++ b/docs/cves/index.md
@@ -1,0 +1,265 @@
+# CVE catalog
+
+This page is auto-generated from the regression tests in
+[`tests/cves/`](https://github.com/sattyamjjain/agent-airlock/tree/main/tests/cves).
+
+Every CVE listed here has a corresponding test that reproduces the
+vulnerable tool-call pattern and asserts an agent-airlock primitive blocks
+it. The suite is a **second defence** — upstream vendors have shipped fixes
+for every CVE below. Agent-airlock's job is to catch the same class of bug
+when a vulnerable server is still running, or when a new tool ships with the
+same shape.
+
+See [`tests/cves/README.md`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/README.md)
+for the classification rules and a list of CVEs we deliberately chose NOT
+to cover (transport-layer and web-framework bugs that sit outside the
+airlock execution seam).
+
+To regenerate this page:
+
+```bash
+python3 scripts/gen_cve_catalog.py --write
+```
+
+CI runs `python3 scripts/gen_cve_catalog.py --check` on every PR, so the
+catalog and the tests stay in lockstep.
+
+
+## Summary
+
+| CVE | Component / title | CVSS | Airlock fit |
+| --- | --- | --- | --- |
+| [CVE-2025-59536](#cve-2025-59536) | Claude Code hooks RCE + MCP consent bypass (exfil leg) | 8.7 (High) | Partial |
+| [CVE-2025-68143](#cve-2025-68143) | Anthropic mcp-server-git `git_init` path traversal | 8.2 (High) | Strong |
+| [CVE-2025-68144](#cve-2025-68144) | Anthropic mcp-server-git argument injection | 8.1 (High) | Strongest |
+| [CVE-2025-68145](#cve-2025-68145) | mcp-server-git `--repository` root not enforced | 7.1 (High) | Strong |
+| [CVE-2026-26118](#cve-2026-26118) | Microsoft Azure MCP Server SSRF (IMDS token theft) | 8.8 (High) | Strong |
+| [CVE-2026-27825](#cve-2026-27825) | mcp-atlassian arbitrary file write via download_path | 9.1 (Critical) | Strong |
+| [CVE-2026-27826](#cve-2026-27826) | mcp-atlassian SSRF via `X-Atlassian-*-Url` headers | 7.5 (High, AV:A/PR:N/UI:N, C:H) | Partial |
+
+## Details
+
+### CVE-2025-59536
+
+**Claude Code hooks RCE + MCP consent bypass (exfil leg)**
+
+- **CVSS:** 8.7 (High)
+- **Airlock fit:** PARTIAL
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2025-59536](https://nvd.nist.gov/vuln/detail/CVE-2025-59536)
+- **Advisory:** [https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/](https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/)
+- **Regression test:** [`tests/cves/test_cve_2025_59536_claude_code_hooks_rce.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2025_59536_claude_code_hooks_rce.py)
+
+**Vulnerability**
+
+Claude Code (< 1.0.111) executes repository-controlled configuration
+— project `hooks`, registered MCP servers, and environment variables
+including `ANTHROPIC_BASE_URL` — BEFORE showing the user the trust
+dialog. Opening a malicious repository is therefore enough to
+(1) run arbitrary shell commands via hooks, and (2) redirect the
+agent's base URL to an attacker-controlled host that exfiltrates
+the API key on the first request.
+
+**Airlock mitigation**
+
+The hook-execution leg runs on the Claude Code *client* before any
+tool call exists, so runtime middleware has no seam. That half is
+out-of-scope for agent-airlock and is fixed by upgrading Claude Code.
+
+The exfiltration leg — sending the API key to an attacker-controlled
+`ANTHROPIC_BASE_URL` — IS blockable. `EndpointPolicy` rejects any
+hostname not in the caller's allow-list, and `SafeURL` applies the
+same guard at the tool-signature level. If the agent's outbound
+requests are routed through an airlock-wrapped HTTP tool, the attempt
+to post to `https://evil.example.com/...` never leaves the process.
+
+<a id="cve-2025-59536"></a>
+
+### CVE-2025-68143
+
+**Anthropic mcp-server-git `git_init` path traversal**
+
+- **CVSS:** 8.2 (High)
+- **Airlock fit:** strong
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2025-68143](https://nvd.nist.gov/vuln/detail/CVE-2025-68143)
+- **Advisory:** [https://github.com/advisories/GHSA-5cgr-j3jf-jw3v](https://github.com/advisories/GHSA-5cgr-j3jf-jw3v)
+- **Regression test:** [`tests/cves/test_cve_2025_68143_git_init_path_traversal.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2025_68143_git_init_path_traversal.py)
+
+**Vulnerability**
+
+The `git_init` tool of anthropics/mcp-server-git (< 2025.9.25 / 2025.12.18)
+accepts an arbitrary filesystem path as its `repo_path` argument without
+validating it against the configured repository root. An attacker who can
+prompt-inject the agent can therefore initialise a .git directory anywhere
+the server process can write, and — chained with a filesystem MCP — drop
+a malicious .git/config that achieves RCE on the next `git` invocation.
+
+**Airlock mitigation**
+
+This is the canonical `SafePath` / `FilesystemPolicy` defense. The fix
+upstream and the fix here are the same: reject any `repo_path` that
+escapes the configured repo root via `os.path.commonpath()`.
+
+We assert both:
+1. `SafePathValidator` with the bare defaults rejects traversal strings
+   (the pre-normalisation defense).
+2. `FilesystemPolicy.validate_path` rejects paths outside the allowed
+   root even when the path is syntactically clean (the post-resolution
+   defense).
+
+<a id="cve-2025-68143"></a>
+
+### CVE-2025-68144
+
+**Anthropic mcp-server-git argument injection**
+
+- **CVSS:** 8.1 (High)
+- **Airlock fit:** strongest
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2025-68144](https://nvd.nist.gov/vuln/detail/CVE-2025-68144)
+- **Advisory:** [https://github.com/advisories/GHSA-9xwc-hfwc-8w59](https://github.com/advisories/GHSA-9xwc-hfwc-8w59)
+- **Regression test:** [`tests/cves/test_cve_2025_68144_git_arg_injection.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2025_68144_git_arg_injection.py)
+
+**Vulnerability**
+
+`git_diff` / `git_checkout` in anthropics/mcp-server-git (< 2025.12.18)
+pass user-controlled refs directly to the `git` CLI. A ref value
+starting with a hyphen (for example `--output=/etc/profile.d/rce.sh`)
+is interpreted by git as an OPTION rather than a ref, allowing
+arbitrary file overwrite through the resulting git subprocess call.
+
+**Airlock mitigation**
+
+The ghost/strict argument validator is exactly the primitive for
+"LLM passes a string that looks like a flag into a typed parameter."
+A Pydantic-strict model with a custom validator that rejects any ref
+beginning with `-` is a one-liner at the tool-decoration layer.
+
+<a id="cve-2025-68144"></a>
+
+### CVE-2025-68145
+
+**mcp-server-git `--repository` root not enforced**
+
+- **CVSS:** 7.1 (High)
+- **Airlock fit:** strong
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2025-68145](https://nvd.nist.gov/vuln/detail/CVE-2025-68145)
+- **Advisory:** [https://github.com/advisories/GHSA-j22h-9j4x-23w5](https://github.com/advisories/GHSA-j22h-9j4x-23w5)
+- **Regression test:** [`tests/cves/test_cve_2025_68145_git_repo_root_escape.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2025_68145_git_repo_root_escape.py)
+
+**Vulnerability**
+
+When anthropics/mcp-server-git (< 2025.12.18) is started with the
+`--repository` flag to declare an allowed repo root, the server
+fails to verify on each subsequent tool call that the `repo_path`
+argument stays inside that root. A crafted argument such as
+`/var/lib/otheruser/.git` lets the server operate on any repo the
+process user can read.
+
+**Airlock mitigation**
+
+`FilesystemPolicy` with an `allowed_roots` list is the canonical
+mitigation. `validate_path` uses `os.path.commonpath()` (not string
+prefix) so it catches the three common escape variants:
+
+- absolute path outside the root
+- relative path with `..` that would normalise outside the root
+- a symlink that points outside the root
+
+<a id="cve-2025-68145"></a>
+
+### CVE-2026-26118
+
+**Microsoft Azure MCP Server SSRF (IMDS token theft)**
+
+- **CVSS:** 8.8 (High)
+- **Airlock fit:** strong
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2026-26118](https://nvd.nist.gov/vuln/detail/CVE-2026-26118)
+- **Advisory:** [https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-26118](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-26118)
+- **Regression test:** [`tests/cves/test_cve_2026_26118_azure_mcp_ssrf.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2026_26118_azure_mcp_ssrf.py)
+
+**Vulnerability**
+
+Azure MCP Server Tools (< 2.0.0-beta.17) fetch URLs passed through
+tool arguments without validating the destination. A crafted argument
+of `http://169.254.169.254/metadata/identity/oauth2/token?...` causes
+the server process to hit the Azure Instance Metadata Service and
+return the managed-identity access token to the caller — trivially
+escalating any prompt-injection bug into full Azure resource takeover.
+
+**Airlock mitigation**
+
+`validate_endpoint(...)` rejects:
+- all four cloud-metadata hosts in `_METADATA_HOSTS`
+  (169.254.169.254 / 253 / fd00:ec2::254 / metadata.google.internal),
+- any hostname that resolves to a private / loopback / link-local IP
+  when `allow_private_ips=False` (the default),
+- any hostname matching a caller-supplied blocklist pattern.
+
+<a id="cve-2026-26118"></a>
+
+### CVE-2026-27825
+
+**mcp-atlassian arbitrary file write via download_path**
+
+- **CVSS:** 9.1 (Critical)
+- **Airlock fit:** strong
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2026-27825](https://nvd.nist.gov/vuln/detail/CVE-2026-27825)
+- **Advisory:** [https://advisories.gitlab.com/pkg/pypi/mcp-atlassian/CVE-2026-27825/](https://advisories.gitlab.com/pkg/pypi/mcp-atlassian/CVE-2026-27825/)
+- **Write-up:** [https://pluto.security/blog/mcpwnfluence-cve-2026-27825-critical/](https://pluto.security/blog/mcpwnfluence-cve-2026-27825-critical/)
+- **Regression test:** [`tests/cves/test_cve_2026_27825_mcp_atlassian_arbitrary_write.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2026_27825_mcp_atlassian_arbitrary_write.py)
+
+**Vulnerability**
+
+mcp-atlassian (< 0.17.0) exposes a `confluence_download_attachment`
+tool with a `download_path` argument. The tool writes the downloaded
+file to the provided path without boundary enforcement. An attacker
+who can prompt-inject the argument can therefore overwrite
+`~/.ssh/authorized_keys`, `~/.bashrc`, or any other file the server
+process can reach — and on the exposed HTTP transport deployment
+this requires no authentication.
+
+**Airlock mitigation**
+
+`SafePath` + `FilesystemPolicy.allowed_roots` is the textbook
+mitigation. The upstream fix (in 0.17.0) introduces a
+`validate_safe_path` function — agent-airlock has had this since
+v0.3.0.
+
+<a id="cve-2026-27825"></a>
+
+### CVE-2026-27826
+
+**mcp-atlassian SSRF via `X-Atlassian-*-Url` headers**
+
+- **CVSS:** 7.5 (High, AV:A/PR:N/UI:N, C:H)
+- **Airlock fit:** partial
+- **NVD:** [https://nvd.nist.gov/vuln/detail/CVE-2026-27826](https://nvd.nist.gov/vuln/detail/CVE-2026-27826)
+- **Advisory:** [https://advisories.gitlab.com/pkg/pypi/mcp-atlassian/CVE-2026-27826/](https://advisories.gitlab.com/pkg/pypi/mcp-atlassian/CVE-2026-27826/)
+- **Regression test:** [`tests/cves/test_cve_2026_27826_mcp_atlassian_header_ssrf.py`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/test_cve_2026_27826_mcp_atlassian_header_ssrf.py)
+
+**Vulnerability**
+
+mcp-atlassian (< 0.17.0) uses unvalidated `X-Atlassian-Jira-Url` and
+`X-Atlassian-Confluence-Url` request headers to decide where to send
+upstream API calls. An attacker can redirect outbound requests to the
+IMDS endpoint or to an internal host to steal credentials or
+fingerprint the internal network.
+
+**Airlock mitigation**
+
+The vulnerability is at the HTTP-transport layer — headers aren't
+tool-call arguments. Runtime middleware cannot validate a header on
+an incoming request that never invokes a decorated tool.
+
+BUT: when an MCP server is fronted by agent-airlock and the base
+URL is surfaced as a tool parameter (the common operator pattern
+these days — per-call URL selection instead of a static config),
+the same `SafeURL` + `EndpointPolicy` primitives that block
+CVE-2026-26118 block this too. That narrower case is what we
+assert here.
+
+For the transport-header path, operators should (a) upgrade
+mcp-atlassian to ≥ 0.17.0 and (b) front their MCP server with an
+HTTP reverse proxy that strips or validates these headers before
+they reach application code.
+
+<a id="cve-2026-27826"></a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Policy Examples: examples/policy.md
     - PII Masking: examples/pii.md
     - Sandbox Execution: examples/sandbox.md
+  - CVE Catalog: cves/index.md
   - Security: SECURITY.md
   - Contributing: CONTRIBUTING.md
   - Changelog: changelog.md

--- a/scripts/gen_cve_catalog.py
+++ b/scripts/gen_cve_catalog.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Generate `docs/cves/index.md` from the regression test headers in `tests/cves/`.
+
+Each CVE regression test module starts with a structured docstring:
+
+    \"\"\"CVE-YYYY-NNNNN — <component> <short title>.
+
+    Vulnerability (from the ...):
+        <paragraph>
+
+    Advisory: <url>
+    NVD:      <url>
+    CVSS:     <n.n> (<severity>)
+
+    Airlock fit: <strong|strongest|partial|out-of-scope>.
+        <paragraph>
+    \"\"\"
+
+This script parses those headers and emits a single markdown page with a
+summary table plus per-CVE detail sections. The output is checked into the
+repo so reviewers can diff it on PRs; `scripts/check_cve_catalog.py` in CI
+verifies the checked-in file matches what the generator would produce.
+
+Usage:
+    python3 scripts/gen_cve_catalog.py > docs/cves/index.md
+    # or, for in-place update:
+    python3 scripts/gen_cve_catalog.py --write
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = ROOT / "tests" / "cves"
+OUTPUT = ROOT / "docs" / "cves" / "index.md"
+
+CVE_HEADER_RE = re.compile(r"^(CVE-\d{4}-\d+)\s+—\s+(.+?)\.?\s*$")
+ADVISORY_RE = re.compile(r"^Advisory:\s*(.+?)\s*$", re.MULTILINE)
+WRITEUP_RE = re.compile(r"^Write-?up:\s*(.+?)\s*$", re.MULTILINE)
+NVD_RE = re.compile(r"^NVD:\s*(.+?)\s*$", re.MULTILINE)
+CVSS_RE = re.compile(r"^CVSS:\s*(.+?)\s*$", re.MULTILINE)
+# Match only the first word on the "Airlock fit:" line so trailing commentary
+# (some headers say "strong — this is what v0.4.1 was built for.") doesn't
+# end up as a badge label.
+AIRLOCK_FIT_LABEL_RE = re.compile(r"^Airlock fit:\s*([A-Za-z-]+)", re.MULTILINE)
+
+
+@dataclass
+class CVEEntry:
+    """Parsed metadata for a single CVE regression test."""
+
+    cve_id: str
+    title: str
+    file: Path
+    advisory: str | None = None
+    writeup: str | None = None
+    nvd: str | None = None
+    cvss: str | None = None
+    airlock_fit: str | None = None
+    description: str = ""
+    mitigation: str = ""
+
+    @property
+    def fit_badge(self) -> str:
+        """Short label for the summary table."""
+        fit = (self.airlock_fit or "").lower()
+        if not fit:
+            return "—"
+        return fit.capitalize()
+
+    @property
+    def sort_key(self) -> tuple[str, str]:
+        year = self.cve_id.split("-")[1] if "-" in self.cve_id else "0"
+        return (year, self.cve_id)
+
+
+def _extract_docstring(path: Path) -> str | None:
+    try:
+        module = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return None
+    return ast.get_docstring(module, clean=False)
+
+
+def _parse_entry(path: Path, doc: str) -> CVEEntry | None:
+    lines = doc.splitlines()
+    if not lines:
+        return None
+
+    header = lines[0].strip()
+    match = CVE_HEADER_RE.match(header)
+    if not match:
+        return None
+
+    entry = CVEEntry(cve_id=match.group(1), title=match.group(2).strip(), file=path)
+
+    if m := ADVISORY_RE.search(doc):
+        entry.advisory = m.group(1).strip()
+    if m := WRITEUP_RE.search(doc):
+        entry.writeup = m.group(1).strip()
+    if m := NVD_RE.search(doc):
+        entry.nvd = m.group(1).strip()
+    if m := CVSS_RE.search(doc):
+        entry.cvss = m.group(1).strip()
+    if m := AIRLOCK_FIT_LABEL_RE.search(doc):
+        entry.airlock_fit = m.group(1).strip()
+
+    description_block: list[str] = []
+    mitigation_block: list[str] = []
+    mode: str | None = None
+    # In "fit" mode, a non-blank zero-indent line signals a new section
+    # (e.g. a concluding note like "This file tests ..."). Stop capturing.
+    just_saw_blank = False
+
+    for raw in lines[1:]:
+        stripped = raw.strip()
+        if stripped.startswith("Vulnerability"):
+            mode = "vuln"
+            just_saw_blank = False
+            continue
+        if stripped.startswith("Airlock fit:"):
+            mode = "fit"
+            just_saw_blank = False
+            continue
+        if stripped.startswith(("Advisory:", "Write-up:", "Writeup:", "NVD:", "CVSS:")):
+            mode = None
+            just_saw_blank = False
+            continue
+        if mode == "fit" and just_saw_blank and stripped and raw[:1] != " ":
+            mode = None
+            continue
+        if mode == "vuln":
+            description_block.append(raw)
+        elif mode == "fit":
+            mitigation_block.append(raw)
+        just_saw_blank = not stripped
+
+    entry.description = _dedent_block(description_block).strip()
+    entry.mitigation = _dedent_block(mitigation_block).strip()
+    return entry
+
+
+def _dedent_block(block: list[str]) -> str:
+    if not block:
+        return ""
+    non_empty = [ln for ln in block if ln.strip()]
+    if not non_empty:
+        return ""
+    indent = min(len(ln) - len(ln.lstrip(" ")) for ln in non_empty)
+    return "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in block)
+
+
+def collect() -> list[CVEEntry]:
+    entries: list[CVEEntry] = []
+    for path in sorted(TESTS_DIR.glob("test_cve_*.py")):
+        doc = _extract_docstring(path)
+        if not doc:
+            continue
+        entry = _parse_entry(path, doc)
+        if entry is None:
+            print(f"warning: could not parse {path}", file=sys.stderr)
+            continue
+        entries.append(entry)
+    entries.sort(key=lambda e: e.sort_key)
+    return entries
+
+
+HEADER = """# CVE catalog
+
+This page is auto-generated from the regression tests in
+[`tests/cves/`](https://github.com/sattyamjjain/agent-airlock/tree/main/tests/cves).
+
+Every CVE listed here has a corresponding test that reproduces the
+vulnerable tool-call pattern and asserts an agent-airlock primitive blocks
+it. The suite is a **second defence** — upstream vendors have shipped fixes
+for every CVE below. Agent-airlock's job is to catch the same class of bug
+when a vulnerable server is still running, or when a new tool ships with the
+same shape.
+
+See [`tests/cves/README.md`](https://github.com/sattyamjjain/agent-airlock/blob/main/tests/cves/README.md)
+for the classification rules and a list of CVEs we deliberately chose NOT
+to cover (transport-layer and web-framework bugs that sit outside the
+airlock execution seam).
+
+To regenerate this page:
+
+```bash
+python3 scripts/gen_cve_catalog.py --write
+```
+
+CI runs `python3 scripts/gen_cve_catalog.py --check` on every PR, so the
+catalog and the tests stay in lockstep.
+"""
+
+
+def render(entries: list[CVEEntry]) -> str:
+    out: list[str] = [HEADER, "", "## Summary", ""]
+    out.append("| CVE | Component / title | CVSS | Airlock fit |")
+    out.append("| --- | --- | --- | --- |")
+    for e in entries:
+        anchor = e.cve_id.lower()
+        out.append(f"| [{e.cve_id}](#{anchor}) | {e.title} | {e.cvss or '—'} | {e.fit_badge} |")
+    out.append("")
+    out.append("## Details")
+    out.append("")
+
+    for e in entries:
+        anchor = e.cve_id.lower()
+        out.append(f"### {e.cve_id}")
+        out.append("")
+        out.append(f"**{e.title}**")
+        out.append("")
+        if e.cvss:
+            out.append(f"- **CVSS:** {e.cvss}")
+        if e.airlock_fit:
+            out.append(f"- **Airlock fit:** {e.airlock_fit}")
+        if e.nvd:
+            out.append(f"- **NVD:** [{e.nvd}]({e.nvd})")
+        if e.advisory:
+            out.append(f"- **Advisory:** [{e.advisory}]({e.advisory})")
+        if e.writeup:
+            out.append(f"- **Write-up:** [{e.writeup}]({e.writeup})")
+        rel = e.file.relative_to(ROOT).as_posix()
+        out.append(
+            f"- **Regression test:** [`{rel}`](https://github.com/sattyamjjain/agent-airlock/blob/main/{rel})"
+        )
+        out.append("")
+        if e.description:
+            out.append("**Vulnerability**")
+            out.append("")
+            out.append(e.description)
+            out.append("")
+        if e.mitigation:
+            out.append("**Airlock mitigation**")
+            out.append("")
+            out.append(e.mitigation)
+            out.append("")
+        out.append(f'<a id="{anchor}"></a>')
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help=f"write output to {OUTPUT.relative_to(ROOT)} instead of stdout",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=f"exit non-zero if {OUTPUT.relative_to(ROOT)} differs from generator output",
+    )
+    args = parser.parse_args()
+
+    entries = collect()
+    content = render(entries)
+
+    if args.check:
+        if not OUTPUT.exists():
+            print(f"FAIL: {OUTPUT.relative_to(ROOT)} is missing.", file=sys.stderr)
+            return 1
+        existing = OUTPUT.read_text(encoding="utf-8")
+        if existing != content:
+            print(
+                f"FAIL: {OUTPUT.relative_to(ROOT)} is out of date. "
+                f"Run `python3 scripts/gen_cve_catalog.py --write`.",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    if args.write:
+        OUTPUT.write_text(content, encoding="utf-8")
+        print(f"wrote {OUTPUT.relative_to(ROOT)} ({len(entries)} CVEs)", file=sys.stderr)
+        return 0
+
+    sys.stdout.write(content)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the launch-day CVE catalog page for the April 2026 roadmap (#6).

- \`scripts/gen_cve_catalog.py\` parses the structured docstring header of each \`tests/cves/test_cve_*.py\` module (CVE id, component, advisory + NVD links, CVSS, Airlock fit, vulnerability paragraph, mitigation paragraph) and emits a single markdown page with a summary table plus per-CVE detail sections. Has \`--write\` (in-place update) and \`--check\` (CI gate) modes.
- \`docs/cves/index.md\` committed so reviewers see the rendered catalog directly in PRs.
- \`mkdocs.yml\` — new \"CVE Catalog\" entry between \"Examples\" and \"Security\".

## Follow-up (needs workflow scope)

The matching CI gate — a new \`docs\` job running \`python3 scripts/gen_cve_catalog.py --check\` — was drafted but pushed separately because this PR's token lacks GitHub Actions \`workflow\` scope. A maintainer with that scope can add the job to \`.github/workflows/ci.yml\`:

\`\`\`yaml
  docs:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Set up Python
        uses: actions/setup-python@v5
        with:
          python-version: \"3.11\"
      - name: Verify docs/cves/index.md is in sync with tests/cves/
        run: python3 scripts/gen_cve_catalog.py --check
\`\`\`

## Test Plan

- [x] \`python3 scripts/gen_cve_catalog.py --write\` → \`wrote docs/cves/index.md (7 CVEs)\`
- [x] \`python3 scripts/gen_cve_catalog.py --check\` → exit 0
- [x] \`pytest tests/ -q --cov=agent_airlock --cov-fail-under=80\` → 1362 passed, 33 skipped, coverage 81.36%
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] mkdocs build (not executed locally — rendered page visible in \`docs/cves/index.md\`)

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)