### PR TITLE
docs(launch): launch-readiness hub — checklist, FAQ, rollback, NVD watcher sample

### DIFF
--- a/docs/launch/faq.md
+++ b/docs/launch/faq.md
@@ -1,0 +1,133 @@
+# Launch-day FAQ
+
+Questions we expect from HN, Reddit, and the security Twitter
+contingent. Keep answers short and cite primary sources.
+
+## Positioning
+
+### Q: How is agent-airlock different from Lakera / Snyk Agent Scan / PANW / Invariant / Cloudflare Firewall for AI / Google Model Armor?
+
+**Runtime seam, not prompt seam.** All of the above intercept at or near
+the LLM prompt boundary — they scan prompts, responses, or proxy HTTP
+traffic. Agent-airlock sits in front of **tool execution**, inside the
+agent process. If your model never calls a tool, airlock never fires.
+If your model invents a tool argument that shouldn't exist
+(ghost argument), airlock catches it before the tool runs — a layer
+none of the prompt-layer products reach.
+
+### Q: Is this a replacement for Model Armor / Lakera?
+
+No — complementary. We ship an opt-in Model Armor adapter
+(`pip install agent-airlock[model-armor]`) so you can use both. Use
+Model Armor to score prompts/responses; use airlock to block a tool
+from ever running with bad arguments.
+
+### Q: Why no hosted SaaS?
+
+The value prop is "offline, stdlib-first, air-gap-safe." A hosted
+version dilutes that. We'd rather be the best local-only primitive than
+a middling SaaS.
+
+## Threat model
+
+### Q: What does airlock NOT block?
+
+- Vulnerabilities at the HTTP/transport layer of an MCP server
+  (e.g. missing auth on `/api/mcp/connect`). We sit in front of tool
+  execution, not the HTTP router. Use a reverse proxy for that.
+- Vulnerabilities before a tool is registered (e.g. the Claude Code
+  CVE-2025-59536 hook-execution path, which runs on client launch).
+  We block the exfil leg via `EndpointPolicy`; we can't block the
+  hook-execution leg.
+- Prompt-injection into the model itself. That's an LLM safety
+  problem — use Model Armor, Lakera, or your model vendor's native
+  guardrails.
+- See `docs/cves/index.md` for the full fit matrix.
+
+### Q: What's the attack surface of airlock itself?
+
+Middleware that enforces policies is a juicy target. We mitigate with:
+
+- Zero heavyweight deps — core is pydantic + structlog
+- No `eval()` anywhere in runtime paths
+- `SafePath` + `SafeURL` validators on every input
+- Honest CVE regression suite (see `docs/cves/`)
+- Private vulnerability reporting via `SECURITY.md` with 48 h triage
+
+## Performance
+
+### Q: How much does this cost per tool call?
+
+From `tests/benchmarks/` on a MacBook M-series:
+
+- `@Airlock` decorator overhead: **~85 μs** per call (no sandbox, no
+  network, no sanitizer). With Pydantic strict validation of 2 fields:
+  **~77 μs**.
+- Output sanitization on a 4 KB clean payload: **~580 μs**.
+- PKCE round-trip: **~100 μs**.
+
+In other words: sub-millisecond on every path that isn't a sandboxed
+execution or a long-output sanitize. For launch we're deliberately NOT
+publishing a single "X μs overhead" headline number because it's
+workload-dependent.
+
+## Usage
+
+### Q: How do I install just the parts I need?
+
+```bash
+pip install agent-airlock                    # core only
+pip install "agent-airlock[mcp]"              # + FastMCP integration
+pip install "agent-airlock[sandbox]"          # + E2B
+pip install "agent-airlock[model-armor]"      # + Google Model Armor
+pip install "agent-airlock[claude-agent]"     # + Claude Agent SDK
+pip install "agent-airlock[all]"              # everything
+```
+
+### Q: Which frameworks work out of the box?
+
+LangChain, LangGraph, CrewAI, AutoGen, OpenAI SDK, Anthropic SDK,
+PydanticAI, smolagents, LlamaIndex. Each has a tested example under
+`examples/`.
+
+### Q: How do I wire it into my MCP server?
+
+```python
+from agent_airlock.mcp import secure_tool
+
+@secure_tool
+def run_sql(query: str) -> list[dict]:
+    ...
+```
+
+Or construct your own `@Airlock(...)` with a custom policy. See
+`docs/getting-started/quickstart.md`.
+
+## Roadmap / community
+
+### Q: Are you looking for design partners?
+
+Yes — email `platform.dev@attri.ai` with your use case. We're
+prioritizing 3 partners for case studies at weeks 8, 10, and 12 after
+launch.
+
+### Q: Is there a Discord?
+
+Link in README. Not fancy — a `#help`, a `#cve-rules`, and a `#dev`
+channel.
+
+### Q: What's the license?
+
+MIT. See `LICENSE`.
+
+### Q: How do you handle CVE disclosures you want to add as regression tests?
+
+File an issue with the [CVE rule request template](https://github.com/sattyamjjain/agent-airlock/issues/new?template=cve_rule_request.md).
+Primary-source link is required — we won't write a test against a
+rumored CVE.
+
+## Business-y stuff
+
+### Q: Who's behind this?
+
+Sattyam Jain at attri.ai. Open-source MIT. Not a company product.

--- a/docs/launch/index.md
+++ b/docs/launch/index.md
@@ -1,0 +1,25 @@
+# Launch hub
+
+Artifacts for the v0.5.0 "April 2026" launch. Everything here is prep —
+none of it ships to end users at runtime.
+
+- [**Readiness checklist**](readiness-checklist.md) — hard go/no-go list
+  per the roadmap (#6). Tick every box before the HN post goes up.
+- [**Launch-day FAQ**](faq.md) — drafted answers for the questions we
+  expect from HN / Reddit / security Twitter.
+- [**Rollback plan**](rollback.md) — what to do if something goes
+  sideways in the first 48 hours after publishing.
+- [**NVD MCP-CVE watcher (sample)**](nvd-mcp-watcher.yml.sample) —
+  GitHub Actions workflow that auto-files CVE rule-request issues for
+  newly-disclosed MCP-adjacent CVEs. Sample file; a maintainer with
+  `workflow` scope must copy it into `.github/workflows/` to enable.
+
+## Why a launch hub?
+
+The April 2026 roadmap (#6) §Phase-4 is explicit that a launch is a
+separate, human-driven deliverable. It calls for a
+"launch-readiness PR" that bundles the demo GIF, CVE regression suite
+state, release tag, FAQ, and rollback plan into a single review
+artifact.
+
+This folder IS that bundle.

--- a/docs/launch/nvd-mcp-watcher.yml.sample
+++ b/docs/launch/nvd-mcp-watcher.yml.sample
@@ -1,0 +1,117 @@
+# NVD MCP-CVE watcher — GitHub Actions workflow (sample)
+#
+# This file is a SAMPLE. A maintainer with GitHub `workflow` scope on
+# the repo needs to copy this into `.github/workflows/nvd-mcp-watch.yml`.
+# The bot that landed docs/launch/ couldn't push under
+# `.github/workflows/` (lacks `workflow` scope).
+#
+# What it does:
+#   - Runs on a daily cron
+#   - Queries the NVD 2.0 REST API for CVEs containing "MCP" or
+#     "Model Context Protocol" disclosed in the last 48 hours
+#   - For each hit, opens a GitHub issue using the
+#     `cve_rule_request.md` template, pre-filled with NVD metadata
+#   - Labels the issue `cve-rule-request` and `nvd-auto` so humans can
+#     triage and convert to a regression test
+#
+# Security considerations:
+#   - Uses `GITHUB_TOKEN` (default), NO external secrets needed
+#   - NVD API does not require an API key for < 5 requests in a 30 s
+#     window; a dedicated key can be added via `secrets.NVD_API_KEY`
+#     for higher volume
+#   - The watcher only CREATES issues. It never modifies test code.
+#
+# Stability:
+#   - NVD API schema:
+#     https://nvd.nist.gov/developers/vulnerabilities (retrieved
+#     2026-04-18)
+#   - If NVD changes the shape, the `jq` filters below will stop
+#     matching and no issues will be created. That's a safe failure
+#     mode — the worst case is "we miss a CVE for a day" not
+#     "we open garbage issues".
+
+name: NVD MCP-CVE watcher
+
+on:
+  schedule:
+    - cron: "17 7 * * *"  # 07:17 UTC daily — off the top-of-hour crowd
+  workflow_dispatch:  # manual trigger for testing
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  nvd-watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch recent MCP CVEs from NVD
+        id: nvd
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}  # optional
+        run: |
+          set -euo pipefail
+          since=$(date -u -d "48 hours ago" +%Y-%m-%dT%H:%M:%S.000)
+          now=$(date -u +%Y-%m-%dT%H:%M:%S.000)
+          url="https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=MCP&pubStartDate=${since}&pubEndDate=${now}"
+          auth=()
+          if [ -n "${NVD_API_KEY:-}" ]; then
+            auth=(-H "apiKey: ${NVD_API_KEY}")
+          fi
+          curl -sSfL "${auth[@]}" "$url" > nvd.json
+          # extract: id, description[en], cvssV3 base score, reference URLs
+          jq -r '
+            .vulnerabilities[]
+            | .cve
+            | {
+                id,
+                desc: (.descriptions[] | select(.lang=="en") | .value),
+                cvss: (try .metrics.cvssMetricV31[0].cvssData.baseScore // null),
+                refs: [.references[].url]
+              }
+          ' nvd.json > hits.jsonl
+          echo "count=$(wc -l < hits.jsonl)" >> "$GITHUB_OUTPUT"
+
+      - name: Open CVE-rule-request issues for each hit
+        if: steps.nvd.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r hit; do
+            id=$(echo "$hit" | jq -r .id)
+            desc=$(echo "$hit" | jq -r .desc)
+            cvss=$(echo "$hit" | jq -r .cvss)
+            refs=$(echo "$hit" | jq -r '.refs | join("\n- ")')
+            # idempotent: skip if an issue for this CVE already exists
+            if gh issue list --repo "${{ github.repository }}" \
+                 --search "in:title \"${id}\"" --state all --json number \
+                 | jq -e 'length > 0' > /dev/null; then
+              echo "Skipping ${id} — issue already exists"
+              continue
+            fi
+            gh issue create --repo "${{ github.repository }}" \
+              --title "CVE rule request: ${id}" \
+              --label cve-rule-request,nvd-auto \
+              --body "$(cat <<EOF
+          Auto-filed by the NVD MCP-CVE watcher.
+
+          **NVD:** https://nvd.nist.gov/vuln/detail/${id}
+          **CVSS:** ${cvss}
+
+          **Description:**
+
+          ${desc}
+
+          **References:**
+
+          - ${refs}
+
+          Please triage and, if the CVE is in scope for runtime middleware
+          (see \`tests/cves/README.md\`), convert to a regression test
+          using the \`cve_rule_request.md\` template fields.
+          EOF
+          )"
+          done < hits.jsonl

--- a/docs/launch/readiness-checklist.md
+++ b/docs/launch/readiness-checklist.md
@@ -1,0 +1,66 @@
+# Launch-readiness checklist — v0.5.0 "April 2026"
+
+Per the April 2026 roadmap (#6), do NOT post to HN/Reddit/X until every
+checkbox below is either ticked or explicitly waived in the PR that
+references this page.
+
+## Code / release
+
+- [ ] All Phase 1 PRs merged to `main` (1.1 SDK rename, 1.2 MCP
+      2025-11-25, 1.3 CVE suite, 1.4 presets, 1.5 Managed backend stub,
+      1.6 A2A middleware, 1.7 Model Armor, 1.8 deep-analysis bug triage)
+- [ ] `pyproject.toml` version bumped to `0.5.0`
+      (see [#17](https://github.com/sattyamjjain/agent-airlock/pull/17))
+- [ ] `src/agent_airlock/__init__.py` `__version__` matches
+- [ ] `CHANGELOG.md` `[0.5.0]` heading with a one-paragraph summary
+- [ ] `CI` green on main for the commit being tagged
+- [ ] `git tag v0.5.0 -a -m "..."` + `git push origin v0.5.0`
+- [ ] Release notes posted to GitHub Releases (matches CHANGELOG body)
+- [ ] `twine upload dist/*` succeeded
+- [ ] `pip install agent-airlock==0.5.0` works from a clean env
+
+## Docs
+
+- [ ] README hero/quickstart up to date
+- [ ] `docs/cves/index.md` auto-generated and in-sync with `tests/cves/`
+      (CI gate runs `scripts/gen_cve_catalog.py --check`)
+- [ ] `docs/observability/semconv.md` present with stable-attribute
+      contract
+- [ ] `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CONTRIBUTING.md`, issue
+      templates present
+- [ ] `.claude-plugin/{plugin,marketplace}.json` point at 0.5.0
+- [ ] `docs/launch/faq.md` drafted (this folder)
+- [ ] `docs/launch/rollback.md` drafted (this folder)
+
+## Artifacts
+
+- [ ] Demo GIF at `docs/media/blocked-cve.gif` (60 s screencast)
+- [ ] Hero image at `docs/media/hero.png`
+- [ ] Coverage badge + test count badge updated
+
+## Security hygiene
+
+- [ ] Latest `bandit -r src/agent_airlock/` → 0 issues
+- [ ] `pip install --quiet safety && safety check` reviewed
+      (deprecation warnings OK, CVEs are not)
+- [ ] SBOM generated and uploaded as a CI artifact
+- [ ] PGP key fingerprint in `SECURITY.md` matches the key used to sign
+      the release tag
+
+## Go / no-go
+
+- [ ] **Launch day is a Tuesday**, not a Friday
+- [ ] Launch-readiness PR approved by the maintainer
+- [ ] Rollback plan reviewed (see `rollback.md`)
+- [ ] Maintainer available to watch HN comments for 4 hours after post
+
+## External submissions (not blocking launch, but schedule)
+
+- [ ] PR opened against `anthropics/claude-plugins-official`
+- [ ] Submission form filed at `claudemarketplaces.com/submit`
+- [ ] `aitmpl.com` outreach via Discord
+- [ ] `buildwithclaude.com` submission form filed
+- [ ] 10 DMs drafted (simonw, swyx, karpathy, Theo, 6 security devs) —
+      NOT sent until after HN post lands on the front page
+- [ ] 8-tweet X thread drafted
+- [ ] `/r/ClaudeAI`, `/r/LocalLLaMA`, `/r/netsec` post drafts reviewed

--- a/docs/launch/rollback.md
+++ b/docs/launch/rollback.md
@@ -1,0 +1,96 @@
+# Launch-day rollback plan
+
+## When to roll back
+
+Roll back to v0.4.1 if **any** of the following happens in the first
+48 hours after posting:
+
+1. A first-week bug in `agent-airlock` 0.5.0 blocks a legitimate tool
+   call that worked on 0.4.1, and the fix will take more than 4 hours.
+2. `pip install agent-airlock==0.5.0` fails in a way that leaks secrets
+   (env vars, token paths) into a traceback visible on PyPI or HN
+   comments.
+3. A new CVE is disclosed against a downstream dep (`pydantic`, `mcp`,
+   `fastmcp`, `e2b`, `anthropic`) that changes our threat-model claims.
+4. CI goes red on main and we don't have a clean forward-fix within
+   2 hours.
+
+## Rollback procedure
+
+### Step 1 — yank the bad release from PyPI
+
+```bash
+# Only yank, do NOT delete — yank preserves resolver semantics.
+pip install --upgrade twine
+twine yank agent-airlock --version 0.5.0
+```
+
+This blocks new installs from resolving to 0.5.0 without breaking
+existing pins.
+
+### Step 2 — revert the main branch to the v0.4.1 commit
+
+```bash
+git fetch origin
+git tag v0.4.1-last-good-pre-rollback  # safety marker
+git push origin v0.4.1-last-good-pre-rollback
+git revert <first-bad-sha>..<last-bad-sha> --no-edit
+# or, if the revert is messy:
+git reset --hard v0.4.1 && git push --force-with-lease origin main
+```
+
+`--force-with-lease` (not plain `--force`) stops if someone pushed
+while you were composing the rollback.
+
+### Step 3 — ship the forward-fix as 0.5.1
+
+```bash
+# Separate branch, separate PR, separate review. No silent republish.
+git switch -c fix/v0.5.0-rollback-forward-fix
+# ... make the fix ...
+# bump pyproject.toml + __init__.py to 0.5.1
+# write the [0.5.1] CHANGELOG entry naming the yanked 0.5.0
+```
+
+### Step 4 — update the outside world
+
+- Pin comment on the HN thread explaining the yank + linking to 0.5.1
+- Reddit threads: edit top comment with the same pointer
+- X thread: reply to the top tweet (do NOT delete the original)
+- Discord announcement in `#releases`
+- Update GitHub Release page for v0.5.0 to mark it yanked and link
+  the replacement
+
+## Pre-commit safety markers
+
+Before publishing 0.5.0, tag the **last known good** revision so we
+have a no-arg rollback target:
+
+```bash
+git tag v0.4.1-pre-april-2026 <commit-sha>
+git push origin v0.4.1-pre-april-2026
+```
+
+(This tag already exists — see the roadmap-phase-0 work.)
+
+## Incident comms template
+
+> **Heads-up:** we yanked `agent-airlock==0.5.0` at HH:MM UTC because
+> of <single-sentence summary>. The fix is tracked in
+> https://github.com/sattyamjjain/agent-airlock/issues/<N> and will
+> ship as 0.5.1 within <timeframe>.
+>
+> If you've already installed 0.5.0, pin to 0.4.1 until the forward-fix
+> lands: `pip install 'agent-airlock==0.4.1'`.
+>
+> Sorry for the disruption — this is why we yank, not hide. Full
+> postmortem will go up at `/blog/postmortems/0-5-0.md` within 7 days.
+
+## Post-rollback obligations
+
+Within 7 days of a rollback:
+
+1. Write a public postmortem at `/blog/postmortems/<version>.md` with
+   5 Whys + remediation tasks tracked in GitHub issues.
+2. Add a new regression test that would have caught the class of bug.
+3. Update this rollback doc if the procedure itself had friction.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,11 @@ nav:
   - CVE Catalog: cves/index.md
   - Security: SECURITY.md
   - Contributing: CONTRIBUTING.md
+  - Launch:
+    - Overview: launch/index.md
+    - Readiness Checklist: launch/readiness-checklist.md
+    - Launch FAQ: launch/faq.md
+    - Rollback Plan: launch/rollback.md
   - Changelog: changelog.md
 
 extra:


### PR DESCRIPTION
## Summary

Closes the Phase 4 launch-prep and Phase 5 NVD-watcher roadmap items from #6 — the parts that don't need human hands.

### Files added

- \`docs/launch/index.md\` — hub
- \`docs/launch/readiness-checklist.md\` — hard go/no-go list before HN post
- \`docs/launch/faq.md\` — drafted HN / Reddit / security-Twitter Q&A (positioning vs Lakera / Snyk / PANW / Cloudflare / Model Armor, threat model, perf numbers from \`tests/benchmarks/\`, install variants, framework matrix, CVE-rules contribution pointer)
- \`docs/launch/rollback.md\` — when to yank, yank-not-delete, revert main, ship forward-fix as 0.5.1, comms template, post-rollback obligations
- \`docs/launch/nvd-mcp-watcher.yml.sample\` — GitHub Actions workflow that auto-files CVE rule-request issues for new MCP-adjacent CVEs on NVD. Idempotent (skips CVEs with existing issues), uses default \`GITHUB_TOKEN\`. **Sample file** — a maintainer with \`workflow\` scope must copy it into \`.github/workflows/nvd-mcp-watch.yml\` to enable.
- \`mkdocs.yml\` — new \"Launch\" nav section

None of this ships at runtime. Pure prep material.

## Test Plan

- [x] \`pytest tests/ --cov=agent_airlock --cov-fail-under=80\` → 1362 passed, coverage 81.36% (unchanged — docs-only)
- [x] \`ruff check\` clean
- [ ] mkdocs build (not executed locally — launch hub is linkable from the nav)

## Explicitly NOT shipped here

- HN / Reddit / X posts (human action, launch day)
- 60-s screencast at \`docs/media/blocked-cve.gif\` (needs screen + voice)
- Domain + Discord + creator DMs (require OAuth/identities this bot can't assume)
- The actual merge of \`nvd-mcp-watcher.yml\` into \`.github/workflows/\` (needs \`workflow\` scope)

Refs #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)