### PR TITLE
feat(sandbox): add ManagedSandboxBackend stub (Phase 1.5)

### DIFF
--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -240,11 +240,12 @@ from .safe_types import (
     create_safe_url_type,
 )
 
-# V0.4.0 Sandbox backends
+# V0.4.0 Sandbox backends (V0.5.0 adds ManagedSandboxBackend stub)
 from .sandbox_backend import (
     DockerBackend,
     E2BBackend,
     LocalBackend,
+    ManagedSandboxBackend,
     SandboxBackend,
     SandboxResult,
     get_default_backend,
@@ -459,6 +460,7 @@ __all__ = [
     "E2BBackend",
     "DockerBackend",
     "LocalBackend",
+    "ManagedSandboxBackend",
     "get_default_backend",
     # V0.4.0 OTel Audit
     "OTelAuditExporter",

--- a/src/agent_airlock/sandbox_backend.py
+++ b/src/agent_airlock/sandbox_backend.py
@@ -541,7 +541,7 @@ class ManagedSandboxBackend(SandboxBackend):
     def is_available(self) -> bool:
         """Check that the SDK is installed AND an API key is reachable."""
         try:
-            import anthropic  # noqa: F401
+            import anthropic  # type: ignore[import-not-found,unused-ignore]  # noqa: F401
         except ImportError:
             return False
         import os

--- a/src/agent_airlock/sandbox_backend.py
+++ b/src/agent_airlock/sandbox_backend.py
@@ -492,6 +492,100 @@ class LocalBackend(SandboxBackend):
             )
 
 
+class ManagedSandboxBackend(SandboxBackend):
+    """Anthropic Managed Agents backend — **beta, opt-in only**.
+
+    Anthropic's Managed Agents product (https://anthropic.com/, announced
+    April 2026) runs complete agent loops — model turns, tool calls, and
+    state — on Anthropic-operated infrastructure. This does NOT map
+    one-to-one onto the `SandboxBackend.execute()` contract, which is
+    "run THIS function with THESE arguments in an isolated environment."
+
+    Why this backend exists:
+
+    - The roadmap (#6) tracks a Managed Agents story for v0.5.0.
+    - Users need a clear opt-in hook rather than discovering later that
+      Managed Agents is not plug-compatible with `E2BBackend`.
+
+    What this backend currently does:
+
+    - ``is_available()`` returns ``True`` when the ``anthropic`` SDK is
+      importable **and** either ``api_key`` is provided or
+      ``ANTHROPIC_API_KEY`` is set in the environment.
+    - ``execute()`` does not run the provided function. It returns a
+      ``SandboxResult(success=False, error=...)`` with a pointer to the
+      Anthropic-SDK-based integration (``examples/anthropic_integration.py``)
+      that wraps an agent loop rather than a single function call.
+    - ``warmup()`` and ``shutdown()`` are no-ops.
+
+    Future work (tracked in #6): a session-based ``ManagedAgentExecutor``
+    that accepts a tool registry and a prompt, then runs a full agent
+    loop inside a Managed session. That lives outside the
+    ``SandboxBackend`` interface because the shapes disagree. When it
+    lands, this class will document the integration point.
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """Initialize the Managed Agents backend.
+
+        Args:
+            api_key: Anthropic API key. Falls back to ``ANTHROPIC_API_KEY``
+                env var.
+        """
+        self.api_key = api_key
+
+    @property
+    def name(self) -> str:
+        return "managed"
+
+    def is_available(self) -> bool:
+        """Check that the SDK is installed AND an API key is reachable."""
+        try:
+            import anthropic  # noqa: F401
+        except ImportError:
+            return False
+        import os
+
+        return bool(self.api_key or os.environ.get("ANTHROPIC_API_KEY"))
+
+    def execute(
+        self,
+        func: Callable[..., R],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        timeout: int = 60,
+    ) -> SandboxResult:
+        """Deliberately does not run ``func``.
+
+        See class docstring — Managed Agents runs agent loops, not single
+        function calls. This method returns a failure ``SandboxResult`` with
+        a message pointing the caller at the right abstraction so silent
+        misuse is impossible.
+        """
+        del args, kwargs, timeout  # intentionally unused — see docstring
+        logger.warning(
+            "managed_sandbox_execute_not_supported",
+            tool_name=getattr(func, "__name__", "unknown"),
+            hint=(
+                "SandboxBackend.execute() runs one function; Anthropic Managed "
+                "Agents runs a full agent loop. Use the anthropic SDK "
+                "integration (examples/anthropic_integration.py) or the "
+                "ClaudeAgentSDK extra for loop-style execution."
+            ),
+        )
+        return SandboxResult(
+            success=False,
+            error=(
+                "ManagedSandboxBackend is a session-based backend: "
+                "single-function execute() is not supported. "
+                "See examples/anthropic_integration.py for the agent-loop "
+                "integration, or roadmap issue #6 for the planned "
+                "ManagedAgentExecutor interface."
+            ),
+            backend=self.name,
+        )
+
+
 # Default backend factory
 def get_default_backend(config: AirlockConfig | None = None) -> SandboxBackend:
     """Get the default sandbox backend based on availability.
@@ -535,4 +629,4 @@ def get_default_backend(config: AirlockConfig | None = None) -> SandboxBackend:
 
 
 # Type alias for backend configuration
-BackendType = E2BBackend | DockerBackend | LocalBackend
+BackendType = E2BBackend | DockerBackend | LocalBackend | ManagedSandboxBackend

--- a/tests/test_managed_sandbox_backend.py
+++ b/tests/test_managed_sandbox_backend.py
@@ -1,0 +1,72 @@
+"""Tests for the ``ManagedSandboxBackend`` stub (Phase 1.5).
+
+The backend deliberately does not execute arbitrary functions — Anthropic
+Managed Agents runs complete agent loops, not single code blobs, so the
+``SandboxBackend.execute()`` shape is wrong for it. These tests pin that
+contract so we can't accidentally regress into silent misuse.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_airlock import ManagedSandboxBackend
+
+
+def _sample(x: int) -> int:
+    return x + 1
+
+
+class TestManagedSandboxBackendAvailability:
+    def test_not_available_without_anthropic_sdk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SDK missing ⇒ unavailable regardless of API key."""
+        monkeypatch.setitem(sys.modules, "anthropic", None)  # forces ImportError
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-xxx")
+        backend = ManagedSandboxBackend()
+        assert backend.is_available() is False
+
+    def test_not_available_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SDK present but no key anywhere ⇒ unavailable."""
+        fake = types.ModuleType("anthropic")
+        monkeypatch.setitem(sys.modules, "anthropic", fake)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        backend = ManagedSandboxBackend()
+        assert backend.is_available() is False
+
+    def test_available_with_sdk_and_env_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = types.ModuleType("anthropic")
+        monkeypatch.setitem(sys.modules, "anthropic", fake)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-xxx")
+        backend = ManagedSandboxBackend()
+        assert backend.is_available() is True
+
+    def test_available_with_sdk_and_explicit_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = types.ModuleType("anthropic")
+        monkeypatch.setitem(sys.modules, "anthropic", fake)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        backend = ManagedSandboxBackend(api_key="sk-explicit")
+        assert backend.is_available() is True
+
+
+class TestManagedSandboxBackendExecuteContract:
+    def test_name(self) -> None:
+        assert ManagedSandboxBackend().name == "managed"
+
+    def test_execute_returns_failure_with_pointer_to_right_abstraction(self) -> None:
+        backend = ManagedSandboxBackend()
+        result = backend.execute(_sample, (5,), {})
+        assert result.success is False
+        assert result.backend == "managed"
+        assert result.error is not None
+        # The error must direct the caller to the right abstraction so a
+        # user who enabled this by mistake learns fast.
+        assert "agent" in result.error.lower()
+        assert "examples/anthropic_integration.py" in result.error
+
+    def test_warmup_and_shutdown_are_noops(self) -> None:
+        backend = ManagedSandboxBackend()
+        assert backend.warmup() is None
+        assert backend.shutdown() is None


### PR DESCRIPTION
## Summary

Closes Phase 1.5 (#6) with a **deliberately-limited stub**.

Anthropic Managed Agents runs full agent loops, not single code blobs — the \`SandboxBackend.execute()\` shape doesn't fit. Pretending it does would be a silent-misuse trap.

### What this PR ships

- \`ManagedSandboxBackend\` in \`src/agent_airlock/sandbox_backend.py\`:
  - \`name = \"managed\"\`
  - \`is_available()\`: \`True\` iff \`anthropic\` SDK importable **AND** \`api_key\` / \`ANTHROPIC_API_KEY\` set
  - \`execute()\`: **does NOT run the function** — returns \`SandboxResult(success=False, ...)\` with a pointer to \`examples/anthropic_integration.py\` and the planned \`ManagedAgentExecutor\`
  - \`warmup()\` / \`shutdown()\` are no-ops
- Exported from \`agent_airlock.__init__\` as \`ManagedSandboxBackend\`
- Added to \`BackendType\` union
- **NOT added to \`get_default_backend()\`** — opt-in only
- 7 unit tests pinning the contract (availability gating, name, execute() failure-with-pointer, no-op warmup/shutdown)

When the real session-based \`ManagedAgentExecutor\` lands, this class will document the integration point. Keeping the backend name in the public API now means users can wire TOML configs ahead of time.

## Test Plan

- [x] \`pytest tests/ --cov=agent_airlock --cov-fail-under=80\` → 1369 passed (was 1362), coverage 81.44%
- [x] \`mypy src/agent_airlock/sandbox_backend.py\` → \`Success: no issues found\`
- [x] \`ruff check\` + \`ruff format --check\` clean

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)