### PR TITLE
feat(sanitizer): opt-in Indic PII masking (Verhoeff + Devanagari)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Opt-in Indic PII masking: Verhoeff + Devanagari (v0.8.9)
+
+A new `pii_locales` opt-in tag on `sanitize_output()` / `mask_sensitive_data()`
+/ `detect_sensitive_data()` / `AirlockConfig`. Defaults to `[]` so the
+zero-dep, US-default PII surface is unchanged for existing callers. When
+`pii_locales=["in"]` is supplied, three things activate:
+
+1. **Aadhaar Verhoeff checksum gate.** The existing Aadhaar regex
+   (`\b[2-9][0-9]{3}[\s-]?[0-9]{4}[\s-]?[0-9]{4}\b`) is permissive —
+   any 12-digit number starting 2-9 matches. With the opt-in, each
+   match is validated against the UIDAI Verhoeff checksum (the same
+   algorithm UIDAI uses to compute the last digit). Cuts the FP rate
+   ~10x on random 12-digit IDs / phone numbers.
+2. **Devanagari personal-name detection** — new
+   `SensitiveDataType.PERSONAL_NAME_DEVANAGARI` enum member. Regex
+   matches sequences of 2+ Devanagari word characters (Unicode block
+   `U+0900–U+097F`), optionally joined by whitespace. A small
+   common-noun allowlist (greetings, pronouns, interrogatives, basic
+   connectives, copulas) filters obvious false positives — multi-word
+   spans where every token is in the allowlist are dropped. This is a
+   conservative heuristic, not NER; production callers who need precise
+   name extraction should layer a proper NER on top.
+3. **India PII auto-include in `sanitize_output(mask_pii=True)`**:
+   Aadhaar / PAN / UPI / IFSC / Devanagari are added to the default
+   masked types. Without the locale tag, callers must still pass
+   `types=[...]` explicitly to mask India-locale PII — that
+   behavior is unchanged.
+
+The existing Aadhaar / PAN / UPI / IFSC enum members, regex patterns,
+default mask strategies, and tests are **untouched** — the new gate
+is purely additive. Reuses the existing four masking strategies
+(`FULL` / `PARTIAL` / `TYPE_ONLY` / `HASH`); no new strategy.
+
+New public exports: `SensitiveDataType.PERSONAL_NAME_DEVANAGARI`,
+`AirlockConfig.pii_locales` field. The new `pii_locales` parameter on
+`detect_sensitive_data` / `mask_sensitive_data` / `sanitize_output` is
+keyword-only by convention (positional callers from before are unaffected).
+
+`pii_locales` is also accepted in TOML config (`pii_locales = ["in"]`
+or `pii_locales = "in,us"`).
+
+32 new tests in `tests/test_indic_pii_masking.py` cover: Verhoeff
+helper (valid / invalid / non-digit / mutation), Aadhaar locale gate
+(opt-in passes valid + drops invalid; no-opt-in keeps permissive
+behavior + separator normalization), Devanagari detection (single +
+multi-word names; common-noun allowlist FP filtering; mixed
+greeting+name spans), `sanitize_output` end-to-end with the locale
+extending the default PII set, full `@Airlock` integration via
+`AirlockConfig.pii_locales`, and backwards-compatibility (all old
+call shapes still work).
+
 ### Added — CVE-2026-35394 Mobile MCP intent-URL guard preset (v0.8.8)
 
 `mobile_mcp_intent_guard_2026_05` — defensive bundle for **CVE-2026-35394**

--- a/README.md
+++ b/README.md
@@ -413,6 +413,44 @@ def get_user(user_id: str) -> dict:
 
 **12 PII types detected** · **4 masking strategies** · **Zero data leakage**
 
+#### Opt-in regional PII (`pii_locales`)
+
+Aadhaar / PAN / UPI / IFSC have always shipped as `SensitiveDataType` members,
+but are not added to the default `mask_pii=True` set — to keep the surface
+zero-dep and US-shaped by default. **v0.8.9** adds a `pii_locales` opt-in
+that pulls them in *and* tightens detection:
+
+```python
+config = AirlockConfig(
+    mask_pii=True,
+    pii_locales=["in"],   # opt in to India-locale detection
+)
+
+@Airlock(config=config)
+def lookup(query: str) -> str:
+    return (
+        "User: राम कुमार, "
+        "Aadhaar: 234567890124, "       # → "23********24" (PARTIAL)
+        "PAN: ABCDE1234F, "             # → "AB******4F" (PARTIAL)
+        "phone: 555-123-4567"           # still masked by existing PHONE regex
+    )
+```
+
+Two things activate when `"in" in pii_locales`:
+
+- **Aadhaar Verhoeff checksum gate** — the existing Aadhaar regex is
+  permissive (any 12-digit number starting 2-9 matches). With the opt-in,
+  each match must also pass the UIDAI Verhoeff checksum, cutting the FP
+  rate ~10x on random IDs / phone numbers.
+- **Devanagari personal-name detection** — `PERSONAL_NAME_DEVANAGARI` runs
+  against the Unicode block `U+0900–U+097F`, with a small allowlist of
+  common Hindi greetings / pronouns / interrogatives to keep ordinary
+  prose from being masked. Conservative heuristic — production callers
+  who need precise extraction should layer NER on top.
+
+The flag is **additive and reversible** — `pii_locales=[]` (the default)
+preserves the prior behavior bit-for-bit.
+
 ---
 
 ### 🌐 Network Airgap (V0.3.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.8"
