### PR TITLE
feat(plugin): .claude-plugin/ marketplace manifest (Phase 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/schemas/marketplace.schema.json",
+  "plugin": "agent-airlock",
+  "listing": {
+    "title": "Agent-Airlock",
+    "tagline": "The open-source firewall for AI agents.",
+    "hero_image": "https://github.com/sattyamjjain/agent-airlock/raw/main/docs/media/hero.png",
+    "demo_gif": "https://github.com/sattyamjjain/agent-airlock/raw/main/docs/media/blocked-cve.gif",
+    "screenshots": [],
+    "feature_bullets": [
+      "Stops hallucinated tool arguments before Pydantic ever sees them",
+      "Pydantic V2 strict validation + self-healing fix_hints for LLM retry",
+      "Sandboxes dangerous execution in E2B, Docker, or local (opt-in)",
+      "Output sanitization: 12 PII / secret types, 4 masking strategies",
+      "RBAC + rate limits + time windows + capability gating",
+      "Regression suite for 7 disclosed MCP-adjacent CVEs (2025-2026)",
+      "OAuth 2.1 + PKCE S256 + RFC 8707 validators for MCP 2025-11-25",
+      "OpenTelemetry audit export with documented semantic conventions",
+      "Works with every major agent framework (LangChain, LangGraph, CrewAI, AutoGen, OpenAI SDK, Anthropic SDK, PydanticAI, smolagents, LlamaIndex)"
+    ],
+    "why_this_plugin": [
+      "Runtime, not prompt-layer. We sit in front of tool execution, not in the system prompt.",
+      "Zero-cost defaults. The core validator does not need an LLM judge model.",
+      "Stdlib-first. No heavyweight deps; pip install agent-airlock is instantaneous.",
+      "Offline-capable. The CVE suite, policy presets, and validators all work air-gapped."
+    ],
+    "proof_points": [
+      "1362 tests, 81%+ coverage",
+      "7 CVE regression tests covering CVE-2025-59536, 68143, 68144, 68145, 2026-26118, 27825, 27826",
+      "5 policy presets (GTG_1002_DEFENSE, MEX_GOV_2026, OWASP_MCP_TOP_10_2026, EU_AI_ACT_ARTICLE_15, INDIA_DPDP_2023)"
+    ],
+    "audience": [
+      "AI platform engineers",
+      "Security engineers evaluating MCP deployments",
+      "Red teamers and MCP tool authors"
+    ]
+  },
+  "submission_targets": [
+    {
+      "marketplace": "anthropics/claude-plugins-official",
+      "status": "pending",
+      "notes": "Requires a PR to https://github.com/anthropics/claude-plugins-official (maintainer action)."
+    },
+    {
+      "marketplace": "claudemarketplaces.com",
+      "status": "pending",
+      "notes": "Submission form at https://claudemarketplaces.com/submit (maintainer action)."
+    },
+    {
+      "marketplace": "aitmpl.com",
+      "status": "pending",
+      "notes": "Outreach via community Discord."
+    },
+    {
+      "marketplace": "buildwithclaude.com",
+      "status": "pending",
+      "notes": "Submission form (maintainer action)."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/schemas/plugin.schema.json",
+  "name": "agent-airlock",
+  "version": "0.5.0",
+  "description": "Security middleware for MCP servers. Intercepts, validates, and sandboxes AI agent tool calls to prevent hallucinated arguments, type errors, and dangerous operations.",
+  "summary": "The open-source firewall for AI agents. One decorator. Zero trust. Full control.",
+  "homepage": "https://github.com/sattyamjjain/agent-airlock",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sattyamjjain/agent-airlock.git"
+  },
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "security",
+    "firewall",
+    "ai-agents",
+    "validation",
+    "sandbox",
+    "pii",
+    "oauth",
+    "pkce",
+    "cve"
+  ],
+  "categories": [
+    "security",
+    "mcp-middleware",
+    "agent-runtime"
+  ],
+  "maintainer": {
+    "name": "Attri.ai",
+    "email": "platform.dev@attri.ai",
+    "url": "https://github.com/sattyamjjain"
+  },
+  "install": {
+    "pypi": "agent-airlock",
+    "extras": {
+      "sandbox": "E2B Firecracker micro-VM execution",
+      "mcp": "FastMCP integration + @secure_tool decorator",
+      "claude-agent": "Claude Agent SDK integration",
+      "model-armor": "Google Cloud Model Armor prompt/response scanner",
+      "all": "Everything above"
+    }
+  },
+  "minimum_claude_version": "1.0.0",
+  "tags": [
+    "mcp-2025-11-25",
+    "oauth-2.1",
+    "cve-regression-suite",
+    "owasp-mcp-top-10"
+  ],
+  "documentation": {
+    "readme": "https://github.com/sattyamjjain/agent-airlock#readme",
+    "quickstart": "https://github.com/sattyamjjain/agent-airlock/blob/main/docs/getting-started/quickstart.md",
+    "cve_catalog": "https://github.com/sattyamjjain/agent-airlock/blob/main/docs/cves/index.md",
+    "compliance": "https://github.com/sattyamjjain/agent-airlock/blob/main/docs/COMPATIBILITY.md"
+  }
+}


### PR DESCRIPTION
## Summary

Prepares marketplace submissions for the v0.5.0 launch (#6).

- \`.claude-plugin/plugin.json\` — canonical plugin manifest (schema: \`anthropics/claude-plugins-official\`). Name, v0.5.0, install details, maintainer, keywords, categories, documentation links, launch-day tags.
- \`.claude-plugin/marketplace.json\` — listing copy + \`submission_targets\` tracking the four roadmap marketplaces: \`anthropics/claude-plugins-official\`, \`claudemarketplaces.com\`, \`aitmpl.com\`, \`buildwithclaude.com\`. All marked \`status: pending\` — actual submission is a maintainer action (needs OAuth to each platform).

## Test Plan

- [x] JSON parses (\`python3 -c 'import json; json.load(...)'\` for both files)
- [x] Version string matches \`pyproject.toml\` + \`__version__\` after #17 lands

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)