### PR TITLE
chore: strip all attri.ai branding and emails

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,8 +28,8 @@
     "agent-runtime"
   ],
   "maintainer": {
-    "name": "Attri.ai",
-    "email": "platform.dev@attri.ai",
+    "name": "Sattyam Jain",
+    "email": "sattyamjjain@gmail.com",
     "url": "https://github.com/sattyamjjain"
   },
   "install": {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the project maintainers at
-[platform.dev@attri.ai](mailto:platform.dev@attri.ai). All complaints will be
+[sattyamjjain@gmail.com](mailto:sattyamjjain@gmail.com). All complaints will be
 reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for considering contributing to Agent-Airlock! It's people 
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Report unacceptable behavior to [platform.dev@attri.ai](mailto:platform.dev@attri.ai).
+This project and everyone participating in it is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Report unacceptable behavior to [sattyamjjain@gmail.com](mailto:sattyamjjain@gmail.com).
 
 ## How Can I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -611,7 +611,6 @@ Agent-Airlock secures AI agent systems in production:
 
 | Project | Use Case |
 |---------|----------|
-| [**Attri.ai**](https://attri.ai) | Multi-agent orchestration platform — governance & security layer |
 | [**FerrumDeck**](https://github.com/sattyamjjain/FerrumDeck) | AgentOps control plane — deny-by-default tool execution |
 | [**Mnemo**](https://github.com/sattyamjjain/Mnemo) | MCP-native memory database — secure tool call validation |
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -71,7 +71,7 @@ pip install agent-airlock[all]
 For contributing to Agent-Airlock:
 
 ```bash
-git clone https://github.com/attri-ai/agent-airlock.git
+git clone https://github.com/sattyamjjain/agent-airlock.git
 cd agent-airlock
 pip install -e ".[dev,all]"
 ```

--- a/docs/launch/faq.md
+++ b/docs/launch/faq.md
@@ -161,7 +161,7 @@ Or construct your own `@Airlock(...)` with a custom policy. See
 
 ### Q: Are you looking for design partners?
 
-Yes — email `platform.dev@attri.ai` with your use case. We're
+Yes — email `sattyamjjain@gmail.com` with your use case. We're
 prioritizing 3 partners for case studies at weeks 8, 10, and 12 after
 launch.
 
@@ -184,4 +184,4 @@ rumored CVE.
 
 ### Q: Who's behind this?
 
-Sattyam Jain at attri.ai. Open-source MIT. Not a company product.
+Sattyam Jain. Open-source MIT, personal project. Not a company product.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,4 +105,4 @@ extra:
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/agent-airlock/
 
-copyright: Copyright &copy; 2024-2026 Attri.ai
+copyright: Copyright &copy; 2024-2026 Sattyam Jain


### PR DESCRIPTION
## Summary

Removes every `Attri.ai` / `attri-ai` / `platform.dev@attri.ai`
reference from the repo. agent-airlock is now consistently attributed
as a personal OSS project by Sattyam Jain.

## What changed

**Broken URL (same class as the mkdocs.yml repo_url fix in PR #25):**
- `docs/getting-started/installation.md` — clone URL now points at
  `sattyamjjain/agent-airlock`, not `attri-ai/agent-airlock` (404).

**Email swap (`platform.dev@attri.ai` → `sattyamjjain@gmail.com`, 4 call sites):**
- `CODE_OF_CONDUCT.md` (enforcement contact)
- `CONTRIBUTING.md` (CoC contact)
- `docs/launch/faq.md` (design-partner outreach)
- `.claude-plugin/plugin.json` (plugin author email)

**Brand strip:**
- `mkdocs.yml` — copyright line: `Attri.ai` → `Sattyam Jain`
- `README.md` — `Used By` table: removed the Attri.ai row
- `docs/launch/faq.md` §"Who's behind this" — `Sattyam Jain at
  attri.ai` → `Sattyam Jain. Open-source MIT, personal project.`
- `.claude-plugin/plugin.json` — maintainer.name: `Attri.ai` →
  `Sattyam Jain`

## Verification

```bash
rg -i 'attri[-._]ai|attri\.ai|Attri\.ai|platform\.dev'
# (no matches)
```

No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)