+version = "0.8.9"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -568,7 +568,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 __all__ = [
     # Core

--- a/src/agent_airlock/config.py
+++ b/src/agent_airlock/config.py
@@ -117,6 +117,14 @@ class AirlockConfig:
     # V0.4.1 Anomaly detection
     anomaly_config: AnomalyDetectorConfig | None = None
 
+    # V0.8.9 — opt-in locale tags for region-specific PII detection.
+    # An empty list (default) keeps the historical PII surface unchanged
+    # (US-shape email/phone/SSN/CC/IP). ``["in"]`` adds Aadhaar / PAN /
+    # UPI / IFSC / Devanagari name detection AND gates Aadhaar matches
+    # through a Verhoeff checksum (cuts false positives on random
+    # 12-digit numbers). Locale codes are lowercase ISO-3166-1 alpha-2.
+    pii_locales: list[str] = field(default_factory=list)
+
     def __post_init__(self) -> None:
         """Apply environment variable overrides after initialization."""
         # E2B API key priority: env var > constructor > config file
@@ -234,6 +242,8 @@ class AirlockConfig:
             "endpoints",
             "anomaly",
             "credentials",
+            # V0.8.9 opt-in locale tags for region-specific PII
+            "pii_locales",
         }
 
         # SECURITY: Warn about unknown keys (likely typos)
@@ -289,6 +299,21 @@ class AirlockConfig:
         # Path fields
         if "audit_log_path" in data:
             result["audit_log_path"] = Path(data["audit_log_path"])
+
+        # V0.8.9 List-of-strings: opt-in PII locale tags.
+        if "pii_locales" in data:
+            raw_locales = data["pii_locales"]
+            if isinstance(raw_locales, (list, tuple)):
+                result["pii_locales"] = [str(x) for x in raw_locales]
+            elif isinstance(raw_locales, str):
+                # Permit a comma-separated string for convenience.
+                result["pii_locales"] = [s.strip() for s in raw_locales.split(",") if s.strip()]
+            else:
+                logger.warning(
+                    "invalid_pii_locales_type",
+                    type=type(raw_locales).__name__,
+                    hint="pii_locales must be a list of strings or comma-separated string.",
+                )
 
         # V0.3.0 nested config sections
         if "filesystem" in data:

--- a/src/agent_airlock/core.py
+++ b/src/agent_airlock/core.py
@@ -500,6 +500,7 @@ class Airlock:
                     mask_pii=self.config.mask_pii,
                     mask_secrets=self.config.mask_secrets,
                     max_chars=max_chars,
+                    pii_locales=self.config.pii_locales or None,
                 )
 
                 sanitized_count = sanitization.detection_count

--- a/src/agent_airlock/sanitizer.py
+++ b/src/agent_airlock/sanitizer.py
@@ -32,6 +32,7 @@ class SensitiveDataType(str, Enum):
     PAN = "pan"  # Indian Permanent Account Number
     UPI_ID = "upi_id"  # Unified Payments Interface ID
     IFSC = "ifsc"  # Indian Financial System Code
+    PERSONAL_NAME_DEVANAGARI = "personal_name_devanagari"  # v0.8.9 — Indic-script names
 
     # Secrets
     API_KEY = "api_key"
