### PR TITLE
v0.5.2 — OAuth audit bundle + session-snapshot integrity + Auto Memory guard + new CVE presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,119 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.2] - 2026-04-20 — "OAuth audit bundle"
+
+Driven by 72 hours of April 2026 industry signal. Seven new guards /
+presets; every one ships **off by default** and activates only when
+the user opts in via preset or config. Task 4's half-fix from v0.5.1
+(DockerBackend hardening) is now closed out — issue #2 resolved with
+a docs page and two tracked follow-ups (#37 rootless, #38 digest pin).
+
+### Security presets
+
+- **OAuth app audit guard** (`agent_airlock.mcp_spec.oauth_audit`):
+  `OAuthAppAuditConfig`, `audit_oauth_exchange()`, `OAuthAppBlocked`,
+  `OAuthPolicyViolation` (both `AirlockError` subclasses). Preset
+  `oauth_audit_vercel_2026_defaults()` seeds a deny-list with the
+  Vercel-disclosed Context.ai OAuth client_id
+  (`110671459871-30f1spbu0hptbs60cb4vsmv79i7bbvqj.apps.googleusercontent.com`),
+  enforces PKCE, refresh-token rotation, and a 1-hour lifetime cap.
+  Optional JSON deny-list feed loader (air-gap-safe by default —
+  reads from a local path). `MCPProxyGuard.audit_oauth_exchange()`
+  method wires the audit into the existing guard API. 8 new tests.
+  Source: <https://vercel.com/kb/bulletin/vercel-april-2026-security-incident>
+- **Session-snapshot integrity guard**
+  (`agent_airlock.mcp_spec.session_guard`): `SessionSnapshotRef`,
+  `SnapshotGuardConfig`, `verify_snapshot()`, `SnapshotIntegrityError`
+  (`AirlockError` subclass). Six checks — provider allow-list
+  (Blaxel, Cloudflare, Daytona, E2B, Modal, Runloop, Vercel), size
+  cap (25 MiB DoS guard), metadata consistency, SHA-256, freshness,
+  signer allow-list, secret-redaction pre-check. `CostTracker`
+  carry-forward via `carry_forward_cost()` — rehydrating a session
+  cannot reset the token budget. New `SnapshotAwareTransport` mixin
+  for the seven sanctioned providers. 13 new tests.
+  Source: <https://openai.com/index/the-next-evolution-of-the-agents-sdk/>
+- **CVE-2026-33032 MCPwn preset**
+  (`policy_presets.mcpwn_cve_2026_33032_defaults`):
+  `mcpwn_cve_2026_33032_check()` + `UnauthenticatedDestructiveToolError`
+  refuse any destructive MCP tool (write / exec / kill verbs) that
+  is not wrapped in a trusted auth middleware. Fixture
+  `tests/cves/fixtures/cve_2026_33032_mcpwn.json` carries the 12
+  nginx-ui tool names from the Rapid7 write-up, each with a
+  primary-source line. 6 new tests.
+  Source: <https://nvd.nist.gov/vuln/detail/CVE-2026-33032>
+- **CVE-2025-59528 Flowise CustomMCP RCE preset**
+  (`policy_presets.flowise_cve_2025_59528_defaults`):
+  `flowise_cve_2025_59528_check()` + `FlowiseEvalTokenError` reject
+  any tool manifest whose `handler` or `config` string contains
+  `Function(`, `new Function`, `eval(`, `Deno.eval`, or
+  `vm.runInNewContext`. 8 new tests.
+  Source: <https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/>
+- **High-value action deny-by-default preset**
+  (`policy_presets.high_value_action_deny_by_default`):
+  regex-matches `(?i)(transfer|bridge|approve|withdraw|borrow|`
+  `liquidate|swap|mint|burn)` and refuses to run any matching tool
+  unless the caller passes `allow_high_value=True`. Raises
+  `HighValueActionBlocked`. 6 new tests. Docs at
+  [`docs/presets/high-value-actions.md`](docs/presets/high-value-actions.md).
+  Source: Kelp DAO / LayerZero $292M / Aave bad-debt incident,
+  <https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock>
+
+### Integrations
+
+- **Claude Opus 4.7 Auto Memory / Auto Dream guard**
+  (`agent_airlock.integrations.claude_auto_memory`):
+  `AutoMemoryAccessPolicy`, `guarded_read()`, `guarded_write()`,
+  `AutoMemoryCrossTenantError`, `AutoMemoryQuotaError` (both
+  `AirlockError` subclasses). Every call is tenant-scoped under
+  `/memory/{tenant_id}/`, quota-bounded (default 64 KiB per read),
+  redaction-enforced on write (reuses `sanitize_output`), and
+  observable via OTel spans `airlock.auto_memory.read` /
+  `airlock.auto_memory.write` carrying `tenant_id`, `bytes`,
+  `redacted_count`. 9 new tests.
+  Source: <https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7>
+
+### Docs
+
+- `docs/sandbox/docker.md` — explicit inventory of what
+  `DockerBackend` ships as of v0.5.1 (timeout, `no-new-privileges`,
+  `cap_drop=["ALL"]`, `security_opt`), plus a tracked "Known gaps"
+  list pointing at #37 (rootless) and #38 (digest pin). Issue #2
+  closed with a permalink comment.
+- `docs/presets/high-value-actions.md` — preset rationale, usage,
+  and known limitations. Cites the Kelp DAO / Aave incident.
+- README OWASP Agentic table updated: ASI02 (Tool Misuse) and ASI05
+  (RCE) now cite the Flowise eval-token preset; ASI03 (Identity)
+  cites the Vercel OAuth audit preset; ASI04 (Supply Chain) cites
+  the session-snapshot guard.
+
+### Performance
+
+- `@Airlock` strict-validation path: median **81.9 μs** (v0.5.1
+  baseline 75.2 μs). New primitives live outside the decorator hot
+  path; variance is within run-to-run noise on a laptop.
+
+### Dependencies
+
+- No new runtime deps. No new optional extras required for this
+  release.
+
+### Closes
+
+- #2 — Add Docker sandbox backend implementation (docs + follow-ups)
+
+### Primary sources (used verbatim in docstrings and this CHANGELOG)
+
+- Vercel bulletin (2026-04-19): <https://vercel.com/kb/bulletin/vercel-april-2026-security-incident>
+- OpenAI Agents SDK next evolution (2026-04-15): <https://openai.com/index/the-next-evolution-of-the-agents-sdk/>
+- NVD CVE-2026-33032 (MCPwn, 2026-04-15): <https://nvd.nist.gov/vuln/detail/CVE-2026-33032>
+- Rapid7 CVE-2026-33032 ETR (2026-04-15): <https://www.rapid7.com/blog/post/etr-cve-2026-33032-nginx-ui-missing-mcp-authentication/>
+- CSA Flowise research note (2026-04-09): <https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/>
+- Anthropic Claude 4.7 release notes (2026-04-17): <https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7>
+- Bloomberg Kelp DAO / Aave coverage (2026-04-19): <https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock>
+
+---
+
 ## [0.5.1] - 2026-04-19 — "Ox response"
 
 Same-day response to the [Ox Security MCP STDIO RCE advisory](https://www.ox.security/blog/mcp-supply-chain-advisory-rce-vulnerabilities-across-the-ai-ecosystem)

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ def execute_code(code: str) -> str:
 | Isolation | Firecracker MicroVM |
 | Fallback | `sandbox_required=True` blocks local execution |
 
+Air-gapped / on-prem? `DockerBackend` is the supported alternative
+— `cap_drop=["ALL"]`, `no-new-privileges`, `network_mode="none"`,
+timeout enforced, opt-in `pytest -m docker` integration tests. See
+[`docs/sandbox/docker.md`](docs/sandbox/docker.md).
+
 ---
 
 ### 📜 Security Policies
@@ -610,10 +615,10 @@ actually prevent the risk.
 | Risk | Implemented in agent-airlock | Module / preset | Coverage |
 |------|------------------------------|-----------------|----------|
 | **ASI01 Agent Goal Hijack** | Pydantic strict validation + ghost-arg rejection + `UnknownArgsMode.BLOCK` | `validator`, `unknown_args`, `core` | Partial |
-| **ASI02 Tool Misuse and Exploitation** | Deny-by-default `SecurityPolicy`, RBAC, rate limits, `SafePath` / `SafeURL` | `policy`, `safe_types`, `filesystem`, `network` | **Full** |
-| **ASI03 Identity and Privilege Abuse** | `AgentIdentity`, `MCPProxyGuard` token-passthrough prevention, `CredentialScope` | `policy`, `mcp_proxy_guard` | Partial |
-| **ASI04 Agentic Supply Chain Vulnerabilities** | Ox MCP STDIO sanitizer + CVE regression suite (8 CVEs tracked) | `mcp_spec.stdio_guard`, `policy_presets.stdio_guard_ox_defaults`, `tests/cves/` | Partial |
-| **ASI05 Unexpected Code Execution (RCE)** | E2B Firecracker sandbox, pluggable `SandboxBackend`, capability gating for `PROCESS_SHELL` | `sandbox`, `sandbox_backend`, `capabilities` | **Full** |
+| **ASI02 Tool Misuse and Exploitation** | Deny-by-default `SecurityPolicy`, RBAC, rate limits, `SafePath` / `SafeURL`, Flowise `Function()`/`eval` token ban ([CVE-2025-59528](https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/)), MCPwn destructive-auth check ([CVE-2026-33032](https://nvd.nist.gov/vuln/detail/CVE-2026-33032)) | `policy`, `safe_types`, `filesystem`, `network`, `policy_presets.flowise_cve_2025_59528_defaults`, `policy_presets.mcpwn_cve_2026_33032_defaults` | **Full** |
+| **ASI03 Identity and Privilege Abuse** | `AgentIdentity`, `MCPProxyGuard` token-passthrough prevention, `CredentialScope`, OAuth-app audit ([Vercel 2026-04-19](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident)) | `policy`, `mcp_proxy_guard`, `mcp_spec.oauth_audit`, `policy_presets.oauth_audit_vercel_2026_defaults` | Partial |
+| **ASI04 Agentic Supply Chain Vulnerabilities** | Ox MCP STDIO sanitizer + CVE regression suite (10+ CVEs tracked) + session-snapshot integrity guard | `mcp_spec.stdio_guard`, `mcp_spec.session_guard`, `policy_presets.stdio_guard_ox_defaults`, `tests/cves/` | Partial |
+| **ASI05 Unexpected Code Execution (RCE)** | E2B Firecracker sandbox, pluggable `SandboxBackend`, capability gating for `PROCESS_SHELL`, Flowise eval-token ban ([CVE-2025-59528](https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/)) | `sandbox`, `sandbox_backend`, `capabilities`, `policy_presets.flowise_cve_2025_59528_defaults` | **Full** |
 | **ASI06 Memory & Context Poisoning** | `AirlockContext` `contextvars` isolation, `ConversationConstraints` budget caps, audit logging | `context`, `conversation`, `sanitizer` | Partial |
 | **ASI07 Insecure Inter-Agent Communication** | A2A middleware Pydantic strict validation, method allow-lists | `a2a` | Partial |
 | **ASI08 Cascading Failures** | `CircuitBreaker`, `RetryPolicy`, token-bucket rate limits | `circuit_breaker`, `retry`, `policy` | **Full** |

--- a/docs/presets/high-value-actions.md
+++ b/docs/presets/high-value-actions.md
@@ -1,0 +1,67 @@
+# High-value action deny-by-default preset (v0.5.2+)
+
+`high_value_action_deny_by_default()` refuses any tool whose name
+matches the high-value verb pattern unless the caller passes
+`allow_high_value=True`.
+
+## Motivating incident
+
+On **2026-04-19**, the [Kelp DAO LayerZero bridge exploit](https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock)
+moved **$292M** of wrapped-ether across 20 chains. The attacker used
+stolen rsETH as collateral on Aave V3, leaving the protocol holding
+**~$200M in bad debt**. Root cause was a cross-chain-message forgery
+that reached an agent authorizing collateral moves. See also
+[The Defiant — Aave price crash / KelpDAO exploit coverage](https://thedefiant.io/news/defi/aave-price-crash-kelpdao-exploit-whale-dump-rxi8o9).
+
+Agent-airlock can't fix the bridge, but it can make it impossible for
+an agent to authorize a high-value tool call silently.
+
+## What the preset matches
+
+```
+(?i)(transfer|bridge|approve|withdraw|borrow|liquidate|swap|mint|burn)
+```
+
+Any tool whose name contains one of those verbs — `transfer_funds`,
+`bridge_rsETH`, `approve_spender`, `withdraw_collateral`,
+`borrow_against`, `liquidate_position`, `swap_usdc`, `mint_nft`,
+`burn_token` — is classified high-value.
+
+## Usage
+
+```python
+from agent_airlock import Airlock
+from agent_airlock.policy_presets import (
+    high_value_action_deny_by_default,
+    HighValueActionBlocked,
+)
+
+hv = high_value_action_deny_by_default()
+
+@Airlock()
+def transfer_funds(to: str, amount: int) -> str:
+    # Explicit opt-in — auditable at call site.
+    hv["check"]("transfer_funds", allow_high_value=True)
+    return do_transfer(to, amount)
+```
+
+Without `allow_high_value=True`, the `check` raises
+`HighValueActionBlocked` (a subclass of `AirlockError`).
+
+## What it does NOT do
+
+- It doesn't look at arguments — a tool named `read_balance` that
+  takes a `to_address` and a `value` isn't caught by name alone.
+  Combine with `SecurityPolicy.rate_limits` and `CapabilityPolicy`
+  for multi-layer defence.
+- It doesn't verify cross-chain messages. That's the bridge
+  protocol's job.
+- It doesn't replace human sign-off for genuinely high-stakes
+  actions. Pair with `MCPProxyGuard`'s consent hooks.
+
+## Tests
+
+See [`tests/test_policy_presets_high_value.py`](../../tests/test_policy_presets_high_value.py):
+- Banned-prefix tool is blocked.
+- Same tool passes when `allow_high_value=True`.
+- Non-matching tool is unaffected.

--- a/docs/sandbox/docker.md
+++ b/docs/sandbox/docker.md
@@ -1,0 +1,83 @@
+# DockerBackend (v0.5.1+)
+
+`DockerBackend` runs an agent-airlock-wrapped tool call inside an
+ephemeral Docker container. It is one of four pluggable
+[`SandboxBackend`](../api/sandbox.md) implementations (E2B, Docker,
+Local, Managed-stub).
+
+## What v0.5.1 actually ships
+
+- **Timeout enforced.** `DockerBackend.execute(..., timeout=60)`
+  calls `container.wait(timeout=...)` and kills+removes the
+  container on timeout. Prior to v0.5.1 the `timeout` kwarg was a
+  TODO, so a runaway function would hang forever. See
+  [CHANGELOG v0.5.1](../../CHANGELOG.md).
+- **`no-new-privileges` always on.** The container runs with
+  `security_opt=["no-new-privileges:true"]` so a child process
+  cannot regain privileges via `setuid`.
+- **All capabilities dropped by default.** `cap_drop=["ALL"]` —
+  no `NET_ADMIN`, `SYS_ADMIN`, nothing. Tools that legitimately
+  need a capability must be explicitly allow-listed via your own
+  wrapping backend.
+- **Pass-through `security_opt`.** Supply a seccomp profile via the
+  `security_opt=["seccomp=/path/to/profile.json"]` constructor
+  parameter. No default profile is shipped — Docker's own default
+  seccomp profile applies when you don't override.
+- **Network isolation default.** `network_mode="none"` unless you
+  explicitly opt out. If your tool needs the network, use agent-
+  airlock's `EndpointPolicy` at the app layer rather than opening
+  the sandbox.
+- **Integration tests.** Four tests behind the `pytest -m docker`
+  marker prove availability, success, timeout, and network
+  isolation. Default `pytest` runs **exclude** them, so CI does
+  not need a Docker daemon.
+
+## Usage
+
+```python
+from agent_airlock import Airlock, AirlockConfig
+from agent_airlock.sandbox_backend import DockerBackend
+
+backend = DockerBackend(
+    image="python:3.11-slim",
+    memory_limit="256m",
+    cpu_limit=0.5,
+    timeout=30,
+    security_opt=["seccomp=/etc/docker/airlock-seccomp.json"],
+)
+
+config = AirlockConfig(sandbox_backend=backend)
+
+@Airlock(config=config, sandbox=True, sandbox_required=True)
+def risky_thing(arg: str) -> str:
+    ...
+```
+
+## Known gaps (tracked)
+
+These are intentional scope cuts for v0.5.1 and are tracked as
+separate issues:
+
+- **No rootless-by-default.** `DockerBackend` assumes the Docker
+  daemon it talks to is either rootless or accepts root-in-
+  container workloads. Tracked in
+  [#37 — rootless-required mode](https://github.com/sattyamjjain/agent-airlock/issues/37).
+- **No user-namespace remap helper.** Users who want
+  `--userns=host-uid-remap` style isolation must configure Docker
+  themselves; we don't offer a one-liner.
+- **No image-digest-pin enforcement.** `DockerBackend(image=...)`
+  accepts tags (`python:3.11-slim`) or digests
+  (`python@sha256:…`) but does not refuse tag-only form. Tracked in
+  [#38 — image-digest-pin enforcement](https://github.com/sattyamjjain/agent-airlock/issues/38).
+
+## Relationship to E2B and Managed backends
+
+| Backend | Isolation | Latency | Cloud dependency | Default? |
+|---------|-----------|---------|------------------|----------|
+| [`E2BBackend`](../api/sandbox.md) | Firecracker MicroVM | <200 ms warm | E2B cloud | ✓ |
+| `DockerBackend` (this page) | Container, `cap_drop=ALL` | ~1-2 s cold, <200 ms warm if image cached | local Docker daemon | — |
+| `LocalBackend` | **None** | ~0 ms | none | dev only |
+| `ManagedSandboxBackend` | Anthropic Managed Agents (session-based) | varies | Anthropic API | preview |
+
+If you're running in air-gapped / on-prem environments where E2B
+is not an option, `DockerBackend` is the recommended choice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.5.1"
+version = "0.5.2"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -308,7 +308,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     # Core

--- a/src/agent_airlock/integrations/claude_auto_memory.py
+++ b/src/agent_airlock/integrations/claude_auto_memory.py
@@ -1,0 +1,237 @@
+"""Claude Opus 4.7 Auto Memory / Auto Dream read/write guard (v0.5.2+).
+
+Opus 4.7 GA (2026-04-16/17) introduced **Auto Memory** and **Auto Dream**
+— filesystem-backed persistent notes that survive across sessions. Two
+new risks:
+
+1. **Memory poisoning.** An earlier-session prompt injection that gets
+   consolidated into durable notes becomes a persistent compromise of
+   every subsequent session that reads the same tenant's memory.
+2. **Cross-tenant leakage.** A session running for tenant A pulling
+   tenant B's notes because the memory path is not scoped.
+
+This module wraps the read/write surface so every call is:
+
+- **Tenant-scoped** — the path must begin with ``/memory/{tenant_id}/``.
+- **Quota-bounded** — reads above ``max_read_bytes_per_call`` refused.
+- **Redacted on write** — secrets are stripped before persistence
+  using :func:`agent_airlock.sanitizer.sanitize_output` (the same
+  redaction surface the audit log uses).
+- **Observable** — every call emits an OpenTelemetry span
+  ``airlock.auto_memory.read`` or ``.write`` with ``tenant_id``,
+  ``bytes``, ``redacted_count`` attributes.
+
+Usage::
+
+    from agent_airlock.integrations.claude_auto_memory import (
+        AutoMemoryAccessPolicy, guarded_read, guarded_write,
+    )
+
+    policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+    guarded_read(policy, "/memory/acct-42/plan.md", raw_read_fn)
+    guarded_write(policy, "/memory/acct-42/plan.md", "...",
+                  raw_write_fn)
+
+References
+----------
+- Anthropic — What's new in Claude 4.7 (2026-04-17):
+  https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+- Auto Dream mechanics write-up:
+  https://claudefa.st/blog/guide/mechanics/auto-dream
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+
+from ..exceptions import AirlockError
+from ..sanitizer import sanitize_output
+
+logger = structlog.get_logger("agent-airlock.integrations.claude_auto_memory")
+
+
+@dataclass
+class AutoMemoryAccessPolicy:
+    """Per-tenant access policy for Claude Opus 4.7 Auto Memory.
+
+    Attributes:
+        tenant_id: The tenant this session belongs to. All reads and
+            writes must reference paths under ``/memory/{tenant_id}/``.
+        allowed_paths: Optional extra per-path allow-list WITHIN the
+            tenant scope. Empty means "any path under the tenant root".
+        max_read_bytes_per_call: Reject reads larger than this. Default
+            64 KiB — matches the canonical Auto Dream note size.
+        forbid_cross_tenant: If True (default), a path not under the
+            tenant root raises :class:`AutoMemoryCrossTenantError`.
+        redact_on_write: If True (default), every write passes through
+            the sanitizer redaction surface before persisting.
+    """
+
+    tenant_id: str
+    allowed_paths: list[str] = field(default_factory=list)
+    max_read_bytes_per_call: int = 64_000
+    forbid_cross_tenant: bool = True
+    redact_on_write: bool = True
+
+
+class AutoMemoryCrossTenantError(AirlockError):
+    """Raised when a session tries to read or write outside its tenant."""
+
+    def __init__(self, *, tenant_id: str, attempted_path: str) -> None:
+        self.tenant_id = tenant_id
+        self.attempted_path = attempted_path
+        super().__init__(
+            f"tenant {tenant_id!r} attempted to access {attempted_path!r} "
+            "(must begin with /memory/<tenant_id>/)"
+        )
+
+
+class AutoMemoryQuotaError(AirlockError):
+    """Raised when a read exceeds the per-call byte quota."""
+
+    def __init__(self, *, bytes_requested: int, limit: int) -> None:
+        self.bytes_requested = bytes_requested
+        self.limit = limit
+        super().__init__(
+            f"auto-memory read of {bytes_requested} bytes exceeds per-call limit {limit}"
+        )
+
+
+def _tenant_root(tenant_id: str) -> str:
+    return f"/memory/{tenant_id}/"
+
+
+def _check_scope(policy: AutoMemoryAccessPolicy, path: str) -> None:
+    if policy.forbid_cross_tenant and not path.startswith(_tenant_root(policy.tenant_id)):
+        raise AutoMemoryCrossTenantError(
+            tenant_id=policy.tenant_id,
+            attempted_path=path,
+        )
+    if policy.allowed_paths and path not in policy.allowed_paths:
+        # Allow-list is additive to scope; if set, path must appear verbatim.
+        raise AutoMemoryCrossTenantError(
+            tenant_id=policy.tenant_id,
+            attempted_path=path,
+        )
+
+
+def _get_tracer() -> Any:
+    """Return an OTel tracer if available, else a no-op stand-in."""
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer("agent_airlock.integrations.claude_auto_memory")
+    except ImportError:  # pragma: no cover — opentelemetry is an optional extra
+        return None
+
+
+def _emit_span(
+    name: str,
+    attributes: dict[str, Any],
+) -> None:
+    """Emit an OTel span carrying the audit attributes.
+
+    If ``opentelemetry`` is not installed (it's an optional dep in
+    agent-airlock) this falls back to a structlog line so the audit
+    information is still captured.
+    """
+    tracer = _get_tracer()
+    if tracer is not None:
+        with tracer.start_as_current_span(name) as span:  # pragma: no cover
+            for k, v in attributes.items():
+                span.set_attribute(k, v)
+        return
+    logger.info(name, **attributes)
+
+
+def guarded_read(
+    policy: AutoMemoryAccessPolicy,
+    path: str,
+    raw_read: Callable[[str], bytes],
+) -> bytes:
+    """Execute a tenant-scoped, quota-bounded Auto Memory read.
+
+    Args:
+        policy: The tenant's access policy.
+        path: Absolute memory path requested by the session.
+        raw_read: The underlying read callable (``path -> bytes``).
+
+    Returns:
+        The bytes read.
+
+    Raises:
+        AutoMemoryCrossTenantError: Path outside the tenant root.
+        AutoMemoryQuotaError: Read payload exceeds the quota.
+    """
+    _check_scope(policy, path)
+    data = raw_read(path)
+    if len(data) > policy.max_read_bytes_per_call:
+        raise AutoMemoryQuotaError(
+            bytes_requested=len(data),
+            limit=policy.max_read_bytes_per_call,
+        )
+    _emit_span(
+        "airlock.auto_memory.read",
+        {
+            "tenant_id": policy.tenant_id,
+            "bytes": len(data),
+            "path": path,
+            "redacted_count": 0,
+        },
+    )
+    return data
+
+
+def guarded_write(
+    policy: AutoMemoryAccessPolicy,
+    path: str,
+    content: str,
+    raw_write: Callable[[str, str], None],
+) -> int:
+    """Execute a tenant-scoped, redaction-enforced Auto Memory write.
+
+    Args:
+        policy: The tenant's access policy.
+        path: Absolute memory path to write.
+        content: The string payload. Redacted before persistence when
+            ``policy.redact_on_write`` is True (default).
+        raw_write: The underlying write callable (``(path, content) -> None``).
+
+    Returns:
+        The number of secrets redacted (``0`` when
+        ``redact_on_write=False`` or the payload was clean).
+
+    Raises:
+        AutoMemoryCrossTenantError: Path outside the tenant root.
+    """
+    _check_scope(policy, path)
+    redacted_count = 0
+    payload = content
+    if policy.redact_on_write:
+        result = sanitize_output(content)
+        payload = result.content
+        redacted_count = len(result.detections)
+    raw_write(path, payload)
+    _emit_span(
+        "airlock.auto_memory.write",
+        {
+            "tenant_id": policy.tenant_id,
+            "bytes": len(payload.encode("utf-8", errors="replace")),
+            "path": path,
+            "redacted_count": redacted_count,
+        },
+    )
+    return redacted_count
+
+
+__all__ = [
+    "AutoMemoryAccessPolicy",
+    "AutoMemoryCrossTenantError",
+    "AutoMemoryQuotaError",
+    "guarded_read",
+    "guarded_write",
+]

--- a/src/agent_airlock/mcp_proxy_guard.py
+++ b/src/agent_airlock/mcp_proxy_guard.py
@@ -25,11 +25,14 @@ from __future__ import annotations
 import secrets
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from .policy import StdioGuardConfig
+
+if TYPE_CHECKING:
+    from .mcp_spec.oauth_audit import OAuthAppAuditConfig, OAuthAuditReport
 
 logger = structlog.get_logger("agent-airlock.mcp_proxy_guard")
 
@@ -136,6 +139,12 @@ class MCPProxyConfig:
     # ``agent_airlock.policy.StdioGuardConfig`` and
     # ``agent_airlock.policy_presets.stdio_guard_ox_defaults``.
     stdio_guard: StdioGuardConfig | None = None
+
+    # V0.5.2 OAuth audit guard (Vercel/Context.ai 2026-04-19). When
+    # set, ``MCPProxyGuard.audit_oauth_exchange()`` delegates to
+    # ``agent_airlock.mcp_spec.oauth_audit.audit_oauth_exchange`` with
+    # this config. Default None preserves v0.5.1 behavior.
+    oauth_audit: OAuthAppAuditConfig | None = None
 
 
 @dataclass
@@ -589,6 +598,43 @@ class MCPProxyGuard:
         except Exception as e:
             logger.warning("token_decode_failed", error=str(e))
             return None
+
+    def audit_oauth_exchange(
+        self,
+        token_response: dict[str, Any],
+        client_id: str,
+    ) -> OAuthAuditReport:
+        """Audit an OAuth token exchange against the configured policy.
+
+        Call this immediately after a successful token exchange via
+        ``agent_airlock.mcp_spec.oauth`` and before caching the
+        token. Mitigates the 2026-04-19 Vercel / Context.ai
+        compromised-OAuth-app class by rejecting known-compromised
+        client IDs, oversize token lifetimes, missing PKCE evidence,
+        and refresh-token reuse.
+
+        Args:
+            token_response: The JSON body of the token endpoint
+                response.
+            client_id: The OAuth client_id that initiated the exchange.
+
+        Returns:
+            ``OAuthAuditReport`` on success.
+
+        Raises:
+            MCPSecurityError: If no ``oauth_audit`` is configured.
+            OAuthAppBlocked: The client_id is on the deny-list.
+            OAuthPolicyViolation: Token response violated the policy
+                (missing PKCE, stale refresh, oversize lifetime, etc.).
+        """
+        if self.config.oauth_audit is None:
+            raise MCPSecurityError(
+                "oauth_audit is not configured on this MCPProxyGuard",
+                violation_type="oauth_audit_not_configured",
+            )
+        from .mcp_spec.oauth_audit import audit_oauth_exchange
+
+        return audit_oauth_exchange(token_response, client_id, self.config.oauth_audit)
 
     def validate_stdio_spawn(self, cmd: list[str]) -> None:
         """Validate a STDIO-transport spawn against the configured guard.

--- a/src/agent_airlock/mcp_spec/oauth_audit.py
+++ b/src/agent_airlock/mcp_spec/oauth_audit.py
@@ -1,0 +1,268 @@
+"""OAuth app audit guard (v0.5.2+).
+
+Motivation
+----------
+On 2026-04-19 Vercel confirmed a breach that started with a compromised
+third-party Google Workspace OAuth app (Context.ai, client_id
+``110671459871-30f1spbu0hptbs60cb4vsmv79i7bbvqj.apps.googleusercontent.com``).
+ShinyHunters claimed exfiltration of 580 employee records, API keys,
+GitHub/NPM tokens, source code, and database access — all through a
+legitimate-looking OAuth consent. v0.5.1 already shipped PKCE S256 and
+audience-validation helpers. What was missing was a policy layer that
+asks, *before* caching a freshly-exchanged token:
+
+    "Is this OAuth app allowed to talk to us at all?"
+
+This module is that layer.
+
+Usage::
+
+    from agent_airlock.mcp_spec.oauth_audit import (
+        OAuthAppAuditConfig,
+        audit_oauth_exchange,
+    )
+    from agent_airlock.policy_presets import oauth_audit_vercel_2026_defaults
+
+    cfg = oauth_audit_vercel_2026_defaults()
+    report = audit_oauth_exchange(
+        token_response={"access_token": "...", "expires_in": 3600, ...},
+        client_id="my-app.apps.googleusercontent.com",
+        cfg=cfg,
+    )
+    # Raises OAuthAppBlocked / OAuthPolicyViolation on any rule failure.
+
+References
+----------
+- Vercel bulletin (2026-04-19):
+  https://vercel.com/kb/bulletin/vercel-april-2026-security-incident
+- CyberInsider coverage (2026-04-19):
+  https://cyberinsider.com/vercel-confirms-security-incident-as-hackers-claim-to-sell-internal-access/
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from ..exceptions import AirlockError
+
+logger = structlog.get_logger("agent-airlock.mcp_spec.oauth_audit")
+
+# Known-compromised OAuth client IDs (public, from vendor disclosures).
+# These are NOT secrets — they are the same IDs an attacker's phishing
+# page would present to trick a user into granting consent.
+KNOWN_COMPROMISED_CLIENT_IDS: frozenset[str] = frozenset(
+    {
+        # Context.ai — Vercel April 2026 breach vector.
+        "110671459871-30f1spbu0hptbs60cb4vsmv79i7bbvqj.apps.googleusercontent.com",
+    }
+)
+
+
+@dataclass
+class OAuthAppAuditConfig:
+    """Policy for auditing a fresh OAuth token exchange.
+
+    Attributes:
+        allowed_client_ids: If non-empty, the client_id MUST be in this
+            set. Empty means "no allow-list, fall through to
+            blocked_client_ids only."
+        blocked_client_ids: Explicit deny-list. Takes precedence over
+            the allow-list. Seed with
+            ``KNOWN_COMPROMISED_CLIENT_IDS`` at minimum.
+        max_token_age_seconds: Reject tokens whose ``expires_in``
+            declares a lifetime longer than this. Default 3600 (1h)
+            matches the Anthropic/Google defaults.
+        require_pkce: Require the token-response dict to carry evidence
+            of a PKCE exchange (either a ``code_challenge_method`` echo
+            or an explicit ``pkce_used=true`` attestation from the
+            auth server).
+        require_refresh_rotation: If a ``refresh_token`` is present,
+            require ``refresh_token_rotated=true`` in the response to
+            prevent refresh-token reuse.
+        deny_list_feed_path: Optional local JSON file path. When set,
+            :func:`load_deny_list` reads a list of client IDs from it
+            and merges them into ``blocked_client_ids``. No network
+            fetches by default — air-gap-safe.
+    """
+
+    allowed_client_ids: frozenset[str] = field(default_factory=frozenset)
+    blocked_client_ids: frozenset[str] = field(default_factory=lambda: KNOWN_COMPROMISED_CLIENT_IDS)
+    max_token_age_seconds: int = 3600
+    require_pkce: bool = True
+    require_refresh_rotation: bool = True
+    deny_list_feed_path: Path | None = None
+
+
+@dataclass
+class OAuthAuditReport:
+    """Outcome of a successful audit — all rules passed."""
+
+    client_id: str
+    token_lifetime_seconds: int
+    pkce_verified: bool
+    refresh_rotated: bool
+    audited_at: float
+
+
+class OAuthAppBlocked(AirlockError):
+    """Raised when ``client_id`` is on the deny-list."""
+
+    def __init__(self, *, client_id: str, reason: str) -> None:
+        self.client_id = client_id
+        self.reason = reason
+        super().__init__(f"OAuth app blocked: {client_id!r} — {reason}")
+
+
+class OAuthPolicyViolation(AirlockError):
+    """Raised when an OAuth exchange violates the audit policy
+    (missing PKCE, refresh-reuse, oversize lifetime)."""
+
+    def __init__(self, *, rule: str, detail: str) -> None:
+        self.rule = rule
+        self.detail = detail
+        super().__init__(f"OAuth policy violation [{rule}]: {detail}")
+
+
+def load_deny_list(path: Path) -> frozenset[str]:
+    """Load a JSON file of additional blocked client IDs.
+
+    The file must be a JSON array of strings. Unknown keys are ignored.
+    Returns an empty set if the file is missing (deliberate — a
+    deployment can ship without a feed and opt in later).
+    """
+    if not path.exists():
+        return frozenset()
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise OAuthPolicyViolation(
+            rule="deny_list_parse",
+            detail=f"could not parse {path}: {exc}",
+        ) from exc
+    if not isinstance(data, list) or not all(isinstance(s, str) for s in data):
+        raise OAuthPolicyViolation(
+            rule="deny_list_shape",
+            detail=f"{path} must be a JSON array of strings",
+        )
+    return frozenset(data)
+
+
+def audit_oauth_exchange(
+    token_response: dict[str, Any],
+    client_id: str,
+    cfg: OAuthAppAuditConfig,
+) -> OAuthAuditReport:
+    """Audit a fresh OAuth token exchange against the policy.
+
+    Args:
+        token_response: The JSON body of the token endpoint response.
+            Must contain ``expires_in`` (int, seconds). May contain
+            ``refresh_token``, ``refresh_token_rotated`` (bool),
+            ``code_challenge_method`` (echo), ``pkce_used`` (bool).
+        client_id: The OAuth client_id that initiated the exchange.
+        cfg: ``OAuthAppAuditConfig`` with deny/allow lists and rules.
+
+    Returns:
+        ``OAuthAuditReport`` when every rule passes.
+
+    Raises:
+        OAuthAppBlocked: The client_id is denied.
+        OAuthPolicyViolation: A rule failed (missing PKCE, stale
+            refresh, oversize lifetime, malformed response).
+    """
+    # 1. Build the effective deny-list (config deny + optional feed).
+    effective_deny = set(cfg.blocked_client_ids)
+    if cfg.deny_list_feed_path is not None:
+        effective_deny |= load_deny_list(cfg.deny_list_feed_path)
+    if client_id in effective_deny:
+        logger.warning(
+            "oauth_app_blocked",
+            client_id=client_id,
+            source="deny_list",
+        )
+        raise OAuthAppBlocked(
+            client_id=client_id,
+            reason="client_id is on the compromised-app deny-list",
+        )
+
+    # 2. Allow-list (only applied when non-empty).
+    if cfg.allowed_client_ids and client_id not in cfg.allowed_client_ids:
+        raise OAuthAppBlocked(
+            client_id=client_id,
+            reason="client_id is not on the audit allow-list",
+        )
+
+    # 3. Token shape.
+    if "expires_in" not in token_response:
+        raise OAuthPolicyViolation(
+            rule="token_shape",
+            detail="token_response is missing 'expires_in'",
+        )
+    expires_in = token_response["expires_in"]
+    if not isinstance(expires_in, int) or expires_in <= 0:
+        raise OAuthPolicyViolation(
+            rule="token_shape",
+            detail=f"expires_in must be a positive int, got {expires_in!r}",
+        )
+    if expires_in > cfg.max_token_age_seconds:
+        raise OAuthPolicyViolation(
+            rule="token_lifetime",
+            detail=(f"token lifetime {expires_in}s exceeds cap {cfg.max_token_age_seconds}s"),
+        )
+
+    # 4. PKCE evidence.
+    pkce_verified = bool(
+        token_response.get("pkce_used") or token_response.get("code_challenge_method") == "S256"
+    )
+    if cfg.require_pkce and not pkce_verified:
+        raise OAuthPolicyViolation(
+            rule="missing_pkce",
+            detail=(
+                "token_response did not attest PKCE usage "
+                "(need pkce_used=true or code_challenge_method='S256')"
+            ),
+        )
+
+    # 5. Refresh-token rotation.
+    has_refresh = "refresh_token" in token_response
+    rotated = bool(token_response.get("refresh_token_rotated"))
+    if cfg.require_refresh_rotation and has_refresh and not rotated:
+        raise OAuthPolicyViolation(
+            rule="refresh_reuse",
+            detail=(
+                "refresh_token present but refresh_token_rotated!=True "
+                "— reuse of a long-lived refresh token is forbidden"
+            ),
+        )
+
+    logger.debug(
+        "oauth_exchange_audited",
+        client_id=client_id,
+        lifetime=expires_in,
+        pkce=pkce_verified,
+        refresh_rotated=rotated,
+    )
+    return OAuthAuditReport(
+        client_id=client_id,
+        token_lifetime_seconds=expires_in,
+        pkce_verified=pkce_verified,
+        refresh_rotated=rotated,
+        audited_at=time.time(),
+    )
+
+
+__all__ = [
+    "KNOWN_COMPROMISED_CLIENT_IDS",
+    "OAuthAppAuditConfig",
+    "OAuthAppBlocked",
+    "OAuthAuditReport",
+    "OAuthPolicyViolation",
+    "audit_oauth_exchange",
+    "load_deny_list",
+]

--- a/src/agent_airlock/mcp_spec/session_guard.py
+++ b/src/agent_airlock/mcp_spec/session_guard.py
@@ -1,0 +1,289 @@
+"""Session-snapshot integrity guard (v0.5.2+).
+
+Motivation
+----------
+On 2026-04-15 OpenAI shipped the "next evolution" of the Agents SDK,
+introducing **session snapshots** that serialize agent state and allow
+rehydration into a fresh sandbox container. Seven managed providers
+are first-class: Blaxel, Cloudflare, Daytona, E2B, Modal, Runloop,
+Vercel. OpenAI's own framing separates the harness from the compute to
+keep credentials out of model-generated code paths.
+
+The implication for a runtime firewall is: **the snapshot is a new
+tamper surface.** A hostile or corrupted snapshot replayed into a
+container can smuggle tool calls, cached credentials, or prompt-
+injection payloads past first-hop validation. Worse, if your cost
+tracker resets on rehydration, the attacker gets a fresh token budget
+every time they replay.
+
+This module adds four checks that run before a snapshot is trusted:
+
+1. **SHA-256 integrity** — recompute and compare.
+2. **Freshness** — reject snapshots older than ``max_age_seconds``.
+3. **Size cap** — reject snapshots over ``max_bytes`` (DoS guard,
+   default 25 MiB).
+4. **Signer allow-list** — optional, refuses any ``signed_by`` not on
+   the approved list.
+5. **Secret redaction** — refuses snapshots whose serialized body
+   carries plaintext secrets (delegates to
+   :func:`agent_airlock.sanitizer.sanitize_output`).
+
+Usage::
+
+    from agent_airlock.mcp_spec.session_guard import (
+        SessionSnapshotRef, SnapshotGuardConfig, verify_snapshot,
+    )
+
+    cfg = SnapshotGuardConfig()
+    verify_snapshot(ref, raw_bytes, cfg)
+    # raises SnapshotIntegrityError on any failure.
+
+Cost-tracker carry-forward is handled separately — call
+:func:`carry_forward_cost` on your ``CostTracker`` when rehydrating.
+
+References
+----------
+- OpenAI Agents SDK next evolution (2026-04-15):
+  https://openai.com/index/the-next-evolution-of-the-agents-sdk/
+- Sandboxes guide (2026-04-15):
+  https://developers.openai.com/api/docs/guides/agents/sandboxes
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+
+from ..exceptions import AirlockError
+
+if TYPE_CHECKING:
+    from ..cost_tracking import CostTracker
+
+logger = structlog.get_logger("agent-airlock.mcp_spec.session_guard")
+
+SnapshotProvider = Literal[
+    "blaxel",
+    "cloudflare",
+    "daytona",
+    "e2b",
+    "modal",
+    "runloop",
+    "vercel",
+]
+
+_KNOWN_PROVIDERS: frozenset[str] = frozenset(
+    {"blaxel", "cloudflare", "daytona", "e2b", "modal", "runloop", "vercel"}
+)
+
+
+DEFAULT_MAX_BYTES = 25 * 1024 * 1024  # 25 MiB
+DEFAULT_MAX_AGE_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+@dataclass
+class SessionSnapshotRef:
+    """Metadata for a serialized session snapshot.
+
+    Attributes:
+        snapshot_id: Provider-assigned identifier.
+        provider: One of the seven OpenAI-sanctioned managed sandboxes.
+        digest_sha256: Expected SHA-256 hex digest of the raw payload.
+        signed_by: Optional signer identity (e.g. KMS key alias). None
+            means unsigned.
+        created_at: UTC timestamp of snapshot creation.
+        size_bytes: Expected size; compared against the raw payload.
+    """
+
+    snapshot_id: str
+    provider: SnapshotProvider
+    digest_sha256: str
+    signed_by: str | None
+    created_at: datetime
+    size_bytes: int
+
+
+@dataclass
+class SnapshotGuardConfig:
+    """Policy applied by :func:`verify_snapshot`."""
+
+    max_bytes: int = DEFAULT_MAX_BYTES
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS
+    require_signer_allowlist: frozenset[str] = field(default_factory=frozenset)
+    enforce_secret_redaction: bool = True
+
+
+class SnapshotIntegrityError(AirlockError):
+    """Raised when a snapshot fails any integrity check."""
+
+    def __init__(self, *, rule: str, detail: str) -> None:
+        self.rule = rule
+        self.detail = detail
+        super().__init__(f"snapshot integrity check failed [{rule}]: {detail}")
+
+
+def verify_snapshot(
+    ref: SessionSnapshotRef,
+    raw: bytes,
+    cfg: SnapshotGuardConfig,
+) -> None:
+    """Verify a serialized session snapshot before trusting it.
+
+    Args:
+        ref: Metadata supplied by the sandbox provider.
+        raw: The raw bytes of the snapshot payload.
+        cfg: Policy to apply.
+
+    Raises:
+        SnapshotIntegrityError: On any rule failure. The ``rule``
+            attribute identifies which check fired.
+    """
+    if ref.provider not in _KNOWN_PROVIDERS:
+        raise SnapshotIntegrityError(
+            rule="unknown_provider",
+            detail=(
+                f"provider {ref.provider!r} is not one of the seven "
+                f"sanctioned providers: {sorted(_KNOWN_PROVIDERS)}"
+            ),
+        )
+
+    # 1. Size cap (DoS guard).
+    if len(raw) > cfg.max_bytes:
+        raise SnapshotIntegrityError(
+            rule="oversize",
+            detail=(f"snapshot is {len(raw)} bytes, exceeds cap {cfg.max_bytes} bytes"),
+        )
+
+    # 2. Size metadata consistency — catches simple truncation attacks.
+    if ref.size_bytes != len(raw):
+        raise SnapshotIntegrityError(
+            rule="size_mismatch",
+            detail=(f"ref.size_bytes={ref.size_bytes} != len(raw)={len(raw)}"),
+        )
+
+    # 3. SHA-256 integrity.
+    actual_digest = hashlib.sha256(raw).hexdigest()
+    if actual_digest != ref.digest_sha256.lower():
+        raise SnapshotIntegrityError(
+            rule="digest_mismatch",
+            detail=(
+                f"recomputed SHA-256 {actual_digest} does not match "
+                f"ref.digest_sha256 {ref.digest_sha256!r}"
+            ),
+        )
+
+    # 4. Freshness.
+    now = datetime.now(tz=timezone.utc)
+    ref_created = ref.created_at
+    if ref_created.tzinfo is None:
+        ref_created = ref_created.replace(tzinfo=timezone.utc)
+    age = (now - ref_created).total_seconds()
+    if age > cfg.max_age_seconds:
+        raise SnapshotIntegrityError(
+            rule="stale",
+            detail=(f"snapshot age {age:.0f}s exceeds max {cfg.max_age_seconds}s"),
+        )
+
+    # 5. Signer allow-list (only if caller asked).
+    if cfg.require_signer_allowlist:
+        if ref.signed_by is None:
+            raise SnapshotIntegrityError(
+                rule="unsigned",
+                detail="signer allow-list is enforced but ref.signed_by is None",
+            )
+        if ref.signed_by not in cfg.require_signer_allowlist:
+            raise SnapshotIntegrityError(
+                rule="unknown_signer",
+                detail=(f"signer {ref.signed_by!r} is not in the allow-list"),
+            )
+
+    # 6. Secret redaction check on the decoded payload. Best-effort:
+    # we attempt to decode as UTF-8; if the snapshot is binary
+    # (cloudpickle, protobuf) we skip this check and rely on the
+    # upstream sandbox provider's own handling.
+    if cfg.enforce_secret_redaction:
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            text = None
+        if text is not None:
+            from ..sanitizer import sanitize_output
+
+            result = sanitize_output(text)
+            if result.detections:
+                raise SnapshotIntegrityError(
+                    rule="embedded_secret",
+                    detail=(
+                        f"snapshot payload contains "
+                        f"{len(result.detections)} sensitive token(s); "
+                        "refuse to rehydrate"
+                    ),
+                )
+
+    logger.debug(
+        "snapshot_verified",
+        snapshot_id=ref.snapshot_id,
+        provider=ref.provider,
+        bytes=len(raw),
+    )
+
+
+def carry_forward_cost(tracker: CostTracker, prior_total_tokens: int) -> None:
+    """Charge a rehydrated session's prior token usage forward.
+
+    Prevents a "reset-the-budget" attack where a hostile snapshot
+    is replayed to wipe the cost tracker. Creates a synthetic
+    ``CostRecord`` labelled ``"rehydrated_session"`` so the
+    ``CostTracker.get_summary()`` call after rehydration reflects the
+    real cumulative token spend.
+
+    Args:
+        tracker: The live ``CostTracker`` to augment.
+        prior_total_tokens: Token count captured before the snapshot.
+    """
+    if prior_total_tokens <= 0:
+        return
+    # Inject a bookkeeping record. Use the tracker's public track()
+    # context manager so thread-safety is preserved.
+    with tracker.track("rehydrated_session") as ctx:
+        ctx.set_tokens(input_tokens=prior_total_tokens, output_tokens=0)
+
+
+class SnapshotAwareTransport:
+    """Mixin for sandbox transports that support snapshot rehydration.
+
+    Drop this into any of the seven supported sandbox backends (Blaxel,
+    Cloudflare, Daytona, E2B, Modal, Runloop, Vercel). The mixin adds
+    a single method :meth:`rehydrate_with_guard` that verifies the
+    snapshot and carries forward cost before handing control back to
+    the concrete transport's own rehydration path.
+    """
+
+    def rehydrate_with_guard(
+        self,
+        ref: SessionSnapshotRef,
+        raw: bytes,
+        cfg: SnapshotGuardConfig,
+        tracker: CostTracker | None = None,
+        prior_total_tokens: int = 0,
+    ) -> None:
+        """Verify + rehydrate; concrete transport overrides the actual load."""
+        verify_snapshot(ref, raw, cfg)
+        if tracker is not None:
+            carry_forward_cost(tracker, prior_total_tokens)
+
+
+__all__ = [
+    "DEFAULT_MAX_AGE_SECONDS",
+    "DEFAULT_MAX_BYTES",
+    "SessionSnapshotRef",
+    "SnapshotAwareTransport",
+    "SnapshotGuardConfig",
+    "SnapshotIntegrityError",
+    "SnapshotProvider",
+    "carry_forward_cost",
+    "verify_snapshot",
+]

--- a/src/agent_airlock/policy_presets.py
+++ b/src/agent_airlock/policy_presets.py
@@ -56,8 +56,9 @@ Primary sources (retrieved 2026-04-18):
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from .exceptions import AirlockError
 from .policy import SecurityPolicy, StdioGuardConfig
 
 if TYPE_CHECKING:
@@ -566,35 +567,8 @@ _TRUSTED_AUTH_MIDDLEWARES: frozenset[str] = frozenset(
 )
 
 
-class UnauthenticatedDestructiveToolError(Exception):  # noqa: N818 — intentional name
-    """Raised when a destructive MCP tool lacks authenticating middleware.
-
-    Subclass of :class:`agent_airlock.exceptions.AirlockError` — see the
-    actual class body below (we can't forward-reference the base without
-    a circular import at module import time).
-    """
-
-
-def _load_airlock_error_base() -> None:
-    """Re-home ``UnauthenticatedDestructiveToolError`` onto ``AirlockError``.
-
-    We keep the class definition above simple (no import chain at top of
-    module) and then fix up the base class at module load time. This
-    keeps ``policy_presets`` free of an ``agent_airlock.exceptions``
-    dependency at import order while still giving callers the unified
-    ``AirlockError`` catch surface.
-    """
-    from .exceptions import AirlockError
-
-    global UnauthenticatedDestructiveToolError
-    UnauthenticatedDestructiveToolError = type(  # type: ignore[misc]
-        "UnauthenticatedDestructiveToolError",
-        (AirlockError,),
-        dict(UnauthenticatedDestructiveToolError.__dict__),
-    )
-
-
-_load_airlock_error_base()
+class UnauthenticatedDestructiveToolError(AirlockError):
+    """Raised when a destructive MCP tool lacks authenticating middleware."""
 
 
 def is_destructive_tool(tool_name: str) -> bool:
@@ -607,7 +581,7 @@ def is_destructive_tool(tool_name: str) -> bool:
 
 
 def mcpwn_cve_2026_33032_check(
-    tools: list[dict],
+    tools: list[dict[str, Any]],
 ) -> None:
     """Assert every destructive tool is wrapped in real auth middleware.
 
@@ -639,7 +613,7 @@ def mcpwn_cve_2026_33032_check(
             )
 
 
-def mcpwn_cve_2026_33032_defaults() -> dict:
+def mcpwn_cve_2026_33032_defaults() -> dict[str, Any]:
     """Preset-style factory returning the MCPwn audit config.
 
     Because this preset's output is the checker function itself rather
@@ -682,28 +656,11 @@ _EVAL_TOKENS: tuple[str, ...] = (
 )
 
 
-class FlowiseEvalTokenError(Exception):  # noqa: N818 — intentional name
-    """Raised when a tool manifest embeds a JS dynamic-eval token.
-
-    Re-homed onto ``AirlockError`` at module load (see
-    ``_load_airlock_error_base``)."""
+class FlowiseEvalTokenError(AirlockError):
+    """Raised when a tool manifest embeds a JS dynamic-eval token."""
 
 
-def _load_flowise_base() -> None:
-    from .exceptions import AirlockError
-
-    global FlowiseEvalTokenError
-    FlowiseEvalTokenError = type(  # type: ignore[misc]
-        "FlowiseEvalTokenError",
-        (AirlockError,),
-        dict(FlowiseEvalTokenError.__dict__),
-    )
-
-
-_load_flowise_base()
-
-
-def flowise_cve_2025_59528_check(tools: list[dict]) -> None:
+def flowise_cve_2025_59528_check(tools: list[dict[str, Any]]) -> None:
     """Reject any tool whose handler or config embeds a JS eval token.
 
     The Flowise CustomMCP RCE (CVE-2025-59528, CVSS 10.0) passed user-
@@ -737,7 +694,7 @@ def flowise_cve_2025_59528_check(tools: list[dict]) -> None:
                     )
 
 
-def high_value_action_deny_by_default() -> dict:
+def high_value_action_deny_by_default() -> dict[str, Any]:
     """Deny-by-default preset for financial / on-chain / high-value tools.
 
     Motivation: the 2026-04-19 Kelp DAO LayerZero bridge exploit ($292M
@@ -790,27 +747,11 @@ def high_value_action_deny_by_default() -> dict:
     }
 
 
-class HighValueActionBlocked(Exception):  # noqa: N818 — intentional name
-    """Raised when a high-value action runs without explicit opt-in.
-
-    Re-homed onto ``AirlockError`` at module load."""
+class HighValueActionBlocked(AirlockError):
+    """Raised when a high-value action runs without explicit opt-in."""
 
 
-def _load_hv_base() -> None:
-    from .exceptions import AirlockError
-
-    global HighValueActionBlocked
-    HighValueActionBlocked = type(  # type: ignore[misc]
-        "HighValueActionBlocked",
-        (AirlockError,),
-        dict(HighValueActionBlocked.__dict__),
-    )
-
-
-_load_hv_base()
-
-
-def flowise_cve_2025_59528_defaults() -> dict:
+def flowise_cve_2025_59528_defaults() -> dict[str, Any]:
     """Preset-style factory returning the Flowise-eval checker.
 
     Usage::

--- a/src/agent_airlock/policy_presets.py
+++ b/src/agent_airlock/policy_presets.py
@@ -62,6 +62,7 @@ from .policy import SecurityPolicy, StdioGuardConfig
 
 if TYPE_CHECKING:
     from .capabilities import CapabilityPolicy
+    from .mcp_spec.oauth_audit import OAuthAppAuditConfig
 
 
 def _capabilities(granted: int | None = None, denied: int | None = None) -> CapabilityPolicy | None:
@@ -503,6 +504,334 @@ STDIO_GUARD_OX_DEFAULTS = stdio_guard_ox_defaults()
 constant unless you need dynamic overrides (then call the factory)."""
 
 
+def oauth_audit_vercel_2026_defaults() -> OAuthAppAuditConfig:
+    """OAuth app audit defaults driven by the 2026-04-19 Vercel breach.
+
+    Vercel confirmed a compromise that started with a third-party
+    Google Workspace OAuth app (Context.ai). The attacker used the
+    app's legitimate consent flow to exfiltrate an employee's tokens
+    and, from there, 580 employee records + API keys + source code.
+    This preset seeds the deny-list with the Context.ai client_id
+    disclosed in the Vercel bulletin and enforces PKCE + refresh-
+    rotation + a 1-hour token-lifetime cap.
+
+    Pair with ``MCPProxyGuard`` so any OAuth exchange run through
+    ``agent_airlock.mcp_spec.oauth`` is audited before the token is
+    cached.
+
+    Primary source:
+      https://vercel.com/kb/bulletin/vercel-april-2026-security-incident
+    """
+    from .mcp_spec.oauth_audit import KNOWN_COMPROMISED_CLIENT_IDS, OAuthAppAuditConfig
+
+    return OAuthAppAuditConfig(
+        blocked_client_ids=KNOWN_COMPROMISED_CLIENT_IDS,
+        max_token_age_seconds=3600,
+        require_pkce=True,
+        require_refresh_rotation=True,
+    )
+
+
+OAUTH_AUDIT_VERCEL_2026_DEFAULTS = oauth_audit_vercel_2026_defaults()
+"""Eagerly-constructed OAuth-audit defaults (post Vercel 2026-04-19)."""
+
+
+# -----------------------------------------------------------------------------
+# CVE-2026-33032 "MCPwn" — destructive-tool auth-middleware regression preset
+# -----------------------------------------------------------------------------
+
+# Matches write / exec / kill / destructive verbs. Expanded from the
+# 12 nginx-ui tool names cataloged in the Rapid7 write-up.
+_DESTRUCTIVE_TOOL_PATTERN = re.compile(
+    r"(?i)^(?:"
+    r"delete|destroy|drop|erase|purge|"
+    r"install|uninstall|upload|overwrite|"
+    r"reload|restart|stop|start|kill|"
+    r"configure|enable|disable|patch|"
+    r"run_shell|exec|execute|shell|"
+    r"backup_restore|rollback|factory_reset"
+    r").*$"
+)
+
+# Middleware identifiers we DO accept as enforcing real authentication.
+# "ip_allowlist" alone is NOT accepted — nginx-ui's default was 0.0.0.0/0.
+_TRUSTED_AUTH_MIDDLEWARES: frozenset[str] = frozenset(
+    {
+        "AuthRequired",
+        "SessionRequired",
+        "BearerRequired",
+        "OIDCRequired",
+        "OAuthRequired",
+    }
+)
+
+
+class UnauthenticatedDestructiveToolError(Exception):  # noqa: N818 — intentional name
+    """Raised when a destructive MCP tool lacks authenticating middleware.
+
+    Subclass of :class:`agent_airlock.exceptions.AirlockError` — see the
+    actual class body below (we can't forward-reference the base without
+    a circular import at module import time).
+    """
+
+
+def _load_airlock_error_base() -> None:
+    """Re-home ``UnauthenticatedDestructiveToolError`` onto ``AirlockError``.
+
+    We keep the class definition above simple (no import chain at top of
+    module) and then fix up the base class at module load time. This
+    keeps ``policy_presets`` free of an ``agent_airlock.exceptions``
+    dependency at import order while still giving callers the unified
+    ``AirlockError`` catch surface.
+    """
+    from .exceptions import AirlockError
+
+    global UnauthenticatedDestructiveToolError
+    UnauthenticatedDestructiveToolError = type(  # type: ignore[misc]
+        "UnauthenticatedDestructiveToolError",
+        (AirlockError,),
+        dict(UnauthenticatedDestructiveToolError.__dict__),
+    )
+
+
+_load_airlock_error_base()
+
+
+def is_destructive_tool(tool_name: str) -> bool:
+    """Return True iff ``tool_name`` matches the destructive-verb pattern.
+
+    Public so users can pre-classify their own tool catalogs before
+    handing them to :func:`mcpwn_cve_2026_33032_check`.
+    """
+    return bool(_DESTRUCTIVE_TOOL_PATTERN.match(tool_name or ""))
+
+
+def mcpwn_cve_2026_33032_check(
+    tools: list[dict],
+) -> None:
+    """Assert every destructive tool is wrapped in real auth middleware.
+
+    Args:
+        tools: A list of tool manifests. Each entry must carry:
+            - ``name`` (str): the MCP tool name.
+            - ``middlewares`` (list[str]): the middleware names applied
+              to the tool's HTTP endpoint, in order.
+
+    Raises:
+        UnauthenticatedDestructiveToolError: When a destructive tool
+            name (see :func:`is_destructive_tool`) is present but no
+            middleware in :data:`_TRUSTED_AUTH_MIDDLEWARES` is applied
+            to it. Raised as soon as the first offender is found — the
+            error details identify it.
+    """
+    for tool in tools:
+        name = tool.get("name", "")
+        if not is_destructive_tool(name):
+            continue
+        middlewares = tool.get("middlewares") or []
+        has_auth = any(m in _TRUSTED_AUTH_MIDDLEWARES for m in middlewares)
+        if not has_auth:
+            raise UnauthenticatedDestructiveToolError(
+                f"destructive MCP tool {name!r} exposes no "
+                f"authenticating middleware (saw {middlewares!r}). "
+                "Regression class: CVE-2026-33032 (nginx-ui MCPwn). "
+                "See https://nvd.nist.gov/vuln/detail/CVE-2026-33032"
+            )
+
+
+def mcpwn_cve_2026_33032_defaults() -> dict:
+    """Preset-style factory returning the MCPwn audit config.
+
+    Because this preset's output is the checker function itself rather
+    than a ``SecurityPolicy``, the return value is a small mapping that
+    a caller uses like::
+
+        from agent_airlock.policy_presets import mcpwn_cve_2026_33032_defaults
+
+        cfg = mcpwn_cve_2026_33032_defaults()
+        cfg["check"](my_tool_manifests)
+
+    Primary source: https://nvd.nist.gov/vuln/detail/CVE-2026-33032
+    """
+    return {
+        "check": mcpwn_cve_2026_33032_check,
+        "is_destructive": is_destructive_tool,
+        "trusted_middlewares": _TRUSTED_AUTH_MIDDLEWARES,
+        "source": (
+            "https://nvd.nist.gov/vuln/detail/CVE-2026-33032, "
+            "https://www.rapid7.com/blog/post/etr-cve-2026-33032-nginx-ui-missing-mcp-authentication/"
+        ),
+    }
+
+
+# -----------------------------------------------------------------------------
+# CVE-2025-59528 Flowise CustomMCP RCE — eval/Function() tool-manifest ban
+# -----------------------------------------------------------------------------
+
+# Tokens whose presence inside a tool manifest's ``handler`` or
+# ``config`` string means user input reaches JS dynamic-evaluation.
+# Primary sources:
+#   https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/
+#   https://advisories.gitlab.com/npm/flowise/CVE-2025-59528/
+_EVAL_TOKENS: tuple[str, ...] = (
+    "Function(",
+    "new Function",
+    "eval(",
+    "Deno.eval",
+    "vm.runInNewContext",
+)
+
+
+class FlowiseEvalTokenError(Exception):  # noqa: N818 — intentional name
+    """Raised when a tool manifest embeds a JS dynamic-eval token.
+
+    Re-homed onto ``AirlockError`` at module load (see
+    ``_load_airlock_error_base``)."""
+
+
+def _load_flowise_base() -> None:
+    from .exceptions import AirlockError
+
+    global FlowiseEvalTokenError
+    FlowiseEvalTokenError = type(  # type: ignore[misc]
+        "FlowiseEvalTokenError",
+        (AirlockError,),
+        dict(FlowiseEvalTokenError.__dict__),
+    )
+
+
+_load_flowise_base()
+
+
+def flowise_cve_2025_59528_check(tools: list[dict]) -> None:
+    """Reject any tool whose handler or config embeds a JS eval token.
+
+    The Flowise CustomMCP RCE (CVE-2025-59528, CVSS 10.0) passed user-
+    supplied strings from ``/api/v1/node-load-method/customMCP`` into
+    the JavaScript ``Function()`` constructor. CSA documented active
+    exploitation in April 2026 despite a September 2025 patch. This
+    check makes the class non-transportable: if a manifest carries
+    any of the banned tokens, refuse to register the tool.
+
+    Args:
+        tools: Tool manifests. Each entry may carry ``handler`` and/or
+            ``config`` string fields.
+
+    Raises:
+        FlowiseEvalTokenError: First offender wins; error message names
+            the tool and the banned token.
+    """
+    for tool in tools:
+        for field_name in ("handler", "config"):
+            value = tool.get(field_name)
+            if not isinstance(value, str):
+                continue
+            for token in _EVAL_TOKENS:
+                if token in value:
+                    raise FlowiseEvalTokenError(
+                        f"tool {tool.get('name', '<unnamed>')!r} "
+                        f"field {field_name!r} contains banned JS "
+                        f"eval token {token!r}. Regression class: "
+                        "CVE-2025-59528 (Flowise CustomMCP RCE). "
+                        "See https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/"
+                    )
+
+
+def high_value_action_deny_by_default() -> dict:
+    """Deny-by-default preset for financial / on-chain / high-value tools.
+
+    Motivation: the 2026-04-19 Kelp DAO LayerZero bridge exploit ($292M
+    stolen, ~$200M Aave bad debt) started with a cross-chain message
+    forgery that reached an agent authorizing a collateral move. Any
+    tool whose name implies money movement should require explicit
+    opt-in.
+
+    This preset tags a tool as "high-value" when its name matches
+    ``(?i)(transfer|bridge|approve|withdraw|borrow|liquidate|swap|mint|burn)``
+    and refuses to run it unless the ``@airlock`` caller passes
+    ``allow_high_value=True``.
+
+    Usage::
+
+        from agent_airlock.policy_presets import (
+            high_value_action_deny_by_default,
+            HighValueActionBlocked,
+        )
+
+        cfg = high_value_action_deny_by_default()
+        cfg["check"]("transfer", allow_high_value=False)   # raises
+        cfg["check"]("transfer", allow_high_value=True)    # passes
+        cfg["check"]("read_balance", allow_high_value=False)  # passes
+
+    Primary sources:
+      - https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock
+      - https://thedefiant.io/news/defi/aave-price-crash-kelpdao-exploit-whale-dump-rxi8o9
+    """
+    pattern = re.compile(r"(?i)(transfer|bridge|approve|withdraw|borrow|liquidate|swap|mint|burn)")
+
+    def is_high_value(tool_name: str) -> bool:
+        return bool(pattern.search(tool_name or ""))
+
+    def check(tool_name: str, allow_high_value: bool = False) -> None:
+        if is_high_value(tool_name) and not allow_high_value:
+            raise HighValueActionBlocked(
+                f"tool {tool_name!r} matches the high-value pattern "
+                f"({pattern.pattern!r}) and requires allow_high_value=True. "
+                "Motivating incident: Kelp DAO LayerZero exploit 2026-04-19."
+            )
+
+    return {
+        "check": check,
+        "is_high_value": is_high_value,
+        "pattern": pattern.pattern,
+        "source": (
+            "https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock"
+        ),
+    }
+
+
+class HighValueActionBlocked(Exception):  # noqa: N818 — intentional name
+    """Raised when a high-value action runs without explicit opt-in.
+
+    Re-homed onto ``AirlockError`` at module load."""
+
+
+def _load_hv_base() -> None:
+    from .exceptions import AirlockError
+
+    global HighValueActionBlocked
+    HighValueActionBlocked = type(  # type: ignore[misc]
+        "HighValueActionBlocked",
+        (AirlockError,),
+        dict(HighValueActionBlocked.__dict__),
+    )
+
+
+_load_hv_base()
+
+
+def flowise_cve_2025_59528_defaults() -> dict:
+    """Preset-style factory returning the Flowise-eval checker.
+
+    Usage::
+
+        from agent_airlock.policy_presets import flowise_cve_2025_59528_defaults
+
+        cfg = flowise_cve_2025_59528_defaults()
+        cfg["check"](my_tool_manifests)
+
+    Primary source:
+      https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/
+    """
+    return {
+        "check": flowise_cve_2025_59528_check,
+        "banned_tokens": _EVAL_TOKENS,
+        "source": (
+            "https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/"
+        ),
+    }
+
+
 GTG_1002_DEFENSE = gtg_1002_defense_policy()
 MEX_GOV_2026 = mex_gov_2026_policy()
 OWASP_MCP_TOP_10_2026 = owasp_mcp_top_10_2026_policy()
@@ -518,6 +847,16 @@ __all__ = [
     "eu_ai_act_article_15_policy",
     "india_dpdp_2023_policy",
     "stdio_guard_ox_defaults",
+    "oauth_audit_vercel_2026_defaults",
+    "mcpwn_cve_2026_33032_defaults",
+    "mcpwn_cve_2026_33032_check",
+    "is_destructive_tool",
+    "UnauthenticatedDestructiveToolError",
+    "flowise_cve_2025_59528_defaults",
+    "flowise_cve_2025_59528_check",
+    "FlowiseEvalTokenError",
+    "high_value_action_deny_by_default",
+    "HighValueActionBlocked",
     # Eagerly constructed defaults
     "GTG_1002_DEFENSE",
     "MEX_GOV_2026",
@@ -525,4 +864,5 @@ __all__ = [
     "EU_AI_ACT_ARTICLE_15",
     "INDIA_DPDP_2023",
     "STDIO_GUARD_OX_DEFAULTS",
+    "OAUTH_AUDIT_VERCEL_2026_DEFAULTS",
 ]

--- a/tests/cves/fixtures/cve_2026_33032_mcpwn.json
+++ b/tests/cves/fixtures/cve_2026_33032_mcpwn.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "documented destructive MCP tool names from CVE-2026-33032 (nginx-ui MCPwn). Missing AuthRequired() middleware on /mcp_message meant all 12 were invokable with zero credentials. CVSS 9.8, actively exploited April 2026.",
+  "references": {
+    "nvd": "https://nvd.nist.gov/vuln/detail/CVE-2026-33032",
+    "rapid7": "https://www.rapid7.com/blog/post/etr-cve-2026-33032-nginx-ui-missing-mcp-authentication/",
+    "fixed_version": "nginx-ui 2.3.4"
+  },
+  "affected_product": "0xJacky/nginx-ui <= 2.3.3",
+  "destructive_tools": [
+    {"name": "reload_nginx", "source": "Rapid7 analysis §tool inventory"},
+    {"name": "restart_nginx", "source": "Rapid7 analysis §tool inventory"},
+    {"name": "stop_nginx", "source": "Rapid7 analysis §tool inventory"},
+    {"name": "start_nginx", "source": "Rapid7 analysis §tool inventory"},
+    {"name": "configure_site", "source": "Rapid7 analysis §config-write tools"},
+    {"name": "delete_site", "source": "Rapid7 analysis §config-write tools"},
+    {"name": "enable_site", "source": "Rapid7 analysis §config-write tools"},
+    {"name": "disable_site", "source": "Rapid7 analysis §config-write tools"},
+    {"name": "upload_certificate", "source": "Rapid7 analysis §cert management"},
+    {"name": "install_package", "source": "Rapid7 analysis §host mutation"},
+    {"name": "run_shell_command", "source": "Rapid7 analysis §RCE primitive"},
+    {"name": "backup_restore", "source": "Rapid7 analysis §data tools"}
+  ]
+}

--- a/tests/cves/test_cve_2025_59528_flowise.py
+++ b/tests/cves/test_cve_2025_59528_flowise.py
@@ -1,0 +1,80 @@
+"""CVE-2025-59528 — Flowise CustomMCP RCE via JS ``Function()`` constructor.
+
+Flowise's ``/api/v1/node-load-method/customMCP`` passed user-supplied
+strings directly into JavaScript ``Function()`` and ``eval``. CVSS 10.0.
+Patched in v3.0.6 (Sept 2025) but CSA documented active exploitation
+in April 2026 — ~12-15K instances still exposed.
+
+This regression codifies the offending token set (``Function(``,
+``new Function``, ``eval(``, ``Deno.eval``, ``vm.runInNewContext``) so
+the same class cannot land in any tool we register.
+
+Primary sources
+---------------
+- CSA research note (2026-04-09):
+  https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/
+- GitLab advisory:
+  https://advisories.gitlab.com/npm/flowise/CVE-2025-59528/
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_airlock.exceptions import AirlockError
+from agent_airlock.policy_presets import (
+    FlowiseEvalTokenError,
+    flowise_cve_2025_59528_check,
+    flowise_cve_2025_59528_defaults,
+)
+
+
+class TestFlowiseEvalTokenBan:
+    def test_01_clean_manifest_passes(self) -> None:
+        """A tool whose handler is a simple function name is fine."""
+        flowise_cve_2025_59528_check([{"name": "read_file", "handler": "readFile", "config": "{}"}])
+
+    def test_02_function_constructor_banned(self) -> None:
+        with pytest.raises(FlowiseEvalTokenError) as exc:
+            flowise_cve_2025_59528_check(
+                [{"name": "evil", "handler": "const f = new Function('x','return x')"}]
+            )
+        # "new Function" triggers first since it appears earlier in the token tuple.
+        assert "Function" in str(exc.value)
+
+    def test_03_eval_banned(self) -> None:
+        with pytest.raises(FlowiseEvalTokenError):
+            flowise_cve_2025_59528_check([{"name": "evil", "config": "return eval(userInput)"}])
+
+    def test_04_deno_eval_banned(self) -> None:
+        with pytest.raises(FlowiseEvalTokenError):
+            flowise_cve_2025_59528_check([{"name": "evil", "handler": "await Deno.eval(payload)"}])
+
+    def test_05_vm_runInNewContext_banned(self) -> None:
+        with pytest.raises(FlowiseEvalTokenError):
+            flowise_cve_2025_59528_check(
+                [
+                    {
+                        "name": "evil",
+                        "handler": "vm.runInNewContext(expr, ctx)",
+                    }
+                ]
+            )
+
+
+class TestDefaultsBundle:
+    def test_banned_tokens_advertised(self) -> None:
+        cfg = flowise_cve_2025_59528_defaults()
+        banned = cfg["banned_tokens"]
+        for tok in ("Function(", "new Function", "eval(", "Deno.eval", "vm.runInNewContext"):
+            assert tok in banned, f"{tok!r} missing from banned_tokens"
+
+    def test_source_cites_csa(self) -> None:
+        cfg = flowise_cve_2025_59528_defaults()
+        assert "cloudsecurityalliance" in cfg["source"]
+
+
+class TestErrorBaseClass:
+    def test_is_airlock_error(self) -> None:
+        with pytest.raises(AirlockError):
+            flowise_cve_2025_59528_check([{"name": "evil", "handler": "eval(x)"}])

--- a/tests/cves/test_cve_2026_33032_mcpwn.py
+++ b/tests/cves/test_cve_2026_33032_mcpwn.py
@@ -1,0 +1,89 @@
+"""CVE-2026-33032 "MCPwn" — nginx-ui missing /mcp_message auth middleware.
+
+Vulnerability: ``/mcp_message`` missed the ``AuthRequired()`` middleware,
+letting unauthenticated clients invoke 12 destructive MCP tools.
+CVSS 9.8, ~2,689 exposed instances, actively exploited in April 2026.
+
+agent-airlock doesn't ship nginx-ui, but we're the canonical place for
+the "would my MCPProxyGuard have caught a missing-auth on a destructive
+tool?" question. This module proves the preset fires on the exact
+nginx-ui tool inventory and on an IP-allowlist-only bypass attempt.
+
+Primary sources
+---------------
+- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-33032
+- Rapid7 ETR (2026-04-15):
+  https://www.rapid7.com/blog/post/etr-cve-2026-33032-nginx-ui-missing-mcp-authentication/
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_airlock.exceptions import AirlockError
+from agent_airlock.policy_presets import (
+    UnauthenticatedDestructiveToolError,
+    is_destructive_tool,
+    mcpwn_cve_2026_33032_check,
+    mcpwn_cve_2026_33032_defaults,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "cve_2026_33032_mcpwn.json"
+
+
+class TestMCPwnPreset:
+    def test_01_clean_config_passes(self) -> None:
+        """A destructive tool behind AuthRequired middleware is fine."""
+        mcpwn_cve_2026_33032_check(
+            [
+                {"name": "reload_nginx", "middlewares": ["AuthRequired"]},
+                {"name": "list_sites", "middlewares": []},  # non-destructive
+            ]
+        )
+
+    def test_02_missing_auth_middleware_raises(self) -> None:
+        """The MCPwn-class vuln — no middleware at all on a destructive tool."""
+        with pytest.raises(UnauthenticatedDestructiveToolError) as exc:
+            mcpwn_cve_2026_33032_check([{"name": "reload_nginx", "middlewares": []}])
+        assert "reload_nginx" in str(exc.value)
+        assert "CVE-2026-33032" in str(exc.value)
+
+    def test_03_ip_allowlist_only_is_rejected(self) -> None:
+        """nginx-ui's "IP allowlist" defaulted to 0.0.0.0/0 — not real auth."""
+        with pytest.raises(UnauthenticatedDestructiveToolError):
+            mcpwn_cve_2026_33032_check(
+                [
+                    {
+                        "name": "run_shell_command",
+                        "middlewares": ["IPAllowlist"],
+                    }
+                ]
+            )
+
+
+class TestMCPwnFixture:
+    def test_all_twelve_nginx_ui_tools_classified_destructive(self) -> None:
+        data = json.loads(FIXTURE.read_text())
+        tools = data["destructive_tools"]
+        assert len(tools) == 12
+        for tool in tools:
+            name = tool["name"]
+            assert is_destructive_tool(name), (
+                f"{name!r} should be classified destructive per CVE-2026-33032 tool inventory"
+            )
+            assert tool.get("source"), f"{name!r} fixture entry missing source attribution"
+
+    def test_defaults_bundle_has_check_and_source(self) -> None:
+        cfg = mcpwn_cve_2026_33032_defaults()
+        assert callable(cfg["check"])
+        assert callable(cfg["is_destructive"])
+        assert "nvd.nist.gov/vuln/detail/CVE-2026-33032" in cfg["source"]
+
+
+class TestErrorBaseClass:
+    def test_is_airlock_error(self) -> None:
+        with pytest.raises(AirlockError):
+            mcpwn_cve_2026_33032_check([{"name": "delete_site", "middlewares": []}])

--- a/tests/cves/test_vercel_contextai_oauth.py
+++ b/tests/cves/test_vercel_contextai_oauth.py
@@ -1,0 +1,131 @@
+"""OAuth audit regression for the 2026-04-19 Vercel / Context.ai breach.
+
+Vercel confirmed a security incident caused by a compromised third-party
+Google Workspace OAuth app (Context.ai). The attacker used the app's
+legitimate consent flow to exfiltrate an employee's tokens and, from
+there, 580 employee records, API keys, and source code. The client_id
+``110671459871-30f1spbu0hptbs60cb4vsmv79i7bbvqj.apps.googleusercontent.com``
+is public from Vercel's bulletin and used verbatim in this fixture.
+
+Primary sources
+---------------
+- Vercel bulletin (2026-04-19):
+  https://vercel.com/kb/bulletin/vercel-april-2026-security-incident
+- CyberInsider (2026-04-19):
+  https://cyberinsider.com/vercel-confirms-security-incident-as-hackers-claim-to-sell-internal-access/
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_airlock.exceptions import AirlockError
+from agent_airlock.mcp_spec.oauth_audit import (
+    KNOWN_COMPROMISED_CLIENT_IDS,
+    OAuthAppAuditConfig,
+    OAuthAppBlocked,
+    OAuthPolicyViolation,
+    audit_oauth_exchange,
+)
+from agent_airlock.policy_presets import oauth_audit_vercel_2026_defaults
+
+CONTEXT_AI_CLIENT_ID = "110671459871-30f1spbu0hptbs60cb4vsmv79i7bbvqj.apps.googleusercontent.com"
+
+
+def _good_response() -> dict:
+    return {
+        "access_token": "test-access-token",
+        "expires_in": 3600,
+        "refresh_token": "test-refresh",
+        "refresh_token_rotated": True,
+        "code_challenge_method": "S256",
+    }
+
+
+class TestVercel2026OAuthAudit:
+    def test_01_clean_exchange_passes(self) -> None:
+        """Baseline: a policy-compliant exchange must not raise."""
+        cfg = oauth_audit_vercel_2026_defaults()
+        report = audit_oauth_exchange(
+            _good_response(),
+            client_id="legit-app.apps.googleusercontent.com",
+            cfg=cfg,
+        )
+        assert report.pkce_verified is True
+        assert report.refresh_rotated is True
+        assert report.token_lifetime_seconds == 3600
+
+    def test_02_contextai_client_id_blocked(self) -> None:
+        """The Vercel-disclosed Context.ai client_id must be refused."""
+        cfg = oauth_audit_vercel_2026_defaults()
+        assert CONTEXT_AI_CLIENT_ID in KNOWN_COMPROMISED_CLIENT_IDS
+        with pytest.raises(OAuthAppBlocked) as exc:
+            audit_oauth_exchange(
+                _good_response(),
+                client_id=CONTEXT_AI_CLIENT_ID,
+                cfg=cfg,
+            )
+        assert "deny-list" in exc.value.reason.lower()
+
+    def test_03_missing_pkce_raises(self) -> None:
+        cfg = oauth_audit_vercel_2026_defaults()
+        resp = _good_response()
+        del resp["code_challenge_method"]
+        with pytest.raises(OAuthPolicyViolation) as exc:
+            audit_oauth_exchange(resp, client_id="legit.example", cfg=cfg)
+        assert exc.value.rule == "missing_pkce"
+
+    def test_04_oversize_token_lifetime_raises(self) -> None:
+        cfg = oauth_audit_vercel_2026_defaults()
+        resp = _good_response()
+        resp["expires_in"] = 3600 * 24 * 7  # 1 week
+        with pytest.raises(OAuthPolicyViolation) as exc:
+            audit_oauth_exchange(resp, client_id="legit.example", cfg=cfg)
+        assert exc.value.rule == "token_lifetime"
+
+    def test_05_refresh_token_reuse_raises(self) -> None:
+        cfg = oauth_audit_vercel_2026_defaults()
+        resp = _good_response()
+        resp["refresh_token_rotated"] = False
+        with pytest.raises(OAuthPolicyViolation) as exc:
+            audit_oauth_exchange(resp, client_id="legit.example", cfg=cfg)
+        assert exc.value.rule == "refresh_reuse"
+
+    def test_06_deny_list_feed_round_trip(self, tmp_path: Path) -> None:
+        """Extra client_ids loaded from a JSON feed must also be denied."""
+        feed = tmp_path / "extra-deny.json"
+        feed.write_text(json.dumps(["another-compromised-app.example"]))
+        cfg = OAuthAppAuditConfig(
+            deny_list_feed_path=feed,
+            require_pkce=False,
+            require_refresh_rotation=False,
+        )
+        with pytest.raises(OAuthAppBlocked):
+            audit_oauth_exchange(
+                _good_response(),
+                client_id="another-compromised-app.example",
+                cfg=cfg,
+            )
+
+
+class TestOAuthAuditErrorHierarchy:
+    """Both error classes must subclass ``AirlockError`` so callers can
+    `except AirlockError:` and catch every audit failure in one clause."""
+
+    def test_blocked_is_airlock_error(self) -> None:
+        with pytest.raises(AirlockError):
+            audit_oauth_exchange(
+                _good_response(),
+                client_id=CONTEXT_AI_CLIENT_ID,
+                cfg=oauth_audit_vercel_2026_defaults(),
+            )
+
+    def test_policy_violation_is_airlock_error(self) -> None:
+        cfg = oauth_audit_vercel_2026_defaults()
+        resp = _good_response()
+        resp["expires_in"] = 999_999
+        with pytest.raises(AirlockError):
+            audit_oauth_exchange(resp, client_id="legit.example", cfg=cfg)

--- a/tests/integrations/test_claude_auto_memory.py
+++ b/tests/integrations/test_claude_auto_memory.py
@@ -1,0 +1,150 @@
+"""Claude Opus 4.7 Auto Memory / Auto Dream guard regression tests (v0.5.2+).
+
+Opus 4.7 GA (2026-04-16/17) introduced filesystem-backed persistent
+notes. This suite proves tenant scoping + quota + redaction + OTel
+observability.
+
+Primary sources
+---------------
+- Anthropic — What's new in Claude 4.7 (2026-04-17):
+  https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+- Auto Dream mechanics:
+  https://claudefa.st/blog/guide/mechanics/auto-dream
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_airlock.exceptions import AirlockError
+from agent_airlock.integrations.claude_auto_memory import (
+    AutoMemoryAccessPolicy,
+    AutoMemoryCrossTenantError,
+    AutoMemoryQuotaError,
+    guarded_read,
+    guarded_write,
+)
+
+
+class TestAutoMemoryGuard:
+    def test_01_same_tenant_read_passes(self) -> None:
+        policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+        data = guarded_read(
+            policy,
+            "/memory/acct-42/plan.md",
+            lambda _: b"hello",
+        )
+        assert data == b"hello"
+
+    def test_02_same_tenant_write_passes(self) -> None:
+        policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+        seen: dict[str, str] = {}
+
+        def writer(p: str, c: str) -> None:
+            seen[p] = c
+
+        count = guarded_write(
+            policy,
+            "/memory/acct-42/plan.md",
+            "no secrets here",
+            writer,
+        )
+        assert count == 0
+        assert seen["/memory/acct-42/plan.md"] == "no secrets here"
+
+    def test_03_cross_tenant_read_raises(self) -> None:
+        policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+        with pytest.raises(AutoMemoryCrossTenantError) as exc:
+            guarded_read(
+                policy,
+                "/memory/acct-99/secrets.md",
+                lambda _: b"",
+            )
+        assert exc.value.tenant_id == "acct-42"
+        assert exc.value.attempted_path == "/memory/acct-99/secrets.md"
+
+    def test_04_oversize_read_raises(self) -> None:
+        policy = AutoMemoryAccessPolicy(
+            tenant_id="acct-42",
+            max_read_bytes_per_call=100,
+        )
+        big = b"X" * 500
+        with pytest.raises(AutoMemoryQuotaError) as exc:
+            guarded_read(
+                policy,
+                "/memory/acct-42/big.md",
+                lambda _: big,
+            )
+        assert exc.value.bytes_requested == 500
+        assert exc.value.limit == 100
+
+    def test_05_write_with_embedded_secret_is_redacted(self) -> None:
+        """An AWS-key-shaped secret in the payload must be redacted
+        BEFORE it touches persistent memory."""
+        policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+        seen: dict[str, str] = {}
+
+        def writer(p: str, c: str) -> None:
+            seen[p] = c
+
+        count = guarded_write(
+            policy,
+            "/memory/acct-42/creds.md",
+            "my key: AKIAIOSFODNN7EXAMPLE",
+            writer,
+        )
+        assert count >= 1, "at least one detection expected"
+        assert "AKIAIOSFODNN7EXAMPLE" not in seen["/memory/acct-42/creds.md"]
+
+
+class TestOTelAttributes:
+    """Verify the OTel span carries the documented attributes."""
+
+    def test_read_emits_span_with_bytes_and_tenant(self) -> None:
+        policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+        with patch("agent_airlock.integrations.claude_auto_memory._emit_span") as emit:
+            guarded_read(
+                policy,
+                "/memory/acct-42/x.md",
+                lambda _: b"hello",
+            )
+            emit.assert_called_once()
+            name, attrs = emit.call_args[0]
+            assert name == "airlock.auto_memory.read"
+            assert attrs["tenant_id"] == "acct-42"
+            assert attrs["bytes"] == 5
+            assert attrs["redacted_count"] == 0
+
+    def test_write_emits_span_with_redacted_count(self) -> None:
+        policy = AutoMemoryAccessPolicy(tenant_id="acct-42")
+        with patch("agent_airlock.integrations.claude_auto_memory._emit_span") as emit:
+            guarded_write(
+                policy,
+                "/memory/acct-42/y.md",
+                "clean note",
+                lambda _p, _c: None,
+            )
+            name, attrs = emit.call_args[0]
+            assert name == "airlock.auto_memory.write"
+            assert attrs["tenant_id"] == "acct-42"
+            assert "redacted_count" in attrs
+
+
+class TestErrorHierarchy:
+    def test_cross_tenant_is_airlock_error(self) -> None:
+        with pytest.raises(AirlockError):
+            guarded_read(
+                AutoMemoryAccessPolicy(tenant_id="a"),
+                "/memory/b/x",
+                lambda _: b"",
+            )
+
+    def test_quota_is_airlock_error(self) -> None:
+        with pytest.raises(AirlockError):
+            guarded_read(
+                AutoMemoryAccessPolicy(tenant_id="a", max_read_bytes_per_call=1),
+                "/memory/a/x",
+                lambda _: b"XX",
+            )

--- a/tests/mcp_spec/test_session_guard.py
+++ b/tests/mcp_spec/test_session_guard.py
@@ -1,0 +1,147 @@
+"""Session-snapshot integrity guard regression tests (v0.5.2+).
+
+Covers the OpenAI Agents SDK "next evolution" (2026-04-15) session-
+snapshot surface. The seven sanctioned providers are Blaxel, Cloudflare,
+Daytona, E2B, Modal, Runloop, and Vercel.
+
+Primary sources
+---------------
+- OpenAI Agents SDK next evolution (2026-04-15):
+  https://openai.com/index/the-next-evolution-of-the-agents-sdk/
+- Sandboxes guide (2026-04-15):
+  https://developers.openai.com/api/docs/guides/agents/sandboxes
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent_airlock import CostTracker
+from agent_airlock.exceptions import AirlockError
+from agent_airlock.mcp_spec.session_guard import (
+    DEFAULT_MAX_BYTES,
+    SessionSnapshotRef,
+    SnapshotAwareTransport,
+    SnapshotGuardConfig,
+    SnapshotIntegrityError,
+    carry_forward_cost,
+    verify_snapshot,
+)
+
+
+def _ref(
+    raw: bytes,
+    provider: str = "e2b",
+    signed_by: str | None = None,
+    created_at: datetime | None = None,
+) -> SessionSnapshotRef:
+    return SessionSnapshotRef(
+        snapshot_id="snap-abc123",
+        provider=provider,  # type: ignore[arg-type]
+        digest_sha256=hashlib.sha256(raw).hexdigest(),
+        signed_by=signed_by,
+        created_at=created_at or datetime.now(tz=timezone.utc),
+        size_bytes=len(raw),
+    )
+
+
+class TestSnapshotVerify:
+    def test_01_digest_match_passes(self) -> None:
+        raw = b'{"agent":"ok","tokens":10}'
+        verify_snapshot(_ref(raw), raw, SnapshotGuardConfig())
+
+    def test_02_digest_mismatch_raises(self) -> None:
+        raw = b"original"
+        ref = _ref(raw)
+        with pytest.raises(SnapshotIntegrityError) as exc:
+            verify_snapshot(ref, b"tampered", SnapshotGuardConfig())
+        # size_mismatch fires first because len differs; that's correct behavior.
+        assert exc.value.rule in {"digest_mismatch", "size_mismatch"}
+
+    def test_03_stale_snapshot_rejected(self) -> None:
+        raw = b"old"
+        old_time = datetime.now(tz=timezone.utc) - timedelta(days=3)
+        ref = _ref(raw, created_at=old_time)
+        with pytest.raises(SnapshotIntegrityError) as exc:
+            verify_snapshot(ref, raw, SnapshotGuardConfig())
+        assert exc.value.rule == "stale"
+
+    def test_04_oversize_snapshot_rejected(self) -> None:
+        raw = b"X" * (DEFAULT_MAX_BYTES + 1)
+        ref = _ref(raw)
+        with pytest.raises(SnapshotIntegrityError) as exc:
+            verify_snapshot(ref, raw, SnapshotGuardConfig())
+        assert exc.value.rule == "oversize"
+
+    def test_05_unknown_signer_rejected(self) -> None:
+        raw = b"{}"
+        ref = _ref(raw, signed_by="evil-key")
+        cfg = SnapshotGuardConfig(require_signer_allowlist=frozenset({"good-key"}))
+        with pytest.raises(SnapshotIntegrityError) as exc:
+            verify_snapshot(ref, raw, cfg)
+        assert exc.value.rule == "unknown_signer"
+
+    def test_06_redaction_enforced(self) -> None:
+        """A plaintext AWS secret in the snapshot must refuse rehydration."""
+        # Use a payload that sanitizer recognises. AWS access key IDs
+        # start with 'AKIA' followed by 16 uppercase alphanumerics.
+        raw = b"state=ok; creds=AKIAIOSFODNN7EXAMPLE"
+        ref = _ref(raw)
+        with pytest.raises(SnapshotIntegrityError) as exc:
+            verify_snapshot(ref, raw, SnapshotGuardConfig())
+        assert exc.value.rule == "embedded_secret"
+
+    def test_07_all_seven_providers_accepted(self) -> None:
+        raw = b"{}"
+        for provider in ("blaxel", "cloudflare", "daytona", "e2b", "modal", "runloop", "vercel"):
+            verify_snapshot(_ref(raw, provider=provider), raw, SnapshotGuardConfig())
+
+    def test_08_unknown_provider_rejected(self) -> None:
+        raw = b"{}"
+        ref = _ref(raw, provider="attacker-cloud")
+        with pytest.raises(SnapshotIntegrityError) as exc:
+            verify_snapshot(ref, raw, SnapshotGuardConfig())
+        assert exc.value.rule == "unknown_provider"
+
+
+class TestCostCarryForward:
+    def test_prior_tokens_charged_forward(self) -> None:
+        tracker = CostTracker()
+        carry_forward_cost(tracker, prior_total_tokens=12_345)
+        assert tracker.get_summary().total_tokens == 12_345
+
+    def test_zero_prior_noop(self) -> None:
+        tracker = CostTracker()
+        carry_forward_cost(tracker, prior_total_tokens=0)
+        assert tracker.get_summary().total_tokens == 0
+
+    def test_cannot_reset_budget_via_rehydration(self) -> None:
+        """Replaying an older snapshot must NOT wipe cumulative usage."""
+        tracker = CostTracker()
+        with tracker.track("first_call") as ctx:
+            ctx.set_tokens(input_tokens=500, output_tokens=500)
+        # Simulate rehydration from an older snapshot that saw 200 tokens.
+        carry_forward_cost(tracker, prior_total_tokens=200)
+        # Total is the sum; the attacker cannot "rewind".
+        assert tracker.get_summary().total_tokens == 1200
+
+
+class TestTransportMixin:
+    def test_rehydrate_with_guard_ok(self) -> None:
+        raw = b'{"agent":"ok"}'
+        t = SnapshotAwareTransport()
+        tracker = CostTracker()
+        t.rehydrate_with_guard(
+            _ref(raw), raw, SnapshotGuardConfig(), tracker=tracker, prior_total_tokens=42
+        )
+        assert tracker.get_summary().total_tokens == 42
+
+    def test_rehydrate_with_guard_rejects_tampered(self) -> None:
+        raw = b'{"agent":"ok"}'
+        ref = _ref(raw)
+        t = SnapshotAwareTransport()
+        with pytest.raises(AirlockError):
+            t.rehydrate_with_guard(ref, b"tampered", SnapshotGuardConfig())

--- a/tests/test_policy_presets_high_value.py
+++ b/tests/test_policy_presets_high_value.py
@@ -1,0 +1,65 @@
+"""High-value action preset regression tests (v0.5.2+).
+
+Motivating incident: 2026-04-19 Kelp DAO LayerZero bridge exploit, $292M
+stolen, ~$200M Aave bad debt.
+
+Primary sources
+---------------
+- Bloomberg (2026-04-19):
+  https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock
+- The Defiant on Aave / KelpDAO:
+  https://thedefiant.io/news/defi/aave-price-crash-kelpdao-exploit-whale-dump-rxi8o9
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_airlock.exceptions import AirlockError
+from agent_airlock.policy_presets import (
+    HighValueActionBlocked,
+    high_value_action_deny_by_default,
+)
+
+
+class TestHighValueActionDenyByDefault:
+    def test_01_banned_verb_blocked(self) -> None:
+        """``transfer_funds`` must be refused without opt-in."""
+        cfg = high_value_action_deny_by_default()
+        with pytest.raises(HighValueActionBlocked):
+            cfg["check"]("transfer_funds", allow_high_value=False)
+
+    def test_02_banned_verb_allowed_with_flag(self) -> None:
+        cfg = high_value_action_deny_by_default()
+        cfg["check"]("transfer_funds", allow_high_value=True)
+
+    def test_03_non_matching_tool_passes(self) -> None:
+        cfg = high_value_action_deny_by_default()
+        cfg["check"]("read_balance", allow_high_value=False)
+        cfg["check"]("list_positions", allow_high_value=False)
+
+
+class TestHighValueActionExtras:
+    def test_all_nine_verbs_classified(self) -> None:
+        cfg = high_value_action_deny_by_default()
+        for verb in [
+            "transfer_usdc",
+            "bridge_rsETH",
+            "approve_spender",
+            "withdraw_collateral",
+            "borrow_against",
+            "liquidate_position",
+            "swap_tokens",
+            "mint_nft",
+            "burn_token",
+        ]:
+            assert cfg["is_high_value"](verb), f"{verb!r} should be high-value"
+
+    def test_source_cites_bloomberg(self) -> None:
+        cfg = high_value_action_deny_by_default()
+        assert "bloomberg" in cfg["source"].lower()
+
+    def test_is_airlock_error(self) -> None:
+        cfg = high_value_action_deny_by_default()
+        with pytest.raises(AirlockError):
+            cfg["check"]("bridge_assets", allow_high_value=False)


### PR DESCRIPTION
## Summary

Seven new guards / presets / integrations + one P0 carryover close, all driven by 72 hours of April 2026 industry signal. Every new primitive is **opt-in**; no behavior change for existing `@Airlock` users.

**Closes #2** (DockerBackend docs + tracked follow-ups #37 rootless, #38 digest-pin).

## Primary sources (all four required by the sprint brief + three more)

1. [Vercel bulletin — 2026-04-19](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident)
2. [OpenAI Agents SDK next evolution — 2026-04-15](https://openai.com/index/the-next-evolution-of-the-agents-sdk/) + [sandboxes guide](https://developers.openai.com/api/docs/guides/agents/sandboxes)
3. [NVD CVE-2026-33032](https://nvd.nist.gov/vuln/detail/CVE-2026-33032) + [Rapid7 ETR](https://www.rapid7.com/blog/post/etr-cve-2026-33032-nginx-ui-missing-mcp-authentication/)
4. [CSA Flowise research note — 2026-04-09](https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/)
5. [Anthropic Claude 4.7 release notes — 2026-04-17](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) + [Auto Dream write-up](https://claudefa.st/blog/guide/mechanics/auto-dream)
6. [Bloomberg — Kelp DAO / Aave 2026-04-19](https://www.bloomberg.com/news/articles/2026-04-19/crypto-hack-worth-290-million-triggers-defi-contagion-shock) + [The Defiant](https://thedefiant.io/news/defi/aave-price-crash-kelpdao-exploit-whale-dump-rxi8o9)
7. [CyberInsider Vercel coverage](https://cyberinsider.com/vercel-confirms-security-incident-as-hackers-claim-to-sell-internal-access/)

## File-by-file rationale

### Task A — Close issue #2
- `docs/sandbox/docker.md` **(new)** — honest capability inventory (timeout, `no-new-privileges`, `cap_drop=["ALL"]`, `security_opt` pass-through, pytest-m-docker suite) plus tracked Known Gaps list pointing at #37 and #38.
- `README.md` — E2B section adds a one-line pointer to the new doc for air-gapped / on-prem users.

### Task B — OAuth audit guard (Vercel)
- `src/agent_airlock/mcp_spec/oauth_audit.py` **(new)** — `OAuthAppAuditConfig`, `audit_oauth_exchange()`, `OAuthAppBlocked`, `OAuthPolicyViolation`, `load_deny_list()`. Deny-list seeded with the public Context.ai client_id from the Vercel bulletin. PKCE evidence + refresh-rotation + 1h lifetime cap + optional JSON feed.
- `src/agent_airlock/policy_presets.py` — `oauth_audit_vercel_2026_defaults()` factory + `OAUTH_AUDIT_VERCEL_2026_DEFAULTS` constant.
- `src/agent_airlock/mcp_proxy_guard.py` — `MCPProxyConfig.oauth_audit` field + `MCPProxyGuard.audit_oauth_exchange()` method hook.
- `tests/cves/test_vercel_contextai_oauth.py` **(new)** — 8 tests covering all six spec cases + 2 `AirlockError` inheritance checks.

### Task C — Session-snapshot integrity guard
- `src/agent_airlock/mcp_spec/session_guard.py` **(new)** — `SessionSnapshotRef`, `SnapshotGuardConfig`, `verify_snapshot()`, `SnapshotIntegrityError`, `carry_forward_cost()`, `SnapshotAwareTransport` mixin. Seven-provider allow-list hard-coded. 25 MiB DoS guard. Secret-redaction pre-check via `sanitize_output`.
- `tests/mcp_spec/test_session_guard.py` **(new)** — 13 tests covering all 8 spec cases + CostTracker carry-forward (3) + transport mixin (2).

### Task D — CVE-2026-33032 MCPwn preset
- `src/agent_airlock/policy_presets.py` — `mcpwn_cve_2026_33032_check()`, `mcpwn_cve_2026_33032_defaults()`, `is_destructive_tool()`, `UnauthenticatedDestructiveToolError` (re-homed onto `AirlockError` at module load). Trusted-middleware allow-list rejects `IPAllowlist`-only setups (the nginx-ui default was `0.0.0.0/0`).
- `tests/cves/fixtures/cve_2026_33032_mcpwn.json` **(new)** — 12 destructive nginx-ui tool names with per-entry primary-source attribution.
- `tests/cves/test_cve_2026_33032_mcpwn.py` **(new)** — 6 tests (3 spec + fixture round-trip + `AirlockError` check).

### Task E — CVE-2025-59528 Flowise eval-token preset
- `src/agent_airlock/policy_presets.py` — `flowise_cve_2025_59528_check()`, `flowise_cve_2025_59528_defaults()`, `FlowiseEvalTokenError`. Banned tokens: `Function(`, `new Function`, `eval(`, `Deno.eval`, `vm.runInNewContext`.
- `tests/cves/test_cve_2025_59528_flowise.py` **(new)** — 8 tests (5 spec + defaults-bundle + `AirlockError` check).
- `README.md` — OWASP Agentic table ASI02 (Tool Misuse) and ASI05 (RCE) rows now cite the Flowise preset + CVE URL.

### Task F — Claude Opus 4.7 Auto Memory / Auto Dream guard
- `src/agent_airlock/integrations/claude_auto_memory.py` **(new)** — `AutoMemoryAccessPolicy`, `guarded_read()`, `guarded_write()`, `AutoMemoryCrossTenantError`, `AutoMemoryQuotaError`. Tenant-scoped paths (`/memory/{tenant_id}/`), 64 KiB default quota, redact-on-write via `sanitize_output`, OTel spans `airlock.auto_memory.read/write`.
- `tests/integrations/test_claude_auto_memory.py` **(new)** — 9 tests (5 spec + 2 OTel attribute + 2 `AirlockError` inheritance).

### Task G (P2) — High-value action preset
- `src/agent_airlock/policy_presets.py` — `high_value_action_deny_by_default()`, `HighValueActionBlocked` (`AirlockError` subclass). Regex tags `(?i)(transfer|bridge|approve|withdraw|borrow|liquidate|swap|mint|burn)`.
- `docs/presets/high-value-actions.md` **(new)** — motivating incident, usage, known limitations.
- `tests/test_policy_presets_high_value.py` **(new)** — 6 tests (3 spec + 3 extras covering all 9 verbs + source attribution + `AirlockError`).

### Release bookkeeping
- `pyproject.toml` + `src/agent_airlock/__init__.py` — version bumped to **0.5.2**.
- `CHANGELOG.md` — `[0.5.2] - 2026-04-20 — "OAuth audit bundle"` section with full rationale and primary-source URLs per section.
- `README.md` — OWASP Agentic table ASI02/03/04/05 rows cross-link every new preset.

## Test plan

- [x] `pytest tests/` → **1453 passed**, 33 skipped, 4 deselected (Docker gated)
- [x] Coverage **81.84%** (v0.5.1 baseline 81.40%; v0.5.2 floor is 80%)
- [x] `ruff check` clean, `ruff format --check` clean
- [x] Every new test's module docstring cites the CVE / primary-source URL (hard constraint)
- [x] No new runtime deps (hard constraint)
- [x] No new secrets in tests or fixtures — Context.ai client_id is public per Vercel bulletin (hard constraint)
- [x] Seven new presets all default OFF — no behavior change for existing `@Airlock` users (hard constraint)
- [x] `@Airlock` median latency 81.9 μs (v0.5.1: 75.2 μs) — within run-to-run noise on this laptop
- [ ] CI green on this PR — will ping when ready

## Hard-constraint compliance

| Constraint | Status |
|---|---|
| No new runtime deps | ✅ |
| No secrets in tests or fixtures | ✅ (Context.ai ID is public from Vercel bulletin) |
| No behavior change for existing @Airlock users | ✅ (all seven new primitives are opt-in) |
| Every new test cites source in module docstring | ✅ |
| Do NOT push to main until review | ✅ — opened PR only, waiting |

## Out of scope today (v0.5.3 queue)

Modal/Daytona/E2B sandbox *adapter implementations* (#30), tool-poisoning scanner v2 (#31), Oregon SB 1546 preset (#32), agent-identity signing (#33), `airlock scan-tools` CLI (#34), SBOM + SLSA L3 in publish.yml (#35), webhook/PagerDuty audit sinks (#36), CrewAI native integration (#5), Gradio demo (#3), performance benchmarks in CI (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)