### PR TITLE
feat(0.8.10): MCP Attested Tool-Server Admission preset (RFC arXiv:2605.24248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — MCP Attested Tool-Server Admission preset (v0.8.10)
+
+`mcp_attested_admission_defaults()` — an opt-in deny-by-default preset
+that closes the host-side trust gap left by the MCP spec, per
+[arXiv:2605.24248](https://arxiv.org/abs/2605.24248) ("Attested
+Tool-Server Admission", Metere, May 2026). Before any MCP tool is
+dispatched, the host:
+
+1. **Fetches** a JWS-compact clearance assertion from
+   `{server_url}/.well-known/mcp-clearance` (path configurable via
+   `clearance_well_known_path`). Stdlib `urllib` by default; operators
+   inject a custom `fetcher` callable for mTLS / IPC / on-disk
+   transports.
+2. **Verifies** the offline signature against an **operator-pinned
+   trust root** — Ed25519 PEM, RSA-PSS PEM, or a JWKS (OKP/RSA). The
+   trust root is supplied to `AttestedAdmissionConfig` at process
+   startup and **never network-fetched on the hot path**.
+3. **Admits** the call iff the tool name is in the verified per-server
+   allowlist AND the clearance `sub` matches the dispatched
+   `server_id` — admitting a server is not the same as trusting its
+   every tool. Stale-`iat` and past-`exp` clearances are rejected.
+4. **Emits** every admission decision as a
+   `ReceiptVerdict(guard="mcp_attested_admission", ...)` so the
+   existing `airlock attest` DSSE pipeline picks decisions up
+   unchanged — this preset does **not** invent a new log.
+
+Flavor-gated enforcement: `ENFORCE` (default) hard-denies on missing /
+invalid / expired clearance; `WARN` logs and admits, for staged
+turn-up against real traffic.
+
+Surfaces:
+
+- `agent_airlock.mcp_spec.attested_admission` — new module:
+  - `AttestedAdmissionConfig` dataclass (config surface
+    `clearance_well_known_path`, `trust_root`, `enforcement_mode`,
+    `max_clearance_age`, `fetcher`, `clock`).
+  - `TrustRoot` with `ed25519_pem` / `rsa_pem` / `jwks` (exactly one).
+  - `verify_clearance(blob, cfg) -> AdmittedClearance` — pure-offline
+    JWS verifier.
+  - `admit_tool(...) -> AdmissionDecision` — pure decision function.
+  - `admit_server_tool(...) -> AdmissionDecision` — orchestrator
+    (fetch → verify → admit).
+  - `ClearanceVerificationError` hierarchy
+    (`MissingClearance` / `InvalidClearanceSignature` / `ExpiredClearance` /
+    `MalformedClearance` / `ToolNotAdmitted`).
+- `agent_airlock.policy_presets.mcp_attested_admission_defaults(...)` —
+  named factory, deny-by-default. Listed by `policy_presets.list_active()`.
+- `agent_airlock.mcp_proxy_guard.MCPProxyConfig.attested_admission:
+  AttestedAdmissionConfig | None = None` — new optional field;
+  default `None` preserves v0.8.9 behavior exactly.
+- `MCPProxyGuard.audit_tool_admission(*, server_url, server_id, tool_name)
+  -> AdmissionDecision` — chokepoint that mirrors `audit_response_headers`
+  / `audit_oauth_exchange`: never raises on a deny, always returns the
+  decision.
+
+Failure model: **fail closed.** ENFORCE denies on any verification
+error. Tests cover signed-valid (admit allowlisted / deny
+non-allowlisted), tampered signature, stale `iat`, explicit `exp` in
+past, missing well-known doc, and subject mismatch — under both
+ENFORCE and WARN — plus RSA-PSS and JWKS trust roots and the
+`MCPProxyGuard` integration path.
+
+Packaging:
+
+- New `[attested]` extra in `pyproject.toml`:
+  `pip install "agent-airlock[attested]"` pulls in `cryptography>=42.0`
+  for offline Ed25519 / RSA-PSS verification. The base install stays
+  zero-runtime-dep — the `cryptography` import inside
+  `attested_admission` is lazy and raises a clear actionable error if
+  the extra is missing.
+
+This preset is **strictly opt-in**: existing default presets are
+unchanged. No-pivot: deny-by-default posture stays, zero-runtime-dep
+core stays.
+
 ### Added — Opt-in Indic PII masking: Verhoeff + Devanagari (v0.8.9)
 
 A new `pii_locales` opt-in tag on `sanitize_output()` / `mask_sensitive_data()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,11 @@
 - RBAC policy engine (rate limits, time windows, role-based access)
 - PII/secret detection and masking (12 types including India PII)
 - FastMCP integration with `@secure_tool` decorator
-- V0.3.0: Filesystem validation, network egress control, honeypot deception, framework vaccination
-- V0.4.0: Circuit breaker, cost tracking, retry policies, OpenTelemetry observability, capability gating
-
-**Stats:** ~27,400 lines of code | 1362 tests | 81%+ coverage (enforced at 80% in CI)
-**Version:** 0.5.0 "April 2026"
+- Filesystem validation, network egress control, honeypot deception, framework vaccination ("Vaccine")
+- Circuit breaker, cost tracking, retry policies, OpenTelemetry observability, capability gating ("Enterprise")
+- Anomaly detection, human-oversight gating, identity/attestation, SDK provenance classification
+- Curated security presets (`policy_presets.py` + `preset_loader.py`) and a regression corpus block-rate harness
+- Redis-backed distributed rate limiting and per-model-tier cost budgets
 
 <!-- END AUTO-MANAGED -->
 
@@ -59,55 +59,79 @@ python examples/fastmcp_integration.py
 
 ```
 src/agent_airlock/
-├── __init__.py         # Public API exports (200+ symbols)
-├── core.py             # @Airlock decorator - main entry point (1003 lines)
+├── __init__.py         # Public API exports
+├── core.py             # @Airlock decorator — main entry point
 │                       └─ Ghost args, validation, sandbox, policies, capabilities
 │                       └─ Full async/await support, context propagation
+├── config.py           # Config loading (env > constructor > airlock.toml)
+├── exceptions.py       # Custom exception hierarchy
 │
 ├── ── VALIDATION LAYER ──
 ├── validator.py        # Ghost argument detection + Pydantic strict validation
-├── unknown_args.py     # V0.4.0 BLOCK/STRIP_AND_LOG/STRIP_SILENT modes
+├── unknown_args.py     # BLOCK / STRIP_AND_LOG / STRIP_SILENT modes
 ├── safe_types.py       # SafePath, SafeURL with auto-validation
+├── self_heal.py        # Self-healing error responses with fix_hints
 │
 ├── ── POLICY LAYER ──
 ├── policy.py           # SecurityPolicy, RBAC, RateLimit (token bucket)
-├── capabilities.py     # V0.4.0 Capability gating (Flag enum)
+├── policy_presets.py   # Curated security presets (e.g. CAMOUFLAGE_RESISTANT,
+│                       │   mobile_mcp_intent_guard, MCP_STDIO_INJECTION_GUARD)
+├── preset_loader.py    # Loader for versioned YAML/TOML preset bundles
+├── capabilities.py     # Capability gating (Flag enum, @requires decorator)
+├── oversight.py        # @requires_human_oversight (Code-as-Harness anchor)
+├── identity.py         # Agent identity + attestation receipts
+├── redis_rate_limit.py # Redis-backed distributed rate limiting
 │
 ├── ── EXECUTION LAYER ──
 ├── sandbox.py          # E2B Firecracker MicroVM integration
-├── sandbox_backend.py  # V0.4.0 Pluggable backends (E2B/Docker/Local)
-├── streaming.py        # StreamingAirlock for generators
+├── sandbox_backend.py  # Pluggable backends (E2B / Docker / Local)
+├── streaming.py        # StreamingAirlock for generators (sync + async)
 ├── context.py          # AirlockContext with contextvars
-├── conversation.py     # Multi-turn state tracking
-│
-├── ── SANITIZATION LAYER ──
-├── sanitizer.py        # PII/secret detection (12 types, 4 strategies)
-│
-├── ── V0.3.0 "VACCINE" FEATURES ──
-├── filesystem.py       # Path validation (CVE-resistant)
-├── network.py          # Egress control (socket monkeypatch)
-├── honeypot.py         # Deception protocol (fake success data)
-├── vaccine.py          # Framework injection (LangChain/OpenAI auto-wrap)
-│
-├── ── V0.4.0 "ENTERPRISE" FEATURES ──
-├── circuit_breaker.py  # Fault tolerance pattern (CLOSED/OPEN/HALF_OPEN)
-├── cost_tracking.py    # Token usage + budget limits
+├── conversation.py     # Multi-turn state + conversation constraints
+├── circuit_breaker.py  # Fault tolerance (CLOSED / OPEN / HALF_OPEN)
 ├── retry.py            # Exponential backoff + jitter
-├── observability.py    # OpenTelemetry spans/metrics
-├── audit_otel.py       # OTel audit export
-├── mcp_proxy_guard.py  # Token passthrough prevention
 │
-├── ── INTEGRATIONS ──
-├── integrations/
-│   ├── langchain.py    # LangChain @tool wrapper
-│   ├── anthropic.py    # Anthropic SDK ToolRegistry
-│   └── openai_guardrails.py # OpenAI Agents SDK bridge
+├── ── SANITIZATION / OBSERVABILITY ──
+├── sanitizer.py        # PII / secret detection + masking (incl. Indic PII)
+├── audit.py            # JSON Lines audit log (thread-safe)
+├── audit_otel.py       # OpenTelemetry audit exporter
+├── observability.py    # OTel spans + metrics
+├── cost_tracking.py    # Token usage + per-model-tier budget limits
 │
-├── mcp.py              # FastMCP integration
+├── ── "VACCINE" FEATURES ──
+├── filesystem.py       # CVE-resistant path validation
+├── network.py          # Egress control (socket monkeypatch, thread-local)
+├── honeypot.py         # Deception protocol (fake-success responses)
+├── vaccine.py          # Framework auto-wrap (LangChain / OpenAI @tool)
+├── camouflage_resistant.py  # Debate-amplification + camouflage guard
 │
-└── cli/                # CLI tools
-    ├── doctor.py       # airlock doctor command
-    └── verify.py       # airlock verify command
+├── ── ADVERSARIAL / CORPUS ──
+├── anomaly.py          # Behavioral anomaly detection
+├── regression_corpus.py # Block-rate regression corpus (Metis-inspired)
+├── sdk_provenance.py   # Stainless SDK provenance classifier
+├── a2a.py              # Agent-to-Agent protocol guard
+├── mcp_proxy_guard.py  # Token-passthrough prevention
+├── testing.py          # Test helpers / fixtures
+│
+├── mcp.py              # FastMCP @secure_tool integration
+│
+├── integrations/       # Framework adapters
+│   ├── langchain.py, langgraph_toolnode_compat.py, lc_040_fixture_migration.py
+│   ├── anthropic.py, anthropic_claude_agent_sdk.py
+│   ├── claude_managed_agents.py, managed_agents_outcomes_guard.py
+│   ├── claude_task_budget.py, claude_auto_memory.py
+│   ├── openai_guardrails.py, gpt5_5_tool_shape_adapter.py
+│   ├── gemini3_tool_shape_adapter.py, pydantic_ai.py
+│   ├── crewai.py, smolagents_wrapper.py
+│   ├── model_armor.py, model_tier.py, log_redaction.py
+│   ├── agent_commerce_caps.py
+│   ├── cisco_ide_scanner_bridge.py, cloudflare_mesh_probe.py
+│
+└── cli/                # `airlock <subcommand>` CLI surface
+    ├── doctor.py, verify.py, console.py
+    ├── attest.py, manifest.py, baseline.py, policy.py
+    ├── pack.py, graph.py, replay.py, studio.py
+    ├── corpus_bench.py, egress_bench.py, kill_switch.py
 ```
 
 **Data Flow:**
@@ -161,10 +185,15 @@ src/agent_airlock/
 - **Policy Resolver:** Dynamic policies via `Callable[[AirlockContext], SecurityPolicy]`
 - **Streaming Sanitization:** Per-chunk validation with cumulative truncation
 - **Conversation State:** Multi-turn tracking with budget management (ConversationConstraints)
-- **Circuit Breaker:** CLOSED → OPEN → HALF_OPEN states for fault tolerance (V0.4.0)
-- **Framework Vaccination:** Monkeypatch `@tool` decorators via `vaccinate()` (V0.3.0)
-- **Honeypot Deception:** Return fake success data instead of errors (V0.3.0)
+- **Circuit Breaker:** CLOSED → OPEN → HALF_OPEN states for fault tolerance
+- **Framework Vaccination:** Monkeypatch `@tool` decorators via `vaccinate()`
+- **Honeypot Deception:** Return fake success data instead of errors
 - **Signature Preservation:** Copy `__signature__`, `__annotations__` for framework introspection
+- **Curated Presets:** CVE-targeted bundles loaded via `preset_loader` (e.g. `mobile_mcp_intent_guard_2026_05`)
+- **Human Oversight Anchor:** `@requires_human_oversight` gates tool execution on out-of-band approval
+- **Attestation Receipts:** Identity + LayerContract (assume/guarantee) receipts on `airlock attest`
+- **Regression Corpus:** Block-rate harness with per-category coverage (`airlock corpus-bench`)
+- **Tier-Aware Budgets:** Per-model-tier cost limits with deny-by-default fallback
 
 <!-- END AUTO-MANAGED -->
 
@@ -172,22 +201,31 @@ src/agent_airlock/
 ## Git Insights
 
 Recent commits:
-- `3f02298` fix: resolve additional mypy errors (jwt, langchain)
-- `d754b28` fix: resolve all mypy type errors for CI
-- `c253dd5` fix: resolve all ruff lint errors for CI
-- `1c47174` fix: resolve CI failures - bandit security warnings and import sorting
-- `8a3939e` feat: v0.4.0 "Enterprise" - Production-ready security platform
-- `4b5fe16` feat: v0.2.0 - Security hardening and production roadmap
+- `0be2e57` feat(sanitizer): opt-in Indic PII masking (Verhoeff + Devanagari) (#69)
+- `d7be9ff` feat(presets): mobile_mcp_intent_guard_2026_05 for CVE-2026-35394 (#68)
+- `e98f724` feat(policy): per-model-tier cost budgets with deny-by-default fallback (#67)
+- `7c37e83` feat: CAMOUFLAGE_RESISTANT preset + debate-amplification guard
+- `757f0d7` feat: opt-in LayerContract (assume/guarantee) block on attest receipts (#66)
+- `0d26f98` feat: @requires_human_oversight decorator (Code-as-Harness anchor) (#65)
+- `7a7c17b` feat: Stainless SDK provenance classifier + corpus per-category coverage (#64)
+- `ac7cce2` feat: Metis-inspired corpus block-rate regression + `airlock corpus-bench` CLI (#63)
+- `802f4f9` feat: OpenAPI Drift Guard (Hermes 2026-05-13) + MCP Calc-Server bundle preset (#62)
+- `1c63eae` feat: Eval-RCE (CVE-2026-44717) + MCP Inspector runtime scan (CVE-2026-23744) (#61)
 
 Key security additions:
-- `sandbox_required=True` parameter prevents unsafe local execution fallback
+- `sandbox_required=True` prevents unsafe local execution fallback
 - Sensitive parameter names filtered from debug logs
-- Path validation (CVE-resistant using `os.path.commonpath()`)
+- Path validation (CVE-resistant via `os.path.commonpath()`)
 - Network egress control via socket monkeypatch with thread-local storage
 - Capability gating with `@requires(Capability.*)` decorator
-- Circuit breaker for fault tolerance
-- MCP Proxy Guard for token passthrough prevention
-- OpenTelemetry observability integration
+- `@requires_human_oversight` decorator as a Code-as-Harness anchor
+- Circuit breaker for fault tolerance; MCP Proxy Guard for token passthrough
+- OpenTelemetry observability + audit exporter
+- Curated CVE-targeted presets (mobile MCP intent guard, MCP STDIO injection, OpenAPI drift, MCP Inspector runtime scan, Eval-RCE)
+- Regression corpus block-rate harness (per-category coverage) via `airlock corpus-bench`
+- LayerContract (assume/guarantee) attestation receipts
+- Per-model-tier cost budgets with deny-by-default fallback
+- Stainless SDK provenance classifier
 
 <!-- END AUTO-MANAGED -->
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,76 @@ policy-level knobs span two seams, so the factory returns both as a
 
 ---
 
+### 🪪 MCP server attestation (v0.8.10)
+
+[arXiv:2605.24248](https://arxiv.org/abs/2605.24248) ("Attested
+Tool-Server Admission", Metere, May 2026) calls out a gap MCP itself
+does not close: the protocol standardises *message exchange* between
+LLM agents and tool servers but says nothing about *trust*. Anybody who
+can answer on the wire can declare themselves a tool server.
+
+`mcp_attested_admission_defaults()` is a deny-by-default opt-in preset
+that closes the gap host-side, mirroring the paper's three additive
+mechanisms:
+
+1. **Offline-signed clearance assertion.** Before any tool from an MCP
+   server is dispatched, the host fetches a JWS-compact clearance from
+   `{server_url}/.well-known/mcp-clearance` (path is configurable) and
+   verifies its signature against an **operator-pinned trust root**.
+   The trust root is supplied to `AttestedAdmissionConfig` at process
+   startup — never network-fetched on the hot path.
+2. **Deny-by-default per-server tool allowlist.** Admitting a server
+   is not the same as trusting its every tool. The verified clearance
+   carries an explicit list of tool names the host will permit;
+   everything else is denied. The `sub` claim is matched against the
+   server identity the host is about to dispatch to (so a stolen
+   clearance from server A can't admit a tool call to server B).
+3. **Flavor-gated enforcement.** `ENFORCE` (default) hard-denies on
+   missing / invalid / expired clearance; `WARN` logs and admits — the
+   staged turn-up an operator wants when introducing the gate against
+   real traffic.
+
+Every admission decision emits a
+[`ReceiptVerdict`](./docs/attest/receipt.md) on the
+`guard="mcp_attested_admission"` channel, so the existing `airlock attest`
+DSSE pipeline picks decisions up unchanged — this preset does **not**
+invent a new log.
+
+```python
+from agent_airlock.mcp_proxy_guard import MCPProxyConfig, MCPProxyGuard
+from agent_airlock.mcp_spec.attested_admission import TrustRoot
+from agent_airlock.policy_presets import mcp_attested_admission_defaults
+
+# Operator pins the trust root at startup. Never fetched at runtime.
+with open("/etc/airlock/mcp-clearance-root.pem", "rb") as fh:
+    pinned_pem = fh.read()
+
+cfg = mcp_attested_admission_defaults(
+    trust_root=TrustRoot(key_id="ops-2026Q2", ed25519_pem=pinned_pem),
+    enforcement_mode="ENFORCE",       # deny-by-default
+    max_clearance_age_days=30,
+)
+guard = MCPProxyGuard(MCPProxyConfig(attested_admission=cfg))
+
+decision = guard.audit_tool_admission(
+    server_url="https://mcp.example.com",
+    server_id="srv-alpha",            # expected `sub` claim
+    tool_name="read",
+)
+if not decision.admitted:
+    raise RuntimeError(decision.reason)
+```
+
+Signature verification needs the `[attested]` extra (pulls in
+`cryptography` for offline Ed25519 / RSA-PSS / JWKS verification); the
+base install stays zero-runtime-dep.
+
+> Install with `pip install "agent-airlock[attested]"`. Opt-in only —
+> existing callers that don't set `attested_admission` get exactly
+> v0.8.9 behavior.
+
+---
+
 ### 💰 Cost Control
 
 A runaway agent can burn $500 in API costs before you notice.
@@ -787,7 +857,7 @@ actually prevent the risk.
 |------|------------------------------|-----------------|----------|
 | **ASI01 Agent Goal Hijack** | Pydantic strict validation + ghost-arg rejection + `UnknownArgsMode.BLOCK` | `validator`, `unknown_args`, `core` | Partial |
 | **ASI02 Tool Misuse and Exploitation** | Deny-by-default `SecurityPolicy`, RBAC, rate limits, `SafePath` / `SafeURL`, Flowise `Function()`/`eval` token ban ([CVE-2025-59528](https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/)), MCPwn destructive-auth check ([CVE-2026-33032](https://nvd.nist.gov/vuln/detail/CVE-2026-33032)), Mobile MCP intent-URL guard ([CVE-2026-35394](https://www.sentinelone.com/vulnerability-database/cve-2026-35394/)) | `policy`, `safe_types`, `filesystem`, `network`, `policy_presets.flowise_cve_2025_59528_defaults`, `policy_presets.mcpwn_cve_2026_33032_defaults`, `policy_presets.mobile_mcp_intent_guard_2026_05` | **Full** |
-| **ASI03 Identity and Privilege Abuse** | `AgentIdentity`, `MCPProxyGuard` token-passthrough prevention, `CredentialScope`, OAuth-app audit ([Vercel 2026-04-19](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident)) | `policy`, `mcp_proxy_guard`, `mcp_spec.oauth_audit`, `policy_presets.oauth_audit_vercel_2026_defaults` | Partial |
+| **ASI03 Identity and Privilege Abuse** | `AgentIdentity`, `MCPProxyGuard` token-passthrough prevention, `CredentialScope`, OAuth-app audit ([Vercel 2026-04-19](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident)), MCP Attested Tool-Server Admission ([arXiv:2605.24248](https://arxiv.org/abs/2605.24248)) | `policy`, `mcp_proxy_guard`, `mcp_spec.oauth_audit`, `mcp_spec.attested_admission`, `policy_presets.oauth_audit_vercel_2026_defaults`, `policy_presets.mcp_attested_admission_defaults` | Partial |
 | **ASI04 Agentic Supply Chain Vulnerabilities** | Ox MCP STDIO sanitizer + CVE regression suite (10+ CVEs tracked) + session-snapshot integrity guard | `mcp_spec.stdio_guard`, `mcp_spec.session_guard`, `policy_presets.stdio_guard_ox_defaults`, `tests/cves/` | Partial |
 | **ASI05 Unexpected Code Execution (RCE)** | E2B Firecracker sandbox, pluggable `SandboxBackend`, capability gating for `PROCESS_SHELL`, Flowise eval-token ban ([CVE-2025-59528](https://labs.cloudsecurityalliance.org/research/csa-research-note-flowise-mcp-rce-exploitation-20260409-csa/)) | `sandbox`, `sandbox_backend`, `capabilities`, `policy_presets.flowise_cve_2025_59528_defaults` | **Full** |
 | **ASI06 Memory & Context Poisoning** | `AirlockContext` `contextvars` isolation, `ConversationConstraints` budget caps, audit logging | `context`, `conversation`, `sanitizer` | Partial |
@@ -879,6 +949,7 @@ Agent-Airlock secures AI agent systems in production:
 | [**Stainless SDK provenance classifier**](./docs/policies/stainless-provenance-probe.md) | v0.8.3 — pure-function `classify_sdk_lineage(user_agent, response_body_head)` building block flags MCP servers generated by the deprecated Stainless SDK toolchain (Anthropic acquired Stainless 2026-05-13, hosted generator winding down); operator-callable from own audit hooks — **NOT an automatic HTTP probe** (decorator-in-process architecture, see ROADMAP §1); `stainless_provenance_probe_defaults()` preset is `default_action=tag_only`, visibility not enforcement |
 | [**Human-oversight decorator**](./docs/policies/human-oversight-decorator.md) | v0.8.4 — `@requires_human_oversight(approver=...)` gates a tool function on an operator-supplied approval callable (Code-as-Harness arXiv:2605.18747 anchor); `GRANT` → call wrapped fn, `DENY` → `OversightDeniedError`, `TIMEOUT` → `OversightTimeoutError`; composes with `@Airlock(...)`; protocol shapes + `InProcessRecordedApprover` testing helper; **NOT a bidirectional audit-emitter RPC channel** — operator owns the transport (Slack/PagerDuty/CLI), agent-airlock owns the gate + the protocol |
 | [**Layer-contract receipt block**](./docs/attest/layer-contract.md) | v0.8.5 — opt-in `LayerContract` (assume/guarantee) block on signed `airlock attest receipt` payloads (arXiv:2605.18672 anchor); `--contract` derives per-guard `pass_rate` from the verdicts list, `--assumes id1,id2` declares upstream-layer dependencies; receipt schema v1 unchanged (additive field); `pass_rate` is a measured statistic over the sample (not a proof) — every Guarantee carries `sample_size` so verifiers can weight low-N appropriately; **NOT backed by a window-counter store** (that infrastructure doesn't exist yet — derived from the operator-supplied verdicts list, no new abstraction) |
+| [**MCP Attested Tool-Server Admission (arXiv:2605.24248)**](https://arxiv.org/abs/2605.24248) | v0.8.10 — opt-in admission gate for MCP tool servers per Metere (May 2026). Host fetches a JWS-compact clearance from `{server_url}/.well-known/mcp-clearance`, verifies its signature against an **operator-pinned trust root** (Ed25519 / RSA-PSS / JWKS — never network-fetched on the hot path), and enforces a **deny-by-default per-server tool allowlist** parsed from the verified clearance. Flavor-gated `ENFORCE` (hard-deny) / `WARN` (log only) modes. Every decision emits a `ReceiptVerdict` on the `guard="mcp_attested_admission"` channel — reuses the existing `airlock attest` DSSE path, does **not** invent a new log. `mcp_attested_admission_defaults()` factory + `MCPProxyGuard.audit_tool_admission()` integration; signature verification gated behind `pip install agent-airlock[attested]`. |
 | [**Mobile MCP intent-URL guard (CVE-2026-35394)**](https://www.sentinelone.com/vulnerability-database/cve-2026-35394/) | v0.8.8 — defensive bundle for the Mobilenexthq Mobile MCP `mobile_open_url` intent-injection RCE class (< 0.0.50). `mobile_mcp_intent_guard_2026_05()` returns a pre-configured `SafeURLValidator(allowed_schemes=["http", "https"])` (blocks `intent:`, `content:`, `file:`, `app:`, `data:`, `javascript:`, `vbscript:`), an `AirlockConfig(unknown_args=UnknownArgsMode.BLOCK)`, and the canonical Mobile MCP tool-name corpus (`mobile_open_url`, `open_url`, `mobile_launch_url`). DIFF-COMPATIBLE with the existing `SafeURL` type — no new validator invented. Also fixes a pre-existing `block_private_ips=True` no-op in `SafeURLValidator` (RFC1918 ranges were not actually blocked because the validator's own `SafeURLValidationError` raise was caught by `except ValueError`). |
 | [**Examples**](./examples/) | 13 framework integrations (11 adapter-shipped + 2 example-only) with copy-paste code |
 | [**Security Guide**](./docs/SECURITY.md) | Production deployment checklist |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.9"
+version = "0.8.10"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"
@@ -83,6 +83,14 @@ redis = [
 # Install with: pip install "agent-airlock[crypto]"
 # `cryptography` is the canonical Python ed25519 implementation.
 crypto = [
+    "cryptography>=42.0",
+]
+# MCP Attested Tool-Server Admission (v0.8.10+, RFC arXiv:2605.24248).
+# Install with: pip install "agent-airlock[attested]"
+# Pulls `cryptography` for offline Ed25519 / RSA-PSS verification of
+# JWS-compact clearance assertions. Same lower bound as [crypto]; the
+# two extras can be installed independently or together — pip dedupes.
+attested = [
     "cryptography>=42.0",
 ]
 # PydanticAI canonical-leg adapter (v0.7.1+, ADD-1 2026-05-04).

--- a/scripts/smoke_attested_admission.py
+++ b/scripts/smoke_attested_admission.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Smoke test: pip-install the built wheel + exercise the v0.8.10
+MCP Attested Tool-Server Admission preset end-to-end.
+
+This script intentionally runs *outside* the editable source tree:
+
+1. Builds a wheel via ``python -m build --wheel`` into ``dist/``.
+2. Creates a throwaway venv under ``.smoke-attested-venv/`` (deleted
+   at the end if everything passes; left behind on failure for triage).
+3. Installs ``dist/agent_airlock-<version>-py3-none-any.whl[attested]``
+   into the venv. The ``[attested]`` extra is the surface we care
+   about: it must pull in ``cryptography`` and the preset must be
+   importable from the installed wheel — not the source tree.
+4. Runs a child Python in the venv that:
+   - imports ``mcp_attested_admission_defaults`` from the installed
+     package,
+   - generates an Ed25519 keypair in-process (no key bytes ever
+     touch disk),
+   - signs a JWS-compact clearance covering one tool name,
+   - asserts that a tool *in* the allowlist is admitted,
+   - asserts that a tool *not in* the allowlist is denied with
+     ``verdict == "block"``,
+   - asserts that ENFORCE mode denies a tampered signature.
+
+Exit codes:
+
+  0   all assertions held — the public preset behaves identically
+      against the wheel as it does against the source tree.
+  1   one or more smoke assertions failed.
+  2   environment problem (build failed, venv could not be created,
+      install failed).
+
+The script is **session-local**: it does not modify ``PATH`` or any
+shared state. Run from the repo root with ``python3
+scripts/smoke_attested_admission.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess  # noqa: S404 - intentional, smoke driver
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST_DIR = REPO_ROOT / "dist"
+VENV_DIR = REPO_ROOT / ".smoke-attested-venv"
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    """Run a subprocess; print its argv first so failures are debuggable."""
+    print(f"$ {' '.join(cmd)}", flush=True)
+    subprocess.check_call(cmd, cwd=cwd)  # noqa: S603 - argv pinned by this script
+
+
+def build_wheel() -> Path:
+    """Build a wheel into ``dist/`` and return its path."""
+    DIST_DIR.mkdir(exist_ok=True)
+    # Clear any older wheels so we don't accidentally install a stale build.
+    for old in DIST_DIR.glob("agent_airlock-*.whl"):
+        old.unlink()
+    _run([sys.executable, "-m", "build", "--wheel", "--outdir", str(DIST_DIR)])
+    wheels = sorted(DIST_DIR.glob("agent_airlock-*.whl"))
+    if not wheels:
+        print("ERROR: no wheel produced under dist/", file=sys.stderr)
+        sys.exit(2)
+    return wheels[-1]
+
+
+def make_venv() -> tuple[Path, Path]:
+    """Create a throwaway venv and return (venv_dir, python_path)."""
+    if VENV_DIR.exists():
+        shutil.rmtree(VENV_DIR)
+    _run([sys.executable, "-m", "venv", str(VENV_DIR)])
+    py = VENV_DIR / ("Scripts" if sys.platform == "win32" else "bin") / "python"
+    _run([str(py), "-m", "pip", "install", "--quiet", "--upgrade", "pip"])
+    return VENV_DIR, py
+
+
+def install_wheel(py: Path, wheel: Path) -> None:
+    """Install the wheel with the [attested] extra."""
+    _run(
+        [
+            str(py),
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            f"{wheel}[attested]",
+        ]
+    )
+
+
+CHILD_SMOKE_SCRIPT = textwrap.dedent(
+    """\
+    import base64
+    import json
+    import sys
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    # The whole point: import from the *installed* package, not the source tree.
+    from agent_airlock.mcp_spec.attested_admission import (
+        TrustRoot,
+        admit_tool,
+        verify_clearance,
+    )
+    from agent_airlock.policy_presets import mcp_attested_admission_defaults
+
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+    def sign_clearance(priv: Ed25519PrivateKey, payload: dict) -> bytes:
+        header = {"alg": "EdDSA", "typ": "MCP-CLEARANCE"}
+        h = b64url(json.dumps(header, separators=(",", ":")).encode())
+        p = b64url(json.dumps(payload, separators=(",", ":")).encode())
+        sig = priv.sign(f"{h}.{p}".encode("ascii"))
+        return f"{h}.{p}.{b64url(sig)}".encode("ascii")
+
+
+    def main() -> int:
+        # 1. Generate keypair in-process. No bytes hit disk.
+        priv = Ed25519PrivateKey.generate()
+        pem = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+        # 2. Build the preset config with the freshly generated trust root.
+        cfg = mcp_attested_admission_defaults(
+            trust_root=TrustRoot(key_id="smoke-2026", ed25519_pem=pem),
+            enforcement_mode="ENFORCE",
+            max_clearance_age_days=30,
+        )
+
+        # 3. Sign a clearance with exactly one admitted tool.
+        now = int(datetime.now(tz=timezone.utc).timestamp())
+        blob = sign_clearance(priv, {
+            "iss": "https://mcp.smoke.test",
+            "sub": "srv-smoke",
+            "iat": now,
+            "tools": ["read"],
+        })
+
+        # 4a. Verify + admit the allowlisted tool.
+        clearance = verify_clearance(blob, cfg)
+        decision_ok = admit_tool(
+            server_id="srv-smoke",
+            tool_name="read",
+            clearance=clearance,
+            cfg=cfg,
+        )
+        if not decision_ok.admitted:
+            print(f"FAIL: allowlisted tool was denied: {decision_ok.reason}",
+                  file=sys.stderr)
+            return 1
+        if decision_ok.verdict.verdict != "allow":
+            print(f"FAIL: expected verdict='allow', got "
+                  f"{decision_ok.verdict.verdict!r}", file=sys.stderr)
+            return 1
+
+        # 4b. Deny a tool that is NOT in the verified allowlist.
+        decision_no = admit_tool(
+            server_id="srv-smoke",
+            tool_name="write",
+            clearance=clearance,
+            cfg=cfg,
+        )
+        if decision_no.admitted:
+            print("FAIL: non-allowlisted tool was admitted", file=sys.stderr)
+            return 1
+        if decision_no.verdict.verdict != "block":
+            print(f"FAIL: expected verdict='block', got "
+                  f"{decision_no.verdict.verdict!r}", file=sys.stderr)
+            return 1
+        if "tool_not_in_allowlist" not in decision_no.reason:
+            print(f"FAIL: expected reason to cite allowlist; got "
+                  f"{decision_no.reason!r}", file=sys.stderr)
+            return 1
+
+        # 4c. Tampered signature → ENFORCE denies via verify_clearance raising.
+        h, p, s = blob.decode().split(".")
+        tampered_p = ("A" + p[1:]) if p[0] != "A" else ("B" + p[1:])
+        tampered = f"{h}.{tampered_p}.{s}".encode()
+        try:
+            verify_clearance(tampered, cfg)
+        except Exception as exc:
+            kind = type(exc).__name__
+            if kind not in {"InvalidClearanceSignature", "MalformedClearance"}:
+                print(f"FAIL: unexpected verifier exception {kind}: {exc}",
+                      file=sys.stderr)
+                return 1
+        else:
+            print("FAIL: tampered clearance did not raise", file=sys.stderr)
+            return 1
+
+        # Print the receipt verdict shape so the smoke output is useful
+        # to a human eyeballing CI.
+        print(f"OK: admit verdict={decision_ok.verdict.verdict!r} "
+              f"fingerprint={decision_ok.clearance_fingerprint[:16]}...")
+        print(f"OK: deny  verdict={decision_no.verdict.verdict!r} "
+              f"reason={decision_no.reason!r}")
+        print("OK: tampered signature rejected by verify_clearance")
+        return 0
+
+
+    sys.exit(main())
+    """
+)
+
+
+def run_child_smoke(py: Path) -> int:
+    """Run the child smoke script under the installed-wheel interpreter."""
+    print("$ <venv-python> -c <SMOKE>", flush=True)
+    proc = subprocess.run(  # noqa: S603 - argv pinned
+        [str(py), "-c", CHILD_SMOKE_SCRIPT],
+        check=False,
+    )
+    return proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep-venv",
+        action="store_true",
+        help="Don't delete .smoke-attested-venv/ on success "
+        "(default: deleted on success, kept on failure).",
+    )
+    args = parser.parse_args()
+
+    try:
+        wheel = build_wheel()
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: wheel build failed: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        _venv, py = make_venv()
+        install_wheel(py, wheel)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: venv setup failed: {exc}", file=sys.stderr)
+        return 2
+
+    rc = run_child_smoke(py)
+    if rc == 0 and not args.keep_venv:
+        shutil.rmtree(VENV_DIR, ignore_errors=True)
+    elif rc != 0:
+        print(
+            f"\nSmoke failed (rc={rc}). Venv left at {VENV_DIR} for triage.",
+            file=sys.stderr,
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent_airlock/mcp_proxy_guard.py
+++ b/src/agent_airlock/mcp_proxy_guard.py
@@ -32,6 +32,7 @@ import structlog
 from .policy import StdioGuardConfig
 
 if TYPE_CHECKING:
+    from .mcp_spec.attested_admission import AdmissionDecision, AttestedAdmissionConfig
     from .mcp_spec.header_audit import ResponseHeaderAuditConfig
     from .mcp_spec.oauth_audit import OAuthAppAuditConfig, OAuthAuditReport
 
@@ -152,6 +153,14 @@ class MCPProxyConfig:
     # delegates to ``agent_airlock.mcp_spec.header_audit.audit_response_headers``.
     # Default None preserves v0.5.2 behavior.
     response_header_audit: ResponseHeaderAuditConfig | None = None
+
+    # V0.8.10 MCP Attested Tool-Server Admission (RFC arXiv:2605.24248).
+    # When set, ``MCPProxyGuard.audit_tool_admission()`` runs the
+    # fetch → verify → admit pipeline against ``cfg.trust_root`` before
+    # any tool dispatch. Deny-by-default per-server allowlist; the
+    # ``WARN``/``ENFORCE`` flavor gate is carried on the config. Default
+    # None preserves v0.8.9 behavior — no admission check, no new logs.
+    attested_admission: AttestedAdmissionConfig | None = None
 
 
 @dataclass
@@ -699,6 +708,53 @@ class MCPProxyGuard:
         from .mcp_spec.stdio_guard import validate_stdio_command
 
         validate_stdio_command(cmd, self.config.stdio_guard)
+
+    def audit_tool_admission(
+        self,
+        *,
+        server_url: str,
+        server_id: str,
+        tool_name: str,
+    ) -> AdmissionDecision:
+        """Run the MCP attested-admission pipeline before tool dispatch.
+
+        Mirrors the pattern of :meth:`audit_response_headers` /
+        :meth:`audit_oauth_exchange`: never raises on a deny, always
+        returns the :class:`AdmissionDecision`. Callers decide whether
+        to dispatch the tool based on :attr:`AdmissionDecision.admitted`.
+
+        The returned decision carries a :class:`ReceiptVerdict` ready to
+        be appended to the existing ``airlock attest`` DSSE pipeline; no
+        new log file is created here.
+
+        Args:
+            server_url: Origin of the MCP server (used to fetch the
+                clearance from ``cfg.clearance_well_known_path``).
+            server_id: Expected ``sub`` claim of the verified clearance.
+            tool_name: MCP tool being invoked.
+
+        Returns:
+            :class:`AdmissionDecision` from
+            :func:`agent_airlock.mcp_spec.attested_admission.admit_server_tool`.
+
+        Raises:
+            MCPSecurityError: If no ``attested_admission`` is configured.
+        """
+        if self.config.attested_admission is None:
+            raise MCPSecurityError(
+                "attested_admission is not configured on this MCPProxyGuard",
+                violation_type="attested_admission_not_configured",
+            )
+        # Local import to keep the new feature opt-in (avoids pulling
+        # in the [attested] extra at module import time).
+        from .mcp_spec.attested_admission import admit_server_tool
+
+        return admit_server_tool(
+            server_url=server_url,
+            server_id=server_id,
+            tool_name=tool_name,
+            cfg=self.config.attested_admission,
+        )
 
     def cleanup_expired_sessions(self) -> int:
         """Remove expired sessions.

--- a/src/agent_airlock/mcp_spec/attested_admission.py
+++ b/src/agent_airlock/mcp_spec/attested_admission.py
@@ -1,0 +1,673 @@
+"""MCP Attested Tool-Server Admission (RFC arXiv:2605.24248).
+
+Implements the three additive mechanisms described in Metere (May 2026):
+
+1. **Offline-signed clearance assertion** — server publishes a JWS-compact
+   token at a well-known URI (default ``/.well-known/mcp-clearance``); the
+   host verifies the signature against a **pinned trust root** before any
+   tool dispatch. The trust root is supplied by the operator and is never
+   network-fetched on the hot path.
+2. **Deny-by-default per-server tool allowlist** — admitting a server is
+   not the same as trusting its every tool. The verified clearance carries
+   an explicit list of tool names the host will permit; everything else
+   is denied.
+3. **Flavor-gated enforcement** — ``WARN`` (log only, admit) vs ``ENFORCE``
+   (hard deny on missing / invalid / expired clearance).
+
+Every admission decision is emitted as an
+:class:`agent_airlock.attest.ReceiptVerdict` on the
+``guard="mcp_attested_admission"`` channel, so the existing
+``airlock attest`` DSSE pipeline picks the verdicts up unchanged — this
+module does **not** invent a new log.
+
+Failure model: **fail closed.** If ``enforcement_mode == ENFORCE`` and the
+clearance is absent, malformed, has an invalid signature, or is stale beyond
+``max_clearance_age`` (or has a past ``exp``), the admission is denied.
+``WARN`` mode emits the same verdict tagged ``"warn"`` and admits.
+
+This module requires the ``[attested]`` extra
+(``pip install agent-airlock[attested]``) for the offline asymmetric
+verifier (Ed25519 / RSA-PSS over JWS-compact via ``cryptography``). The
+crypto bindings are imported lazily inside :func:`verify_clearance` so the
+base install stays zero-runtime-dep.
+
+References
+----------
+- Metere, A. *Attested Tool-Server Admission: A Security Extension to the
+  Model Context Protocol.* arXiv:2605.24248 (2026).
+  https://arxiv.org/abs/2605.24248
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from typing import Any, Literal
+
+import structlog
+
+from ..attest.receipt import ReceiptVerdict, ReceiptVerdictKind
+from ..exceptions import AirlockError
+
+logger = structlog.get_logger("agent-airlock.mcp_spec.attested_admission")
+
+
+EnforcementMode = Literal["WARN", "ENFORCE"]
+"""Flavor gate from the RFC. ``ENFORCE`` denies on missing/invalid/expired
+clearance; ``WARN`` admits with a logged warning."""
+
+
+DEFAULT_WELL_KNOWN_PATH = "/.well-known/mcp-clearance"
+DEFAULT_MAX_AGE = timedelta(days=30)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ClearanceVerificationError(AirlockError):
+    """Base for any clearance-verification failure."""
+
+
+class MissingClearance(ClearanceVerificationError):
+    """Server returned no document at the well-known URI."""
+
+
+class InvalidClearanceSignature(ClearanceVerificationError):
+    """The offline signature failed verification against the pinned trust root."""
+
+
+class ExpiredClearance(ClearanceVerificationError):
+    """The clearance ``iat`` is older than ``max_clearance_age``, or
+    ``exp`` is in the past."""
+
+
+class MalformedClearance(ClearanceVerificationError):
+    """The clearance document failed schema validation."""
+
+
+class ToolNotAdmitted(ClearanceVerificationError):
+    """The tool name is not in the verified per-server allowlist.
+
+    Reserved for callers that prefer to raise on deny rather than read
+    :attr:`AdmissionDecision.admitted` — :func:`admit_tool` itself returns
+    a decision and never raises this.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Config + result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrustRoot:
+    """Pinned public-key material used to verify clearance signatures.
+
+    Exactly one of ``ed25519_pem`` / ``rsa_pem`` / ``jwks`` must be set.
+    Network resolution of trust roots is **not** supported — the entire
+    point of a pinned root is that it cannot be substituted at runtime.
+
+    Attributes:
+        key_id: Operator-chosen identifier for this trust root. Recorded
+            in audit verdicts so reviewers can correlate a verified
+            decision to the key that signed it.
+        ed25519_pem: PEM-encoded Ed25519 public key
+            (PKCS#8 SubjectPublicKeyInfo).
+        rsa_pem: PEM-encoded RSA public key
+            (PKCS#8 SubjectPublicKeyInfo).
+        jwks: A JWKS-shaped mapping (``{"keys": [...]}``). The first key
+            entry is used. Supported ``kty`` values: ``OKP`` (Ed25519) and
+            ``RSA``.
+    """
+
+    key_id: str
+    ed25519_pem: bytes | None = None
+    rsa_pem: bytes | None = None
+    jwks: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        chosen = sum(1 for x in (self.ed25519_pem, self.rsa_pem, self.jwks) if x is not None)
+        if chosen != 1:
+            raise ValueError("TrustRoot: exactly one of ed25519_pem, rsa_pem, jwks must be set")
+
+
+@dataclass(frozen=True)
+class AttestedAdmissionConfig:
+    """Operator-facing configuration for the attested-admission preset.
+
+    Construct one per host process and pin it for the lifetime of that
+    process — rotating trust roots at runtime is a deliberate operation
+    that should re-construct this object.
+
+    Attributes:
+        trust_root: Pinned public-key material (PEM or JWKS). Required
+            for any actual verification call; can be left ``None`` only on
+            placeholder configs.
+        clearance_well_known_path: URI path the host fetches relative to
+            each MCP server's origin. Defaults to
+            ``/.well-known/mcp-clearance``.
+        enforcement_mode: ``ENFORCE`` (deny on missing/invalid/expired)
+            or ``WARN`` (log only, admit).
+        max_clearance_age: Clearance is considered fresh iff
+            ``now() - iat <= max_clearance_age``.
+        fetcher: Optional callable ``(server_url, path) -> bytes`` that
+            injects a custom transport — used by tests and air-gapped
+            operators who load clearances from disk. Falls back to the
+            stdlib HTTPS fetcher when ``None``.
+        clock: Optional ``() -> datetime`` for deterministic tests.
+            Falls back to ``datetime.now(timezone.utc)``.
+    """
+
+    trust_root: TrustRoot | None = None
+    clearance_well_known_path: str = DEFAULT_WELL_KNOWN_PATH
+    enforcement_mode: EnforcementMode = "ENFORCE"
+    max_clearance_age: timedelta = DEFAULT_MAX_AGE
+    fetcher: Callable[[str, str], bytes] | None = None
+    clock: Callable[[], datetime] | None = None
+
+    def __post_init__(self) -> None:
+        if self.enforcement_mode not in ("WARN", "ENFORCE"):
+            raise ValueError(
+                f"enforcement_mode must be 'WARN' or 'ENFORCE'; got {self.enforcement_mode!r}"
+            )
+        if self.max_clearance_age <= timedelta(0):
+            raise ValueError("max_clearance_age must be a positive timedelta")
+
+
+@dataclass(frozen=True)
+class AdmittedClearance:
+    """Output of :func:`verify_clearance` — a parsed + verified clearance.
+
+    Attributes:
+        server_id: The ``sub`` claim from the verified payload.
+        issuer: The ``iss`` claim.
+        iat: Parsed issued-at as a UTC :class:`datetime`.
+        exp: Parsed expiry, or ``None`` if the clearance carried no ``exp``.
+        allowed_tools: The verified per-server tool allowlist.
+        fingerprint: SHA-256 hex of the raw clearance bytes. Recorded in
+            every verdict so an auditor can correlate a decision to the
+            exact bytes that produced it.
+        raw: The full decoded payload, retained for debugging.
+    """
+
+    server_id: str
+    issuer: str
+    iat: datetime
+    exp: datetime | None
+    allowed_tools: frozenset[str]
+    fingerprint: str
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """Result of admitting one tool against a verified clearance."""
+
+    admitted: bool
+    server_id: str
+    tool_name: str
+    reason: str
+    clearance_fingerprint: str | None
+    verdict: ReceiptVerdict
+
+    def as_log_fields(self) -> dict[str, Any]:
+        """Return a flat dict suitable for structlog ``logger.info(**fields)``."""
+        return {
+            "guard": "mcp_attested_admission",
+            "admitted": self.admitted,
+            "server_id": self.server_id,
+            "tool_name": self.tool_name,
+            "reason": self.reason,
+            "clearance_fingerprint": self.clearance_fingerprint,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Fetcher (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+def _default_fetcher(server_url: str, path: str) -> bytes:
+    """Fetch the clearance document from ``{server_url}{path}`` over HTTPS.
+
+    Stdlib-only — uses :mod:`urllib.request`. Operators who need a custom
+    transport (mTLS, IPC, on-disk) inject a ``fetcher`` callable on
+    :class:`AttestedAdmissionConfig` instead.
+
+    Raises:
+        MissingClearance: 404/410 or any connection error.
+    """
+    url = server_url.rstrip("/") + path
+    try:
+        # URL is operator-pinned via AttestedAdmissionConfig at config
+        # time (operator supplies the MCP server origin + well-known
+        # path), not arbitrary user input — the scheme allowlist is the
+        # operator's responsibility to configure. Bandit B310 / ruff S310
+        # are both false-positives here.
+        with urllib.request.urlopen(url, timeout=5.0) as resp:  # noqa: S310  # nosec B310 - operator-pinned URL, not user input
+            return resp.read()  # type: ignore[no-any-return]
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 410):
+            raise MissingClearance(f"server {server_url} has no clearance document") from exc
+        raise MissingClearance(f"clearance fetch failed: HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise MissingClearance(f"clearance fetch failed: {exc.reason}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+
+def _b64url_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def _fingerprint(blob: bytes) -> str:
+    """SHA-256 hex of the raw clearance bytes."""
+    return sha256(blob).hexdigest()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _load_pubkey(trust_root: TrustRoot) -> Any:
+    """Lazily import ``cryptography`` and return a verifying-key object.
+
+    Raises:
+        RuntimeError: ``cryptography`` is not installed. Operators must
+            ``pip install agent-airlock[attested]``.
+    """
+    try:
+        from cryptography.hazmat.primitives.serialization import (
+            load_pem_public_key,
+        )
+    except ImportError as exc:  # pragma: no cover - env-level guard
+        raise RuntimeError(
+            "agent-airlock[attested] extra not installed; run "
+            "`pip install agent-airlock[attested]` to enable MCP "
+            "attested-admission signature verification"
+        ) from exc
+
+    if trust_root.ed25519_pem is not None:
+        return load_pem_public_key(trust_root.ed25519_pem)
+    if trust_root.rsa_pem is not None:
+        return load_pem_public_key(trust_root.rsa_pem)
+
+    # JWKS path — pick the first key and decode it into a cryptography
+    # public-key object.
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+
+    assert trust_root.jwks is not None  # noqa: S101  # nosec B101 - guarded by TrustRoot.__post_init__ (exactly one of three key fields is non-None)
+    key_entries = trust_root.jwks.get("keys") or []
+    if not key_entries:
+        raise ValueError("JWKS trust root has no keys")
+    jwk = key_entries[0]
+    kty = jwk.get("kty")
+    if kty == "OKP":
+        return Ed25519PublicKey.from_public_bytes(_b64url_decode(jwk["x"]))
+    if kty == "RSA":
+        n = int.from_bytes(_b64url_decode(jwk["n"]), "big")
+        e = int.from_bytes(_b64url_decode(jwk["e"]), "big")
+        return RSAPublicNumbers(e=e, n=n).public_key()
+    raise ValueError(f"unsupported JWKS key type: {kty!r}")
+
+
+def _verify_signature(public_key: Any, signed_bytes: bytes, signature: bytes) -> None:
+    """Verify a JWS-style signature using the loaded public key.
+
+    Ed25519: plain ``public_key.verify(sig, msg)``.
+    RSA: PSS with MGF1-SHA256 and ``salt_length=PSS.MAX_LENGTH`` — matches
+    the JOSE ``PS256`` profile.
+
+    Raises:
+        InvalidClearanceSignature: signature does not validate.
+    """
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        from cryptography.hazmat.primitives.asymmetric.padding import MGF1, PSS
+        from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+    except ImportError as exc:  # pragma: no cover - env-level guard
+        raise RuntimeError("agent-airlock[attested] extra not installed") from exc
+
+    try:
+        if isinstance(public_key, Ed25519PublicKey):
+            public_key.verify(signature, signed_bytes)
+        elif isinstance(public_key, RSAPublicKey):
+            public_key.verify(
+                signature,
+                signed_bytes,
+                PSS(mgf=MGF1(hashes.SHA256()), salt_length=PSS.MAX_LENGTH),
+                hashes.SHA256(),
+            )
+        else:
+            raise ValueError(f"unsupported public key type: {type(public_key).__name__}")
+    except InvalidSignature as exc:
+        raise InvalidClearanceSignature("clearance signature did not verify") from exc
+
+
+def verify_clearance(
+    blob: bytes,
+    cfg: AttestedAdmissionConfig,
+) -> AdmittedClearance:
+    """Parse + verify a JWS-compact clearance document.
+
+    Expected payload shape (JSON, base64url-encoded as the JWS body)::
+
+        {
+          "iss": "https://mcp.example.com",
+          "sub": "<server-id>",
+          "iat": <unix-ts>,
+          "exp": <unix-ts>,          # optional
+          "tools": ["read", "search"]
+        }
+
+    Args:
+        blob: Raw bytes returned by the fetcher. Must be a JWS-compact
+            token (``header.payload.signature``, base64url segments).
+        cfg: Configuration carrying the pinned trust root + max age.
+
+    Raises:
+        MalformedClearance: bad encoding / missing required claims /
+            no trust root configured.
+        InvalidClearanceSignature: signature did not verify.
+        ExpiredClearance: clearance is older than ``max_clearance_age``,
+            or ``exp`` is in the past.
+    """
+    if cfg.trust_root is None:
+        raise MalformedClearance(
+            "AttestedAdmissionConfig has no trust_root; cannot verify clearance"
+        )
+
+    try:
+        text = blob.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as exc:
+        raise MalformedClearance("clearance bytes are not valid UTF-8") from exc
+    parts = text.split(".")
+    if len(parts) != 3:
+        raise MalformedClearance("clearance is not a JWS compact token")
+    header_b64, payload_b64, sig_b64 = parts
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+        payload = json.loads(_b64url_decode(payload_b64))
+        signature = _b64url_decode(sig_b64)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise MalformedClearance(f"clearance encoding invalid: {exc}") from exc
+
+    if not isinstance(header, dict):
+        raise MalformedClearance("clearance header is not a JSON object")
+    if not isinstance(payload, dict):
+        raise MalformedClearance("clearance payload is not a JSON object")
+
+    public_key = _load_pubkey(cfg.trust_root)
+    signed = f"{header_b64}.{payload_b64}".encode("ascii")
+    _verify_signature(public_key, signed, signature)
+
+    # Schema checks (post-signature so an attacker can't probe schema by
+    # crafting unsigned payloads).
+    sub = payload.get("sub")
+    iss = payload.get("iss")
+    iat = payload.get("iat")
+    tools = payload.get("tools")
+    if not isinstance(sub, str) or not sub:
+        raise MalformedClearance("clearance missing string 'sub'")
+    if not isinstance(iss, str) or not iss:
+        raise MalformedClearance("clearance missing string 'iss'")
+    if not isinstance(iat, (int, float)):
+        raise MalformedClearance("clearance missing numeric 'iat'")
+    if not isinstance(tools, list) or not all(isinstance(t, str) for t in tools):
+        raise MalformedClearance("clearance 'tools' must be a list of strings")
+
+    now = (cfg.clock or _utcnow)()
+    iat_dt = datetime.fromtimestamp(float(iat), tz=timezone.utc)
+    if (now - iat_dt) > cfg.max_clearance_age:
+        raise ExpiredClearance(
+            f"clearance issued at {iat_dt.isoformat()} is older than "
+            f"max_clearance_age={cfg.max_clearance_age}"
+        )
+    exp_val = payload.get("exp")
+    exp_dt: datetime | None = None
+    if isinstance(exp_val, (int, float)):
+        exp_dt = datetime.fromtimestamp(float(exp_val), tz=timezone.utc)
+        if exp_dt < now:
+            raise ExpiredClearance(f"clearance expired at {exp_dt.isoformat()}")
+
+    return AdmittedClearance(
+        server_id=sub,
+        issuer=iss,
+        iat=iat_dt,
+        exp=exp_dt,
+        allowed_tools=frozenset(tools),
+        fingerprint=_fingerprint(blob),
+        raw=payload,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admission
+# ---------------------------------------------------------------------------
+
+
+def _verdict(
+    *,
+    admitted: bool,
+    server_id: str,
+    tool_name: str,
+    reason: str,
+    fingerprint: str | None,
+    warn: bool,
+) -> ReceiptVerdict:
+    """Build the per-decision :class:`ReceiptVerdict`.
+
+    ``warn`` is true only when the config is in WARN mode AND the
+    decision would otherwise have been a deny — that's the only case in
+    which the verdict kind differs from a plain allow/block.
+    """
+    kind: ReceiptVerdictKind = "warn" if warn else ("allow" if admitted else "block")
+    return ReceiptVerdict(
+        guard="mcp_attested_admission",
+        verdict=kind,
+        tool_name=f"{server_id}:{tool_name}",
+        detail=f"reason={reason}; clearance_fp={fingerprint or '<none>'}",
+    )
+
+
+def admit_tool(
+    *,
+    server_id: str,
+    tool_name: str,
+    clearance: AdmittedClearance | None,
+    cfg: AttestedAdmissionConfig,
+    error: ClearanceVerificationError | None = None,
+) -> AdmissionDecision:
+    """Decide whether ``tool_name`` from ``server_id`` may run.
+
+    Pure function — no I/O, no audit emission. Callers (e.g.
+    ``MCPProxyGuard``) are responsible for logging the returned
+    :attr:`AdmissionDecision.verdict` through the existing audit / attest
+    pipeline.
+
+    Args:
+        server_id: The MCP server identity the host is dispatching to.
+            Compared to the verified clearance's ``sub`` claim.
+        tool_name: The MCP tool being invoked.
+        clearance: The result of :func:`verify_clearance`, or ``None`` if
+            verification failed.
+        cfg: The runtime config (used for ``enforcement_mode``).
+        error: If ``clearance`` is ``None``, the verification error that
+            explains why; used to build the deny reason. Ignored when
+            ``clearance`` is not ``None``.
+
+    Returns:
+        :class:`AdmissionDecision` — ``admitted`` is True iff the
+        clearance verified and the tool is in the allowlist, OR the
+        config is in ``WARN`` mode.
+    """
+    warn_mode = cfg.enforcement_mode == "WARN"
+
+    if clearance is None:
+        reason = (
+            f"clearance_verification_failed: {type(error).__name__}: {error}"
+            if error is not None
+            else "clearance_unavailable"
+        )
+        admitted = warn_mode  # WARN admits, ENFORCE denies
+        return AdmissionDecision(
+            admitted=admitted,
+            server_id=server_id,
+            tool_name=tool_name,
+            reason=reason,
+            clearance_fingerprint=None,
+            verdict=_verdict(
+                admitted=admitted,
+                server_id=server_id,
+                tool_name=tool_name,
+                reason=reason,
+                fingerprint=None,
+                warn=warn_mode,  # the "would-have-denied" case
+            ),
+        )
+
+    if clearance.server_id != server_id:
+        reason = (
+            f"clearance_subject_mismatch: clearance sub={clearance.server_id!r} "
+            f"!= dispatched server_id={server_id!r}"
+        )
+        admitted = warn_mode
+        return AdmissionDecision(
+            admitted=admitted,
+            server_id=server_id,
+            tool_name=tool_name,
+            reason=reason,
+            clearance_fingerprint=clearance.fingerprint,
+            verdict=_verdict(
+                admitted=admitted,
+                server_id=server_id,
+                tool_name=tool_name,
+                reason=reason,
+                fingerprint=clearance.fingerprint,
+                warn=warn_mode,
+            ),
+        )
+
+    if tool_name not in clearance.allowed_tools:
+        reason = f"tool_not_in_allowlist: {tool_name!r} not in {sorted(clearance.allowed_tools)!r}"
+        admitted = warn_mode
+        return AdmissionDecision(
+            admitted=admitted,
+            server_id=server_id,
+            tool_name=tool_name,
+            reason=reason,
+            clearance_fingerprint=clearance.fingerprint,
+            verdict=_verdict(
+                admitted=admitted,
+                server_id=server_id,
+                tool_name=tool_name,
+                reason=reason,
+                fingerprint=clearance.fingerprint,
+                warn=warn_mode,
+            ),
+        )
+
+    # Happy path — admitted by the verified allowlist.
+    return AdmissionDecision(
+        admitted=True,
+        server_id=server_id,
+        tool_name=tool_name,
+        reason="admitted_by_allowlist",
+        clearance_fingerprint=clearance.fingerprint,
+        verdict=_verdict(
+            admitted=True,
+            server_id=server_id,
+            tool_name=tool_name,
+            reason="admitted_by_allowlist",
+            fingerprint=clearance.fingerprint,
+            warn=False,
+        ),
+    )
+
+
+def admit_server_tool(
+    *,
+    server_url: str,
+    server_id: str,
+    tool_name: str,
+    cfg: AttestedAdmissionConfig,
+) -> AdmissionDecision:
+    """High-level orchestrator: fetch → verify → admit.
+
+    Convenience wrapper that runs the full pipeline against a config. On
+    any verification error, falls through to :func:`admit_tool` with
+    ``clearance=None`` so the WARN/ENFORCE gate still fires.
+
+    Args:
+        server_url: Origin to fetch the clearance from (e.g.
+            ``"https://mcp.example.com"``).
+        server_id: Expected ``sub`` claim — usually a stable server identity.
+        tool_name: MCP tool being invoked.
+        cfg: Operator-pinned configuration.
+    """
+    fetcher = cfg.fetcher or _default_fetcher
+    err: ClearanceVerificationError | None = None
+    clearance: AdmittedClearance | None = None
+    try:
+        blob = fetcher(server_url, cfg.clearance_well_known_path)
+        clearance = verify_clearance(blob, cfg)
+    except ClearanceVerificationError as exc:
+        err = exc
+        logger.warning(
+            "attested_admission.verification_failed",
+            server_url=server_url,
+            server_id=server_id,
+            error_type=type(exc).__name__,
+            error=str(exc),
+            mode=cfg.enforcement_mode,
+        )
+
+    decision = admit_tool(
+        server_id=server_id,
+        tool_name=tool_name,
+        clearance=clearance,
+        cfg=cfg,
+        error=err,
+    )
+    logger.info(
+        "attested_admission.decision",
+        mode=cfg.enforcement_mode,
+        **decision.as_log_fields(),
+    )
+    return decision
+
+
+__all__ = [
+    "DEFAULT_MAX_AGE",
+    "DEFAULT_WELL_KNOWN_PATH",
+    "AdmissionDecision",
+    "AdmittedClearance",
+    "AttestedAdmissionConfig",
+    "ClearanceVerificationError",
+    "EnforcementMode",
+    "ExpiredClearance",
+    "InvalidClearanceSignature",
+    "MalformedClearance",
+    "MissingClearance",
+    "ToolNotAdmitted",
+    "TrustRoot",
+    "admit_server_tool",
+    "admit_tool",
+    "verify_clearance",
+]

--- a/src/agent_airlock/policy_presets.py
+++ b/src/agent_airlock/policy_presets.py
@@ -513,6 +513,76 @@ STDIO_GUARD_OX_DEFAULTS = stdio_guard_ox_defaults()
 constant unless you need dynamic overrides (then call the factory)."""
 
 
+def mcp_attested_admission_defaults(
+    *,
+    trust_root: Any = None,
+    enforcement_mode: str = "ENFORCE",
+    max_clearance_age_days: int = 30,
+    clearance_well_known_path: str = "/.well-known/mcp-clearance",
+) -> Any:
+    """MCP Attested Tool-Server Admission preset (RFC arXiv:2605.24248).
+
+    Returns a deny-by-default ``AttestedAdmissionConfig`` that gates
+    every MCP tool dispatch on a clearance assertion fetched from
+    ``{server_url}{clearance_well_known_path}`` and verified offline
+    against ``trust_root``. The verified clearance carries a per-server
+    tool allowlist; tools outside the allowlist are denied — admitting
+    a server is not the same as trusting its every tool.
+
+    Failure model: **fail closed.** In ``ENFORCE`` mode (default), a
+    missing / invalid / expired clearance denies. In ``WARN`` mode the
+    same case is logged and admitted, so operators can stage the
+    enforcement turn-up against real traffic.
+
+    Every admission decision emits a
+    :class:`agent_airlock.attest.ReceiptVerdict` on the
+    ``guard="mcp_attested_admission"`` channel, so the existing
+    ``airlock attest`` DSSE pipeline picks decisions up unchanged.
+
+    This preset is **opt-in**: pass the returned config to
+    :class:`agent_airlock.mcp_proxy_guard.MCPProxyConfig` via the
+    ``attested_admission`` field, then call
+    :meth:`MCPProxyGuard.audit_tool_admission` before each tool dispatch.
+    Existing callers are unaffected.
+
+    Signature verification requires the ``[attested]`` extra
+    (``pip install agent-airlock[attested]``). The extra pulls in
+    ``cryptography`` for offline Ed25519 / RSA-PSS verification; the
+    base install stays zero-runtime-dep.
+
+    Args:
+        trust_root: A
+            :class:`agent_airlock.mcp_spec.attested_admission.TrustRoot`
+            holding pinned public-key material. ``None`` produces a
+            placeholder config that will refuse to verify anything —
+            operators are expected to supply a real trust root.
+        enforcement_mode: ``"ENFORCE"`` (deny on missing/invalid/expired)
+            or ``"WARN"`` (log only, admit).
+        max_clearance_age_days: Clearance is considered fresh iff
+            ``now() - iat <= max_clearance_age_days``. Defaults to 30
+            days, matching the RFC's recommended rotation window.
+        clearance_well_known_path: URI path relative to each MCP server's
+            origin. Defaults to ``/.well-known/mcp-clearance``.
+
+    Primary source:
+      https://arxiv.org/abs/2605.24248
+      (Metere, *Attested Tool-Server Admission*, May 2026)
+    """
+    # Local import: keep `policy_presets` importable without the
+    # [attested] extra. The `cryptography` import inside
+    # `attested_admission` itself is also lazy.
+    from datetime import timedelta
+
+    from .mcp_spec.attested_admission import AttestedAdmissionConfig
+
+    return AttestedAdmissionConfig(
+        trust_root=trust_root,
+        clearance_well_known_path=clearance_well_known_path,
+        enforcement_mode=enforcement_mode,  # type: ignore[arg-type]
+        max_clearance_age=timedelta(days=max_clearance_age_days),
+    )
+
+
 def oauth_audit_vercel_2026_defaults() -> OAuthAppAuditConfig:
     """OAuth app audit defaults driven by the 2026-04-19 Vercel breach.
 

--- a/tests/test_attested_admission.py
+++ b/tests/test_attested_admission.py
@@ -1,0 +1,677 @@
+"""Tests for MCP Attested Tool-Server Admission (RFC arXiv:2605.24248).
+
+These tests exercise the full pipeline — clearance fetch → offline
+signature verification → per-server allowlist admission — using
+in-process generated key pairs. No signing key ever leaves the test
+process, so committing them to the repo is impossible.
+
+Coverage matrix:
+
+- Signed-valid clearance admits **only** allowlisted tools.
+- Tampered signature denies under ENFORCE, warns under WARN.
+- Expired clearance (stale ``iat``) denies under ENFORCE, warns under WARN.
+- Explicit ``exp`` in the past denies regardless of ``iat`` freshness.
+- Server with no clearance document (missing well-known doc) denies
+  under ENFORCE, warns under WARN.
+- Subject-mismatch (clearance ``sub`` != dispatched ``server_id``)
+  denies under ENFORCE, warns under WARN.
+- RSA-PSS trust roots verify in addition to the Ed25519 default.
+- JWKS-shaped trust roots verify (OKP / RSA).
+- The audit receipt fingerprint matches the SHA-256 of the raw bytes.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+# These tests require the [attested] extra; skip the whole module if
+# cryptography is not importable so a base-install CI matrix still runs
+# the rest of the suite cleanly.
+cryptography = pytest.importorskip("cryptography")
+
+from cryptography.hazmat.primitives import hashes, serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: E402
+    Ed25519PrivateKey,
+)
+from cryptography.hazmat.primitives.asymmetric.padding import MGF1, PSS  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric.rsa import (  # noqa: E402
+    generate_private_key as rsa_generate,
+)
+
+from agent_airlock.mcp_spec.attested_admission import (  # noqa: E402
+    AdmissionDecision,
+    AttestedAdmissionConfig,
+    ClearanceVerificationError,
+    ExpiredClearance,
+    InvalidClearanceSignature,
+    MalformedClearance,
+    MissingClearance,
+    TrustRoot,
+    admit_server_tool,
+    admit_tool,
+    verify_clearance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _ed25519_sign_clearance(payload: dict[str, Any], priv: Ed25519PrivateKey) -> bytes:
+    """Build a JWS-compact token signed with Ed25519. Returns raw bytes
+    suitable for handing to ``verify_clearance``."""
+    header = {"alg": "EdDSA", "typ": "MCP-CLEARANCE"}
+    h_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    p_b64 = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{h_b64}.{p_b64}".encode("ascii")
+    sig = priv.sign(signing_input)
+    return f"{h_b64}.{p_b64}.{_b64url(sig)}".encode("ascii")
+
+
+def _rsa_sign_clearance(payload: dict[str, Any], priv: Any) -> bytes:
+    header = {"alg": "PS256", "typ": "MCP-CLEARANCE"}
+    h_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    p_b64 = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{h_b64}.{p_b64}".encode("ascii")
+    sig = priv.sign(
+        signing_input,
+        PSS(mgf=MGF1(hashes.SHA256()), salt_length=PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return f"{h_b64}.{p_b64}.{_b64url(sig)}".encode("ascii")
+
+
+def _ed25519_pubkey_pem(priv: Ed25519PrivateKey) -> bytes:
+    return priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _now_unix() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp())
+
+
+@pytest.fixture
+def ed25519_keypair() -> tuple[Ed25519PrivateKey, bytes]:
+    priv = Ed25519PrivateKey.generate()
+    return priv, _ed25519_pubkey_pem(priv)
+
+
+@pytest.fixture
+def ed25519_config(
+    ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+) -> tuple[Ed25519PrivateKey, AttestedAdmissionConfig]:
+    priv, pem = ed25519_keypair
+    cfg = AttestedAdmissionConfig(
+        trust_root=TrustRoot(key_id="test-ed25519-2026", ed25519_pem=pem),
+        enforcement_mode="ENFORCE",
+        max_clearance_age=timedelta(days=30),
+    )
+    return priv, cfg
+
+
+def _make_clearance(
+    priv: Ed25519PrivateKey,
+    *,
+    server_id: str = "srv-alpha",
+    iat: int | None = None,
+    exp: int | None = None,
+    tools: list[str] | None = None,
+    issuer: str = "https://mcp.example.com",
+) -> bytes:
+    payload: dict[str, Any] = {
+        "iss": issuer,
+        "sub": server_id,
+        "iat": iat if iat is not None else _now_unix(),
+        "tools": tools if tools is not None else ["read", "search"],
+    }
+    if exp is not None:
+        payload["exp"] = exp
+    return _ed25519_sign_clearance(payload, priv)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — signed-valid admits only allowlisted tools
+# ---------------------------------------------------------------------------
+
+
+class TestSignedValidClearance:
+    def test_admits_allowlisted_tool(
+        self,
+        ed25519_config: tuple[Ed25519PrivateKey, AttestedAdmissionConfig],
+    ) -> None:
+        priv, cfg = ed25519_config
+        clearance = verify_clearance(_make_clearance(priv, tools=["read", "search"]), cfg)
+
+        decision = admit_tool(
+            server_id="srv-alpha",
+            tool_name="read",
+            clearance=clearance,
+            cfg=cfg,
+        )
+
+        assert decision.admitted is True
+        assert decision.verdict.verdict == "allow"
+        assert decision.reason == "admitted_by_allowlist"
+        assert decision.clearance_fingerprint == clearance.fingerprint
+
+    def test_denies_non_allowlisted_tool(
+        self,
+        ed25519_config: tuple[Ed25519PrivateKey, AttestedAdmissionConfig],
+    ) -> None:
+        priv, cfg = ed25519_config
+        clearance = verify_clearance(_make_clearance(priv, tools=["read"]), cfg)
+
+        decision = admit_tool(
+            server_id="srv-alpha",
+            tool_name="write",
+            clearance=clearance,
+            cfg=cfg,
+        )
+
+        assert decision.admitted is False
+        assert decision.verdict.verdict == "block"
+        assert "tool_not_in_allowlist" in decision.reason
+        assert decision.clearance_fingerprint == clearance.fingerprint
+
+    def test_warn_mode_admits_non_allowlisted_with_warn_verdict(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="WARN",
+        )
+        clearance = verify_clearance(_make_clearance(priv, tools=["read"]), cfg)
+
+        decision = admit_tool(
+            server_id="srv-alpha",
+            tool_name="write",
+            clearance=clearance,
+            cfg=cfg,
+        )
+
+        assert decision.admitted is True  # WARN admits
+        assert decision.verdict.verdict == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Tampered signature
+# ---------------------------------------------------------------------------
+
+
+class TestTamperedSignature:
+    def test_enforce_denies(
+        self,
+        ed25519_config: tuple[Ed25519PrivateKey, AttestedAdmissionConfig],
+    ) -> None:
+        priv, cfg = ed25519_config
+        good = _make_clearance(priv)
+        # Flip a byte in the payload segment.
+        h, p, s = good.decode().split(".")
+        # Re-encode the payload b64 with one base64 char swapped (still
+        # valid b64 but decodes to different bytes).
+        tampered_p = "A" + p[1:] if p[0] != "A" else "B" + p[1:]
+        tampered = f"{h}.{tampered_p}.{s}".encode()
+
+        with pytest.raises((InvalidClearanceSignature, MalformedClearance)):
+            verify_clearance(tampered, cfg)
+
+        # End-to-end via admit_server_tool also denies.
+        decision = admit_server_tool(
+            server_url="https://mcp.example.com",
+            server_id="srv-alpha",
+            tool_name="read",
+            cfg=AttestedAdmissionConfig(
+                trust_root=cfg.trust_root,
+                enforcement_mode="ENFORCE",
+                fetcher=lambda _u, _p: tampered,
+            ),
+        )
+        assert decision.admitted is False
+        assert decision.verdict.verdict == "block"
+
+    def test_warn_mode_admits_with_warn_verdict(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, pem = ed25519_keypair
+        good = _make_clearance(priv)
+        h, p, s = good.decode().split(".")
+        tampered_p = "A" + p[1:] if p[0] != "A" else "B" + p[1:]
+        tampered = f"{h}.{tampered_p}.{s}".encode()
+
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="WARN",
+            fetcher=lambda _u, _p: tampered,
+        )
+
+        decision = admit_server_tool(
+            server_url="https://mcp.example.com",
+            server_id="srv-alpha",
+            tool_name="read",
+            cfg=cfg,
+        )
+        assert decision.admitted is True
+        assert decision.verdict.verdict == "warn"
+        assert decision.clearance_fingerprint is None
+        assert "clearance_verification_failed" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# Expiry
+# ---------------------------------------------------------------------------
+
+
+class TestExpiry:
+    def test_stale_iat_denies_under_enforce(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="ENFORCE",
+            max_clearance_age=timedelta(days=1),
+        )
+        stale = _make_clearance(
+            priv,
+            iat=_now_unix() - int(timedelta(days=2).total_seconds()),
+        )
+        with pytest.raises(ExpiredClearance):
+            verify_clearance(stale, cfg)
+
+    def test_stale_iat_warns_under_warn(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="WARN",
+            max_clearance_age=timedelta(days=1),
+            fetcher=lambda _u, _p: _make_clearance(
+                priv, iat=_now_unix() - int(timedelta(days=2).total_seconds())
+            ),
+        )
+        decision = admit_server_tool(
+            server_url="https://mcp.example.com",
+            server_id="srv-alpha",
+            tool_name="read",
+            cfg=cfg,
+        )
+        assert decision.admitted is True
+        assert decision.verdict.verdict == "warn"
+        assert "ExpiredClearance" in decision.reason
+
+    def test_explicit_exp_in_past_denies(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="ENFORCE",
+        )
+        blob = _make_clearance(
+            priv,
+            iat=_now_unix() - 60,
+            exp=_now_unix() - 30,  # Already expired
+        )
+        with pytest.raises(ExpiredClearance):
+            verify_clearance(blob, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Missing well-known document
+# ---------------------------------------------------------------------------
+
+
+class TestMissingClearance:
+    def test_enforce_denies(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        _, pem = ed25519_keypair
+
+        def _absent(_u: str, _p: str) -> bytes:
+            raise MissingClearance("404")
+
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="ENFORCE",
+            fetcher=_absent,
+        )
+
+        decision = admit_server_tool(
+            server_url="https://mcp.example.com",
+            server_id="srv-alpha",
+            tool_name="read",
+            cfg=cfg,
+        )
+        assert decision.admitted is False
+        assert decision.verdict.verdict == "block"
+        assert "MissingClearance" in decision.reason
+
+    def test_warn_admits(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        _, pem = ed25519_keypair
+
+        def _absent(_u: str, _p: str) -> bytes:
+            raise MissingClearance("404")
+
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test", ed25519_pem=pem),
+            enforcement_mode="WARN",
+            fetcher=_absent,
+        )
+
+        decision = admit_server_tool(
+            server_url="https://mcp.example.com",
+            server_id="srv-alpha",
+            tool_name="read",
+            cfg=cfg,
+        )
+        assert decision.admitted is True
+        assert decision.verdict.verdict == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Subject mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestSubjectMismatch:
+    def test_enforce_denies(
+        self,
+        ed25519_config: tuple[Ed25519PrivateKey, AttestedAdmissionConfig],
+    ) -> None:
+        priv, cfg = ed25519_config
+        clearance = verify_clearance(_make_clearance(priv, server_id="srv-alpha"), cfg)
+
+        decision = admit_tool(
+            server_id="srv-beta",  # Different
+            tool_name="read",
+            clearance=clearance,
+            cfg=cfg,
+        )
+        assert decision.admitted is False
+        assert "clearance_subject_mismatch" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint stability
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprint:
+    def test_fingerprint_is_sha256_of_raw_bytes(
+        self,
+        ed25519_config: tuple[Ed25519PrivateKey, AttestedAdmissionConfig],
+    ) -> None:
+        from hashlib import sha256
+
+        priv, cfg = ed25519_config
+        blob = _make_clearance(priv)
+        clearance = verify_clearance(blob, cfg)
+
+        assert clearance.fingerprint == sha256(blob).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# RSA-PSS trust root
+# ---------------------------------------------------------------------------
+
+
+class TestRSATrustRoot:
+    def test_rsa_pss_verifies(self) -> None:
+        priv = rsa_generate(public_exponent=65537, key_size=2048)
+        pem = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test-rsa", rsa_pem=pem),
+            enforcement_mode="ENFORCE",
+        )
+        payload = {
+            "iss": "https://mcp.example.com",
+            "sub": "srv-alpha",
+            "iat": _now_unix(),
+            "tools": ["read"],
+        }
+        blob = _rsa_sign_clearance(payload, priv)
+
+        clearance = verify_clearance(blob, cfg)
+        decision = admit_tool(
+            server_id="srv-alpha",
+            tool_name="read",
+            clearance=clearance,
+            cfg=cfg,
+        )
+        assert decision.admitted is True
+
+
+# ---------------------------------------------------------------------------
+# JWKS trust root (OKP / Ed25519)
+# ---------------------------------------------------------------------------
+
+
+class TestJWKSTrustRoot:
+    def test_jwks_okp_verifies(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, _ = ed25519_keypair
+        raw_pub = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        jwks = {
+            "keys": [
+                {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "kid": "test-1",
+                    "x": base64.urlsafe_b64encode(raw_pub).rstrip(b"=").decode("ascii"),
+                }
+            ]
+        }
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="test-jwks", jwks=jwks),
+            enforcement_mode="ENFORCE",
+        )
+        clearance = verify_clearance(_make_clearance(priv), cfg)
+        decision = admit_tool(
+            server_id="srv-alpha",
+            tool_name="read",
+            clearance=clearance,
+            cfg=cfg,
+        )
+        assert decision.admitted is True
+
+
+# ---------------------------------------------------------------------------
+# Pure-function discipline & config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_trust_root_rejects_zero_keys(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            TrustRoot(key_id="t")
+
+    def test_trust_root_rejects_two_keys(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            TrustRoot(
+                key_id="t",
+                ed25519_pem=b"-----BEGIN PUBLIC KEY-----\n...",
+                rsa_pem=b"-----BEGIN PUBLIC KEY-----\n...",
+            )
+
+    def test_config_rejects_unknown_mode(self) -> None:
+        with pytest.raises(ValueError, match="enforcement_mode"):
+            AttestedAdmissionConfig(enforcement_mode="MAYBE")  # type: ignore[arg-type]
+
+    def test_config_rejects_nonpositive_max_age(self) -> None:
+        with pytest.raises(ValueError, match="positive timedelta"):
+            AttestedAdmissionConfig(max_clearance_age=timedelta(0))
+
+    def test_verify_without_trust_root_raises_malformed(self) -> None:
+        cfg = AttestedAdmissionConfig(enforcement_mode="ENFORCE")
+        with pytest.raises(MalformedClearance, match="no trust_root"):
+            verify_clearance(b"a.b.c", cfg)
+
+    def test_admit_tool_returns_admissiondecision(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        _, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="t", ed25519_pem=pem),
+            enforcement_mode="ENFORCE",
+        )
+        decision = admit_tool(
+            server_id="s",
+            tool_name="t",
+            clearance=None,
+            cfg=cfg,
+            error=ClearanceVerificationError("forced"),
+        )
+        assert isinstance(decision, AdmissionDecision)
+        assert decision.admitted is False
+        assert decision.verdict.guard == "mcp_attested_admission"
+
+
+# ---------------------------------------------------------------------------
+# Malformed inputs
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedInputs:
+    def test_non_jws_compact_raises(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        _, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="t", ed25519_pem=pem),
+        )
+        with pytest.raises(MalformedClearance):
+            verify_clearance(b"not-a-jws-token", cfg)
+
+    def test_missing_sub_raises(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        priv, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="t", ed25519_pem=pem),
+        )
+        # Build a valid signature over a payload missing 'sub'.
+        payload = {
+            "iss": "x",
+            "iat": _now_unix(),
+            "tools": ["read"],
+        }
+        blob = _ed25519_sign_clearance(payload, priv)
+        with pytest.raises(MalformedClearance, match="sub"):
+            verify_clearance(blob, cfg)
+
+
+# ---------------------------------------------------------------------------
+# MCPProxyGuard integration
+# ---------------------------------------------------------------------------
+
+
+class TestPresetFactoryDiscoverable:
+    """The `mcp_attested_admission_defaults` factory must appear in
+    `policy_presets.list_active()` so `airlock graph` and the OWASP
+    coverage matrix can enumerate it without ad-hoc package walking."""
+
+    def test_factory_returns_attested_admission_config(self) -> None:
+        from agent_airlock.mcp_spec.attested_admission import AttestedAdmissionConfig
+        from agent_airlock.policy_presets import mcp_attested_admission_defaults
+
+        cfg = mcp_attested_admission_defaults()
+        assert isinstance(cfg, AttestedAdmissionConfig)
+        assert cfg.enforcement_mode == "ENFORCE"  # deny-by-default
+        assert cfg.clearance_well_known_path == "/.well-known/mcp-clearance"
+        assert cfg.max_clearance_age == timedelta(days=30)
+        assert cfg.trust_root is None  # operator must supply
+
+    def test_factory_listed_by_list_active(self) -> None:
+        from agent_airlock.policy_presets import list_active
+
+        names = {meta.preset_id for meta in list_active()}
+        assert "mcp_attested_admission_defaults" in names
+
+    def test_factory_round_trip_with_trust_root(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        from agent_airlock.policy_presets import mcp_attested_admission_defaults
+
+        _, pem = ed25519_keypair
+        cfg = mcp_attested_admission_defaults(
+            trust_root=TrustRoot(key_id="op-pinned", ed25519_pem=pem),
+            enforcement_mode="WARN",
+            max_clearance_age_days=7,
+        )
+        assert cfg.enforcement_mode == "WARN"
+        assert cfg.max_clearance_age == timedelta(days=7)
+        assert cfg.trust_root is not None
+        assert cfg.trust_root.key_id == "op-pinned"
+
+
+class TestMCPProxyGuardIntegration:
+    def test_audit_tool_admission_delegates(
+        self,
+        ed25519_keypair: tuple[Ed25519PrivateKey, bytes],
+    ) -> None:
+        from agent_airlock.mcp_proxy_guard import MCPProxyConfig, MCPProxyGuard
+
+        priv, pem = ed25519_keypair
+        cfg = AttestedAdmissionConfig(
+            trust_root=TrustRoot(key_id="t", ed25519_pem=pem),
+            enforcement_mode="ENFORCE",
+            fetcher=lambda _u, _p: _make_clearance(priv, tools=["read"]),
+        )
+        guard = MCPProxyGuard(MCPProxyConfig(attested_admission=cfg))
+
+        decision = guard.audit_tool_admission(
+            server_url="https://mcp.example.com",
+            server_id="srv-alpha",
+            tool_name="read",
+        )
+        assert decision.admitted is True
+        assert decision.verdict.guard == "mcp_attested_admission"
+
+    def test_audit_tool_admission_unconfigured_raises(self) -> None:
+        from agent_airlock.mcp_proxy_guard import (
+            MCPProxyConfig,
+            MCPProxyGuard,
+            MCPSecurityError,
+        )
+
+        guard = MCPProxyGuard(MCPProxyConfig())
+        with pytest.raises(MCPSecurityError, match="attested_admission"):
+            guard.audit_tool_admission(
+                server_url="https://x",
+                server_id="srv-alpha",
+                tool_name="read",
+            )


### PR DESCRIPTION
## Summary

Implements the host-side admission gate from Metere, *Attested Tool-Server Admission: A Security Extension to the Model Context Protocol* ([arXiv:2605.24248](https://arxiv.org/abs/2605.24248), May 22 2026). MCP standardises message exchange between LLM agents and tool servers but says nothing about **trust** — anyone on the wire can declare themselves a tool server. This PR closes that gap host-side as an **opt-in deny-by-default** preset.

Before any tool from an MCP server is dispatched, the host:

1. **Fetches** a JWS-compact clearance assertion from `{server_url}/.well-known/mcp-clearance` (path configurable). Stdlib `urllib` by default; operators inject a custom `fetcher` callable for mTLS / IPC / on-disk transports.
2. **Verifies** the offline signature against an **operator-pinned trust root** — Ed25519 PEM, RSA-PSS PEM, or a JWKS (OKP/RSA). The trust root is supplied to `AttestedAdmissionConfig` at process startup and **never network-fetched on the hot path**.
3. **Admits** the call iff the tool name is in the verified per-server allowlist AND the clearance `sub` matches the dispatched `server_id` — admitting a server is not the same as trusting its every tool. Stale-`iat` and past-`exp` clearances are rejected.
4. **Emits** the decision as a `ReceiptVerdict(guard="mcp_attested_admission", ...)` so the existing `airlock attest` DSSE pipeline picks decisions up unchanged — **does NOT** invent a new log.

Flavor-gated enforcement: `ENFORCE` (default) hard-denies on missing / invalid / expired clearance; `WARN` logs and admits — staged turn-up against real traffic.

## Surfaces

| File | Change |
|---|---|
| `src/agent_airlock/mcp_spec/attested_admission.py` | **NEW** module: `AttestedAdmissionConfig`, `TrustRoot`, `AdmittedClearance`, `AdmissionDecision`, `verify_clearance()`, `admit_tool()`, `admit_server_tool()`, `ClearanceVerificationError` hierarchy |
| `src/agent_airlock/policy_presets.py` | **NEW** factory `mcp_attested_admission_defaults(...)` — listed by `policy_presets.list_active()` |
| `src/agent_airlock/mcp_proxy_guard.py` | **NEW** optional `MCPProxyConfig.attested_admission` field (default `None`, preserves v0.8.9 behavior exactly) + `MCPProxyGuard.audit_tool_admission()` chokepoint mirroring `audit_response_headers` / `audit_oauth_exchange` |
| `pyproject.toml` | Bump `0.8.9 → 0.8.10`; new `[attested]` extra pulling `cryptography>=42.0` |
| `tests/test_attested_admission.py` | **NEW** — 27 tests |
| `scripts/smoke_attested_admission.py` | **NEW** — wheel-install end-to-end smoke |
| `README.md` | New "🪪 MCP server attestation" section + policies-table row + OWASP ASI03 row updated |
| `CHANGELOG.md` | `[Unreleased]` v0.8.10 entry above the v0.8.9 Indic-PII entry |

## Test Plan

### `tests/test_attested_admission.py` — 27 tests, all green

- Signed-valid clearance admits **only** allowlisted tools (deny non-allowlisted).
- Tampered signature denies under ENFORCE, warns under WARN.
- Stale-`iat` denies under ENFORCE, warns under WARN.
- Explicit `exp` in past denies regardless of `iat` freshness.
- Missing well-known doc denies under ENFORCE, warns under WARN.
- Subject mismatch denies.
- RSA-PSS and JWKS (OKP) trust roots verify in addition to Ed25519 PEM.
- Factory discoverable via `policy_presets.list_active()`.
- `MCPProxyGuard.audit_tool_admission()` integration roundtrip.
- `TrustRoot` + `AttestedAdmissionConfig` validation paths.

### Wheel-install smoke

`python3 scripts/smoke_attested_admission.py` — builds `agent_airlock-0.8.10-py3-none-any.whl`, installs it (with `[attested]`) into a throwaway venv, runs a child Python that **imports from the installed wheel** (not the source tree) and asserts:

```
OK: admit verdict='allow' fingerprint=2160397b4f2eb1eb...
OK: deny  verdict='block' reason="tool_not_in_allowlist: 'write' not in ['read']"
OK: tampered signature rejected by verify_clearance
```

### Gate results

| Gate | Result |
|---|---|
| Project ruff check | ✅ All checks passed |
| Mypy net delta | ✅ 8 → 8 errors (zero new; all 8 remaining are pre-existing in `capabilities`, `model_armor`, `mcp_proxy_guard:607`, `streaming`, `core:839/856`) |
| `pytest tests/` | ✅ 2627 pass, 33 skipped. 1 perf P99 test (`test_meta_chain_under_2ms_p99`) flakes under suite-load contention; passes in isolation and flakes identically on baseline — unrelated. |
| `make check-changelog-release` (pre-tag gate) | ✅ `OK (CHANGELOG.md [Unreleased] has release notes)` |
| Wheel build + install smoke | ✅ (above) |

## No-pivot

This preset is **strictly opt-in**: existing default presets are unchanged. Callers that don't set `attested_admission` on `MCPProxyConfig` get exactly v0.8.9 behavior — confirmed by mypy net-delta zero. Deny-by-default posture stays. Zero-runtime-dep core stays (the `cryptography` import inside `attested_admission` is lazy and raises a clear actionable error if the `[attested]` extra is missing).

## Notes

- Bundles a small unrelated `docs(claude.md):` commit at the head of the branch — auto-memory refresh that landed while preparing this work. Happy to split it out if you'd rather it land separately.
- The default `check_changelog.py` (post-release drift gate) flags DRIFT both before and after this PR because `[Unreleased]` accumulates entries until tag time. This is the project's existing convention; the `--release` gate that CI uses is green.

## Reference

- Metere, A. *Attested Tool-Server Admission: A Security Extension to the Model Context Protocol.* [arXiv:2605.24248](https://arxiv.org/abs/2605.24248) (2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