@@ -105,6 +106,11 @@ PATTERNS: dict[SensitiveDataType, re.Pattern[str]] = {
     SensitiveDataType.IFSC: re.compile(
         r"\b[A-Z]{4}0[A-Z0-9]{6}\b"  # 4 letters + 0 + 6 alphanumeric
     ),
+    # V0.8.9 Devanagari (Unicode U+0900–U+097F) personal-name span heuristic.
+    # Matches 2+ Devanagari word characters surrounded by word boundaries.
+    # The Hindi-noun allowlist further down filters common non-name words
+    # (greetings, pronouns, interrogatives) to cut false positives.
+    SensitiveDataType.PERSONAL_NAME_DEVANAGARI: re.compile(r"[ऀ-ॿ]{2,}(?:\s+[ऀ-ॿ]{2,})*"),
     # Secret Patterns
     SensitiveDataType.API_KEY: re.compile(
         r"\b(?:"
@@ -149,6 +155,7 @@ DEFAULT_MASK_CONFIG: dict[SensitiveDataType, MaskingStrategy] = {
     SensitiveDataType.PAN: MaskingStrategy.PARTIAL,  # Show first 2 + last 2
     SensitiveDataType.UPI_ID: MaskingStrategy.PARTIAL,  # Show @bank suffix
     SensitiveDataType.IFSC: MaskingStrategy.TYPE_ONLY,  # Bank codes are semi-public
+    SensitiveDataType.PERSONAL_NAME_DEVANAGARI: MaskingStrategy.PARTIAL,  # v0.8.9
     # Secrets
     SensitiveDataType.API_KEY: MaskingStrategy.PARTIAL,
     SensitiveDataType.AWS_KEY: MaskingStrategy.PARTIAL,
@@ -214,20 +221,187 @@ def _mask_value(
     return value[:3] + "***" + value[-3:]
 
 
+# --- V0.8.9 Indic PII helpers --------------------------------------------
+# The two arrays below are the standard Verhoeff dihedral-group tables.
+# Provided in canonical form so the algorithm reads identically to the
+# reference; no symmetry shortcuts. Verhoeff is the algorithm UIDAI uses
+# to generate Aadhaar's last digit — a checksum gate cuts the regex's
+# false-positive rate (any 12-digit number starting 2-9 currently passes
+# the bare regex; only ~1 in 10 of those pass Verhoeff).
+_VERHOEFF_D: tuple[tuple[int, ...], ...] = (
+    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+    (1, 2, 3, 4, 0, 6, 7, 8, 9, 5),
+    (2, 3, 4, 0, 1, 7, 8, 9, 5, 6),
+    (3, 4, 0, 1, 2, 8, 9, 5, 6, 7),
+    (4, 0, 1, 2, 3, 9, 5, 6, 7, 8),
+    (5, 9, 8, 7, 6, 0, 4, 3, 2, 1),
+    (6, 5, 9, 8, 7, 1, 0, 4, 3, 2),
+    (7, 6, 5, 9, 8, 2, 1, 0, 4, 3),
+    (8, 7, 6, 5, 9, 3, 2, 1, 0, 4),
+    (9, 8, 7, 6, 5, 4, 3, 2, 1, 0),
+)
+_VERHOEFF_P: tuple[tuple[int, ...], ...] = (
+    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+    (1, 5, 7, 6, 2, 8, 3, 0, 9, 4),
+    (5, 8, 0, 3, 7, 9, 6, 1, 4, 2),
+    (8, 9, 1, 6, 0, 4, 3, 5, 2, 7),
+    (9, 4, 5, 3, 1, 2, 6, 8, 7, 0),
+    (4, 2, 8, 6, 5, 7, 3, 9, 0, 1),
+    (2, 7, 9, 3, 8, 0, 6, 4, 1, 5),
+    (7, 0, 4, 6, 9, 1, 3, 2, 5, 8),
+)
+
+
+def _verhoeff_check(num: str) -> bool:
+    """Return True if ``num`` (a digits-only string) passes Verhoeff.
+
+    Reference: Verhoeff, J. (1969) "Error Detecting Decimal Codes".
+    Used by UIDAI for Aadhaar's last-digit checksum. The function is
+    deliberately tolerant of input length — Aadhaar is 12 digits but
+    the algorithm itself works for any length.
+    """
+    if not num.isdigit():
+        return False
+    c = 0
+    for i, ch in enumerate(reversed(num)):
+        c = _VERHOEFF_D[c][_VERHOEFF_P[i % 8][int(ch)]]
+    return c == 0
+
+
+# Common high-frequency Devanagari tokens that are NOT personal names.
+# This list is intentionally small — it covers the most-likely false
+# positives (greetings, pronouns, common interrogatives, basic
+# connectives) so the heuristic doesn't mask every line of Hindi prose.
+# Production callers who need a proper NER should layer one on top.
+_DEVANAGARI_NON_NAME_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Greetings / pleasantries
+        "नमस्ते",
+        "नमस्कार",
+        "धन्यवाद",
+        "शुभ",
+        "स्वागत",
+        # Yes/no
+        "हाँ",
+        "हां",
+        "जी",
+        "नहीं",
+        # Pronouns
+        "मैं",
+        "हम",
+        "तुम",
+        "आप",
+        "वह",
+        "वे",
+        "यह",
+        "ये",
+        # Interrogatives
+        "क्या",
+        "कौन",
+        "कब",
+        "कहाँ",
+        "कैसे",
+        "क्यों",
+        "कितना",
+        "कितने",
+        # Connectives / particles
+        "और",
+        "या",
+        "लेकिन",
+        "किन्तु",
+        "परन्तु",
+        "अगर",
+        "तो",
+        "भी",
+        "ही",
+        # Common verbs / copulas
+        "है",
+        "हैं",
+        "था",
+        "थी",
+        "थे",
+        "होगा",
+        "होगी",
+        "होंगे",
+        # Common nouns
+        "नाम",
+        "घर",
+        "देश",
+        "दिन",
+        "रात",
+        "समय",
+        "साल",
+        "महीना",
+        # Quality adjectives
+        "अच्छा",
+        "अच्छी",
+        "बुरा",
+        "बुरी",
+        "बड़ा",
+        "बड़ी",
+        "छोटा",
+        "छोटी",
+    }
+)
+
+
+def _filter_devanagari_non_names(value: str) -> bool:
+    """Return True if a Devanagari match should be KEPT as a name.
+
+    Filters out tokens whose every word is in the common-noun allowlist;
+    a multi-word span keeps if even one word is unrecognized (likely a
+    proper noun). Single-word matches are kept unless they're in the
+    allowlist.
+    """
+    words = value.split()
+    if not words:
+        return False
+    # Drop if every word is a known non-name token
+    return not all(w in _DEVANAGARI_NON_NAME_ALLOWLIST for w in words)
+
+
+def _normalize_pii_locales(locales: list[str] | None) -> frozenset[str]:
+    """Coerce ``pii_locales`` to a normalized frozenset of lowercase codes."""
+    if not locales:
+        return frozenset()
+    return frozenset(loc.strip().lower() for loc in locales if loc)
+
+
+# India-locale types that ``sanitize_output`` adds to the default PII set
+# when ``pii_locales=["in"]`` is supplied. Existing callers who manually
+# pass ``types=[...]`` continue to work unchanged.
+_INDIA_LOCALE_PII_TYPES: tuple[SensitiveDataType, ...] = (
+    SensitiveDataType.AADHAAR,
+    SensitiveDataType.PAN,
+    SensitiveDataType.UPI_ID,
+    SensitiveDataType.IFSC,
+    SensitiveDataType.PERSONAL_NAME_DEVANAGARI,
+)
+
+
 def detect_sensitive_data(
     content: str,
     types: list[SensitiveDataType] | None = None,
+    pii_locales: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Detect sensitive data in content.
 
     Args:
         content: Text content to scan.
         types: Types of sensitive data to detect. If None, detect all.
+        pii_locales: V0.8.9 opt-in locale tags. When ``"in"`` is included,
+            Aadhaar matches are filtered through a Verhoeff checksum
+            (cuts false positives) and Devanagari name matches are
+            filtered against the common-noun allowlist. Locale-gating is
+            additive and does NOT change behavior for callers that pass
+            ``types`` explicitly without the locale flag.
 
     Returns:
         List of detection dictionaries with type, value, and position.
     """
     types = types or list(SensitiveDataType)
+    locales = _normalize_pii_locales(pii_locales)
+    indic_gate = "in" in locales
     detections: list[dict[str, Any]] = []
 
     for data_type in types:
@@ -241,6 +415,23 @@ def detect_sensitive_data(
                 value = match.group(1) if match.lastindex else match.group(0)
             else:
                 value = match.group(0)
+
+            # V0.8.9: Aadhaar Verhoeff gate (opt-in). When the caller
+            # signals India locale, drop matches that don't pass
+            # the UIDAI Verhoeff checksum.
+            if indic_gate and data_type == SensitiveDataType.AADHAAR:
+                digits_only = re.sub(r"[\s-]", "", value)
+                if not _verhoeff_check(digits_only):
+                    continue
+
+            # V0.8.9: Devanagari name allowlist (opt-in). Drop matches
+            # that are entirely common Hindi non-name tokens.
+            if (
+                indic_gate
+                and data_type == SensitiveDataType.PERSONAL_NAME_DEVANAGARI
+                and not _filter_devanagari_non_names(value)
+            ):
+                continue
 
             detections.append(
                 {
@@ -261,6 +452,7 @@ def mask_sensitive_data(
     content: str,
     types: list[SensitiveDataType] | None = None,
     mask_config: dict[SensitiveDataType, MaskingStrategy] | None = None,
+    pii_locales: list[str] | None = None,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Mask sensitive data in content.
 
@@ -268,12 +460,16 @@ def mask_sensitive_data(
         content: Text content to sanitize.
         types: Types of sensitive data to mask. If None, mask all.
         mask_config: Masking strategy per type. Uses defaults if not provided.
+        pii_locales: V0.8.9 opt-in locale tags (forwarded to
+            :func:`detect_sensitive_data`). When ``"in"`` is present,
+            Aadhaar matches are Verhoeff-validated and Devanagari name
+            matches are filtered through the common-noun allowlist.
 
     Returns:
         Tuple of (masked_content, list of detections).
     """
     mask_config = mask_config or DEFAULT_MASK_CONFIG
-    detections = detect_sensitive_data(content, types)
+    detections = detect_sensitive_data(content, types, pii_locales=pii_locales)
 
     if not detections:
         return content, []
@@ -349,6 +545,7 @@ def sanitize_output(
     mask_secrets: bool = True,
     max_chars: int | None = None,
     mask_config: dict[SensitiveDataType, MaskingStrategy] | None = None,
+    pii_locales: list[str] | None = None,
 ) -> SanitizationResult:
     """Sanitize output content.
 
@@ -360,6 +557,14 @@ def sanitize_output(
         mask_secrets: If True, mask secrets (API keys, passwords, etc.).
         max_chars: Maximum output length. None for no limit.
         mask_config: Custom masking strategies per type.
+        pii_locales: V0.8.9 opt-in locale tags. When ``"in"`` is present
+            and ``mask_pii=True``, Aadhaar / PAN / UPI / IFSC / Devanagari
+            name detection is added to the default PII set. The Aadhaar
+            regex is gated with a Verhoeff checksum (cuts false positives
+            on random 12-digit numbers) and Devanagari matches are
+            filtered against a small common-noun allowlist. Existing
+            callers that did not pass this argument get exactly the
+            previous behavior — defaults are unchanged.
 
     Returns:
         SanitizationResult with sanitized content and metadata.
@@ -391,6 +596,12 @@ def sanitize_output(
                 SensitiveDataType.IP_ADDRESS,
             ]
         )
+        # V0.8.9: India locale opt-in. ``pii_locales=["in"]`` extends
+        # the default PII set with Aadhaar / PAN / UPI / IFSC and the
+        # new Devanagari name detector. Aadhaar matches are then
+        # Verhoeff-gated inside ``detect_sensitive_data``.
+        if "in" in _normalize_pii_locales(pii_locales):
+            types_to_mask.extend(_INDIA_LOCALE_PII_TYPES)
 
     if mask_secrets:
         types_to_mask.extend(
@@ -406,7 +617,9 @@ def sanitize_output(
 
     # Mask sensitive data
     if types_to_mask:
-        text, detections = mask_sensitive_data(text, types_to_mask, mask_config)
+        text, detections = mask_sensitive_data(
+            text, types_to_mask, mask_config, pii_locales=pii_locales
+        )
 
         if detections:
             logger.info(

--- a/src/agent_airlock/streaming.py
+++ b/src/agent_airlock/streaming.py
@@ -131,6 +131,7 @@ class StreamingAirlock:
             mask_pii=self.config.mask_pii,
             mask_secrets=self.config.mask_secrets,
             max_chars=None,  # Don't truncate individual chunks
+            pii_locales=self.config.pii_locales or None,
         )
 
         self._state.sanitized_count += result.detection_count

--- a/tests/test_indic_pii_masking.py
+++ b/tests/test_indic_pii_masking.py
@@ -1,0 +1,331 @@
+"""V0.8.9 — opt-in Indic PII masking (Verhoeff Aadhaar gate + Devanagari names).
+
+The existing Aadhaar / PAN / UPI / IFSC detectors keep their permissive
+default behavior. When ``pii_locales=["in"]`` is supplied, two new behaviors
+activate:
+
+1. Aadhaar regex matches are validated against the UIDAI Verhoeff checksum,
+   so random 12-digit numbers no longer false-positive as Aadhaar.
+2. A Devanagari personal-name detector (U+0900–U+097F) runs, with a small
+   common-noun allowlist to keep ordinary Hindi prose from being masked.
+
+The locale tag is additive — existing callers that don't pass it get
+exactly the prior behavior (verified by ``tests/test_sanitizer.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_airlock import Airlock, AirlockConfig
+from agent_airlock.sanitizer import (
+    SensitiveDataType,
+    _verhoeff_check,
+    detect_sensitive_data,
+    mask_sensitive_data,
+    sanitize_output,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: Verhoeff-valid and Verhoeff-invalid 12-digit numbers
+# ---------------------------------------------------------------------------
+
+# Synthetic Aadhaar-shaped numbers that pass the Verhoeff checksum. Computed
+# by exhaustive last-digit search; do not match any real-world Aadhaar.
+VALID_AADHAAR_NUMBERS = (
+    "234567890124",
+    "998877665548",
+    "345678901238",
+)
+
+# 12-digit number that matches the Aadhaar regex (starts 2-9, all digits)
+# but fails the Verhoeff checksum — exactly the kind of false positive
+# the opt-in gate is designed to catch. This is the fixture used by
+# the existing tests in test_sanitizer.py.
+INVALID_AADHAAR_NUMBERS = (
+    "234567890123",  # last digit one off from 234567890124
+    "234567890125",
+    "345678901230",
+)
+
+
+# ---------------------------------------------------------------------------
+# Verhoeff helper
+# ---------------------------------------------------------------------------
+
+
+class TestVerhoeffHelper:
+    """Direct tests of the Verhoeff implementation."""
+
+    @pytest.mark.parametrize("num", VALID_AADHAAR_NUMBERS)
+    def test_valid_aadhaar_passes(self, num: str) -> None:
+        assert _verhoeff_check(num) is True
+
+    @pytest.mark.parametrize("num", INVALID_AADHAAR_NUMBERS)
+    def test_invalid_aadhaar_fails(self, num: str) -> None:
+        assert _verhoeff_check(num) is False
+
+    def test_non_digit_input_rejected(self) -> None:
+        assert _verhoeff_check("12345abcdefg") is False
+        assert _verhoeff_check("") is False
+
+    def test_short_input_still_runs(self) -> None:
+        # Verhoeff works on any length — the gate is whether the
+        # composed checksum returns 0. A bare zero passes (trivial).
+        assert _verhoeff_check("0") is True
+
+    def test_known_pair_one_digit_apart_differ(self) -> None:
+        """Sanity: changing any digit breaks the checksum."""
+        for valid in VALID_AADHAAR_NUMBERS:
+            mutated = valid[:-1] + str((int(valid[-1]) + 1) % 10)
+            assert _verhoeff_check(mutated) is False
+
+
+# ---------------------------------------------------------------------------
+# Aadhaar locale gate
+# ---------------------------------------------------------------------------
+
+
+class TestAadhaarLocaleGate:
+    """Aadhaar behavior with and without ``pii_locales=['in']``."""
+
+    def test_no_locale_keeps_permissive_match(self) -> None:
+        """Without opt-in, the existing permissive regex behavior holds —
+        a Verhoeff-invalid 12-digit number still matches (backwards-compat)."""
+        content = "Aadhaar: 234567890123"
+        detections = detect_sensitive_data(content, [SensitiveDataType.AADHAAR])
+        assert len(detections) == 1
+        assert detections[0]["type"] == "aadhaar"
+
+    def test_in_locale_keeps_verhoeff_valid_match(self) -> None:
+        content = "Aadhaar: 234567890124"  # passes Verhoeff
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.AADHAAR],
+            pii_locales=["in"],
+        )
+        assert len(detections) == 1
+        assert detections[0]["value"] == "234567890124"
+
+    def test_in_locale_drops_verhoeff_invalid_match(self) -> None:
+        content = "Aadhaar: 234567890123"  # fails Verhoeff
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.AADHAAR],
+            pii_locales=["in"],
+        )
+        assert detections == []
+
+    def test_in_locale_handles_spaced_and_dashed_forms(self) -> None:
+        """Verhoeff gate must ignore separators when re-parsing the digits."""
+        for sep in (" ", "-", ""):
+            content = f"Aadhaar: 2345{sep}6789{sep}0124"
+            detections = detect_sensitive_data(
+                content,
+                [SensitiveDataType.AADHAAR],
+                pii_locales=["in"],
+            )
+            assert len(detections) == 1, f"failed for separator {sep!r}"
+
+    def test_in_locale_irrelevant_when_aadhaar_not_in_types(self) -> None:
+        """The locale gate only affects types the caller asked for."""
+        content = "user@example.com"
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.EMAIL],
+            pii_locales=["in"],
+        )
+        assert len(detections) == 1
+        assert detections[0]["type"] == "email"
+
+
+# ---------------------------------------------------------------------------
+# Devanagari personal-name detection
+# ---------------------------------------------------------------------------
+
+
+class TestDevanagariNameDetection:
+    """Devanagari personal-name span heuristic + common-noun allowlist."""
+
+    def test_two_word_name_detected(self) -> None:
+        content = "Name: राम कुमार"
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.PERSONAL_NAME_DEVANAGARI],
+            pii_locales=["in"],
+        )
+        assert len(detections) >= 1
+        assert any("राम कुमार" in d["value"] for d in detections)
+
+    def test_single_word_name_detected(self) -> None:
+        content = "अमित"
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.PERSONAL_NAME_DEVANAGARI],
+            pii_locales=["in"],
+        )
+        assert len(detections) == 1
+
+    def test_common_noun_filtered_by_allowlist(self) -> None:
+        """नमस्ते is a greeting, not a name — the allowlist must drop it."""
+        content = "नमस्ते"
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.PERSONAL_NAME_DEVANAGARI],
+            pii_locales=["in"],
+        )
+        assert detections == []
+
+    def test_pronoun_string_filtered(self) -> None:
+        """Sequence of allowlisted tokens — every word is a known non-name."""
+        content = "मैं और आप"
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.PERSONAL_NAME_DEVANAGARI],
+            pii_locales=["in"],
+        )
+        assert detections == []
+
+    def test_mixed_sentence_keeps_name_span_only(self) -> None:
+        """A real sentence with greeting + name should still flag the name part."""
+        content = "नमस्ते राम कुमार"
+        detections = detect_sensitive_data(
+            content,
+            [SensitiveDataType.PERSONAL_NAME_DEVANAGARI],
+            pii_locales=["in"],
+        )
+        # The regex matches contiguous Devanagari words; the heuristic
+        # may produce one or two spans. At least one detection must
+        # include the actual name tokens.
+        assert any("राम" in d["value"] and "कुमार" in d["value"] for d in detections)
+
+    def test_no_opt_in_no_devanagari_detection_via_sanitize_output(self) -> None:
+        """Without ``pii_locales=["in"]``, sanitize_output does NOT add
+        Devanagari to its default PII set even when mask_pii=True."""
+        content = "Hello राम कुमार"
+        result = sanitize_output(content, mask_pii=True)
+        # No Devanagari detection in the default surface
+        assert not any(d["type"] == "personal_name_devanagari" for d in result.detections)
+
+
+# ---------------------------------------------------------------------------
+# sanitize_output end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeOutputLocale:
+    """End-to-end masking through sanitize_output with the locale opt-in."""
+
+    def test_locale_in_extends_pii_set(self) -> None:
+        """``mask_pii=True`` + ``pii_locales=["in"]`` masks Aadhaar/PAN/Devanagari."""
+        content = "User: राम शर्मा, Aadhaar: 234567890124, PAN: ABCDE1234F, email: foo@example.com"
+        result = sanitize_output(content, mask_pii=True, pii_locales=["in"])
+        types_found = {d["type"] for d in result.detections}
+        # Existing US-shape email still masked (unchanged)
+        assert "email" in types_found
+        # India-locale opt-in adds these three
+        assert "aadhaar" in types_found
+        assert "pan" in types_found
+        assert "personal_name_devanagari" in types_found
+
+    def test_locale_in_drops_verhoeff_invalid_aadhaar(self) -> None:
+        """An invalid-checksum 12-digit number is NOT masked under in-locale."""
+        content = "Random ID: 234567890123 belongs to nobody."
+        result = sanitize_output(content, mask_pii=True, pii_locales=["in"])
+        types_found = {d["type"] for d in result.detections}
+        assert "aadhaar" not in types_found
+
+    def test_no_locale_default_behavior_unchanged(self) -> None:
+        """Without ``pii_locales``, the default PII surface is unchanged."""
+        content = "User: राम शर्मा, Aadhaar: 234567890124"
+        result = sanitize_output(content, mask_pii=True)
+        # No India types added without explicit opt-in
+        types_found = {d["type"] for d in result.detections}
+        assert "aadhaar" not in types_found
+        assert "personal_name_devanagari" not in types_found
+
+    def test_explicit_types_param_still_works_without_locale(self) -> None:
+        """A caller can still mask Aadhaar by passing ``types`` directly —
+        opt-in is additive, not exclusive (backwards-compat)."""
+        content = "Aadhaar: 234567890123"  # fails Verhoeff
+        masked, detections = mask_sensitive_data(content, [SensitiveDataType.AADHAAR])
+        assert len(detections) == 1  # permissive regex still matches
+
+
+# ---------------------------------------------------------------------------
+# AirlockConfig + @Airlock integration
+# ---------------------------------------------------------------------------
+
+
+class TestAirlockConfigIntegration:
+    """The opt-in propagates from AirlockConfig through the decorator seam."""
+
+    def test_default_config_has_empty_pii_locales(self) -> None:
+        config = AirlockConfig()
+        assert config.pii_locales == []
+
+    def test_config_accepts_in_locale(self) -> None:
+        config = AirlockConfig(pii_locales=["in"])
+        assert "in" in config.pii_locales
+
+    def test_decorator_threads_locale_to_sanitizer(self) -> None:
+        config = AirlockConfig(pii_locales=["in"])
+
+        @Airlock(config=config, return_dict=True)
+        def lookup(query: str) -> str:
+            # Return content that should be masked under in-locale
+            return f"Result for {query}: Aadhaar 234567890124, PAN ABCDE1234F"
+
+        result = lookup(query="who")
+        assert isinstance(result, dict)
+        assert result["success"] is True
+        # Aadhaar should be masked (partial)
+        assert "234567890124" not in result["result"]
+        # PAN should be masked (partial)
+        assert "ABCDE1234F" not in result["result"]
+
+    def test_decorator_without_locale_does_not_mask_aadhaar(self) -> None:
+        """Without ``pii_locales=["in"]``, Aadhaar pass-through still works
+        (existing behavior preserved)."""
+        config = AirlockConfig()  # default: pii_locales=[]
+
+        @Airlock(config=config, return_dict=True)
+        def lookup(query: str) -> str:
+            return f"Aadhaar 234567890124 for {query}"
+
+        result = lookup(query="who")
+        assert isinstance(result, dict)
+        assert result["success"] is True
+        # Aadhaar is NOT masked by default
+        assert "234567890124" in result["result"]
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility (existing fixtures keep working)
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardsCompat:
+    """The new ``pii_locales`` arg is optional — old call shapes still work."""
+
+    def test_detect_without_locale(self) -> None:
+        # Existing call shape: just (content, types)
+        detections = detect_sensitive_data("user@example.com", [SensitiveDataType.EMAIL])
+        assert len(detections) == 1
+
+    def test_mask_without_locale(self) -> None:
+        masked, _ = mask_sensitive_data("user@example.com", [SensitiveDataType.EMAIL])
+        assert "@" in masked  # PARTIAL strategy keeps domain
+
+    def test_sanitize_output_without_locale(self) -> None:
+        result = sanitize_output("user@example.com", mask_pii=True)
+        assert result.detection_count >= 1
+
+    def test_existing_aadhaar_tests_unaffected(self) -> None:
+        """The existing test_sanitizer.py tests pass content like
+        'Aadhaar: 2345 6789 0123' and expect 1 detection. The new
+        opt-in must not change that default behavior."""
+        content = "Aadhaar: 2345 6789 0123"  # this is the existing fixture
+        detections = detect_sensitive_data(content, [SensitiveDataType.AADHAAR])
+        # No locale → permissive match (the historical contract).
+        assert len(detections) == 1


### PR DESCRIPTION
## Summary

Aadhaar / PAN / UPI / IFSC have shipped as `SensitiveDataType` members since v0.4.0 — **not duplicated here**. This PR adds the three things that were genuinely missing from the existing surface:

1. **Aadhaar Verhoeff checksum gate.** The existing regex `\b[2-9][0-9]{3}[\s-]?[0-9]{4}[\s-]?[0-9]{4}\b` matches any 12-digit number starting 2-9 — high FP rate on random IDs / phone numbers. With the opt-in, each match must also pass the UIDAI Verhoeff checksum (the same algorithm UIDAI uses to compute the last digit). Cuts FP rate ~10x.
2. **Devanagari personal-name detection** — new `SensitiveDataType.PERSONAL_NAME_DEVANAGARI` member. Regex matches sequences of 2+ Devanagari word characters (Unicode block `U+0900–U+097F`); a small common-noun allowlist (greetings, pronouns, interrogatives, basic connectives, copulas) filters obvious false positives. Conservative heuristic, not NER.
3. **`pii_locales` opt-in tag** on `sanitize_output()` / `mask_sensitive_data()` / `detect_sensitive_data()` / `AirlockConfig`. When `pii_locales=["in"]` is supplied, the two behaviors above activate **and** the India PII types (Aadhaar / PAN / UPI / IFSC / Devanagari) are auto-included in the default `mask_pii=True` set.

**Existing defaults are unchanged.** `pii_locales=[]` (default) preserves bit-for-bit prior behavior — the existing `test_sanitizer.py` 56 tests stay green. No new dependencies, no new masking strategy (reuses the existing FULL / PARTIAL / TYPE_ONLY / HASH).

The `pii_locales` parameter is also accepted via TOML config (`pii_locales = ["in"]` or `pii_locales = "in,us"`).

Version: **0.8.8 → 0.8.9**.

## Test plan

- [x] `pytest tests/ -q --cov=agent_airlock --cov-fail-under=80` — **2601 passed**, coverage **83.69%** (was 2569 before this PR)
- [x] `pytest tests/test_sanitizer.py -q` — **56/56 pass**, no regressions in the existing PII surface
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — no new errors introduced (8 pre-existing repo-wide errors unchanged)
- [x] Smoke import: `from agent_airlock import AirlockConfig; from agent_airlock.sanitizer import SensitiveDataType, _verhoeff_check, sanitize_output` then exercise Aadhaar (Verhoeff valid + invalid) + PAN + Devanagari name through `pii_locales=["in"]`
- [ ] Post-merge: install the published wheel in a fresh venv (`pip install agent-airlock==0.8.9`) and exercise the new opt-in end-to-end before tagging the release as good.

## Fixture corpus

The 32 new tests in `tests/test_indic_pii_masking.py` lock the following behavior:

| Class | Fixtures |
|-------|----------|
| Aadhaar — Verhoeff-valid (must mask under `["in"]`) | `234567890124`, `998877665548`, `345678901238` (synthetic, checksum-verified) |
| Aadhaar — Verhoeff-invalid (must drop under `["in"]`, still match without locale) | `234567890123`, `234567890125`, `345678901230` |
| Aadhaar — separator robustness | `2345 6789 0124`, `2345-6789-0124`, `234567890124` all keep one match |
| Devanagari — names detected | `राम कुमार`, `अमित` |
| Devanagari — common nouns filtered | `नमस्ते`, `मैं और आप` |
| Devanagari — mixed | `नमस्ते राम कुमार` → name span retained |
| Backwards-compat | Existing call shapes without `pii_locales` produce identical results |

🤖 Generated with [Claude Code](https://claude.com/claude-code)