### PR TITLE
feat(0.8.12): behavioral tool-call sequence guard (arXiv:2605.27901)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Behavioral tool-call sequence guard (v0.8.12)
+
+`SequenceGuard` — an opt-in behavioral-only sequence anomaly guard that
+watches the **ordered stream of tool calls** within a session and flags
+divergence from a declared expected order. By construction it does
+**not** read the model's reasoning trace — Onyame et al.
+*The Fragility of Chain-of-Thought Monitoring Across Typologically
+Diverse Languages* ([arXiv:2605.27901](https://arxiv.org/abs/2605.27901),
+May 2026) reports an average **95.9% CoT unfaithfulness across 8B–120B
+models**, so trusting the model's stated reasoning to detect
+misbehavior is not viable; trusting its behavior is.
+
+Two modes:
+
+- **DECLARED.** Operator supplies a permitted-transition DAG
+  (`{from_tool: {allowed_next_tools}}`, with `"__entry__"` listing
+  tool names permitted as the first call). Any transition not in the
+  DAG is a `SequenceViolation`. Deny-by-default.
+- **BASELINE.** Guard maintains a per-session-key Markov transition
+  profile in a local JSON file (no cloud, no PII — only tool names
+  and SHA-256 *shape hashes* of `(arg types, kwarg names+types)`,
+  **never argument values**) and flags transitions with observed
+  `P(curr | prev) < low_probability_threshold` once the sample size
+  from `prev` reaches `min_baseline_samples`. Atomic temp-file +
+  rename on persist.
+
+Per-call `action`: `"block"` (default — raises `SequenceViolation`,
+routed through the existing `handle_policy_violation` path so existing
+deployments see no new error shape) or `"warn"` (logs via structlog +
+emits the OTel attribute, lets the call proceed).
+
+OTel: every flagged transition sets attributes on the current span via
+the existing `observability` provider —
+`airlock.sequence_guard.mode`, `.from_tool`, `.to_tool`,
+`.session_key`, and (baseline mode) `.observed_probability`.
+Telemetry failures are swallowed so they cannot break enforcement.
+
+Surfaces:
+
+- `agent_airlock.sequence_guard` — new module:
+  - `SequenceGuard` (`@dataclass`, thread-safe, `threading.Lock`).
+  - `SequenceViolation(PolicyViolation)` — preserves the existing
+    error-handler chain.
+  - `args_shape_hash(args, kwargs) -> str` — privacy-preserving stable
+    hash of `(arg types, kwarg names+types)`.
+  - `ENTRY_SENTINEL`, `PREV_NONE_SENTINEL`, mode/action enums.
+- `agent_airlock.policy.SecurityPolicy.sequence_guard: SequenceGuard | None = None`
+  — new optional field; default `None` preserves v0.8.11 behavior
+  exactly.
+- `agent_airlock.core.Airlock._check_sequence_guard(...)` — new private
+  Step 2.5 in the `@Airlock` pre-execution pipeline. Runs right after
+  the standard policy check; routes a block decision through the
+  existing `handle_policy_violation` → `on_blocked` callback chain.
+
+Disambiguation: this is **not** `agent_airlock.anomaly.AnomalyDetector`
+(which monitors call **rate** / endpoint **diversity** / **error rate** /
+**consecutive blocked** over sliding windows). `SequenceGuard` is a
+per-transition **ORDER** signal; `AnomalyDetector` is an aggregate
+per-window signal. They are complementary — an attacker who keeps the
+rate flat but reorders calls slips past `AnomalyDetector`; an attacker
+who hammers a single permitted transition slips past `SequenceGuard`.
+
+Tests: 36 tests in `tests/test_sequence_guard.py` covering
+`args_shape_hash` invariants (value invariance, arity/type/keyword
+sensitivity, order-independence), construction validation (mode,
+action, DAG entry-sentinel, threshold range, min-samples positivity),
+declared-DAG semantics (entry, transitions, per-session isolation,
+warn vs block), baseline cold-start (no flag below min-samples),
+baseline flagging (rare transition post warmup), baseline non-flag for
+the high-probability path, baseline JSON privacy guarantee (no
+argument values on disk), baseline round-trip from disk, OTel
+attribute emission, OTel failure swallowed, thread-safe concurrent
+record_and_check, and `@Airlock` end-to-end (clean run / block-mode
+DAG violation / warn-mode no-block).
+
+Zero new runtime deps. Pydantic-only core stays intact.
+
 ### Added — ModalBackend sandbox (v0.8.11, issue #30)
 
 `ModalBackend(SandboxBackend)` — opt-in sandbox backend that delegates

--- a/README.md
+++ b/README.md
@@ -445,6 +445,84 @@ base install stays zero-runtime-dep.
 
 ---
 
+### 🧭 Behavioral sequence guard (v0.8.12)
+
+Watches the **ordered stream of tool calls** in a session and flags
+divergence from a declared expected order — *not* the model's stated
+reasoning trace.
+
+[arXiv:2605.27901](https://arxiv.org/abs/2605.27901) ("The Fragility
+of Chain-of-Thought Monitoring", Onyame, Zhou, Thopalli, Kailkhura
+& Agarwal, May 2026) reports an average **95.9% CoT unfaithfulness
+across 8B–120B-parameter models** — including answer-switching,
+post-hoc rationalisation, and procedural exploitation of hints.
+Trusting the model's stated reasoning to detect misbehavior is
+therefore not viable. Trusting its **behavior** — the sequence of
+tools it actually invokes — is.
+
+`SequenceGuard` is an opt-in field on `SecurityPolicy` that runs in
+the `@Airlock` seam **right after** the standard policy check, in two
+modes:
+
+**DECLARED mode** — operator supplies a permitted-transition DAG.
+Any transition not in the DAG is a `SequenceViolation`. Deny-by-default.
+
+```python
+from agent_airlock import Airlock, SecurityPolicy
+from agent_airlock.sequence_guard import SequenceGuard, ENTRY_SENTINEL
+
+policy = SecurityPolicy(
+    sequence_guard=SequenceGuard(
+        mode="declared",
+        action="block",                       # or "warn"
+        dag={
+            ENTRY_SENTINEL: {"read"},         # only `read` may start a session
+            "read": {"read", "summarize"},    # after read, either re-read or summarize
+            "summarize": {"send"},            # after summarize, only send
+            "send": set(),                    # send is terminal
+        },
+    ),
+)
+```
+
+**BASELINE mode** — guard maintains a per-session-key Markov transition
+profile in a local JSON file (no cloud, no PII — only tool names and
+SHA-256 *shape hashes* of `(arg types, kwarg names+types)`, **never
+argument values**) and flags transitions with observed
+`P(curr | prev) < threshold` once the sample size from `prev` reaches
+`min_baseline_samples`.
+
+```python
+from pathlib import Path
+from agent_airlock.sequence_guard import SequenceGuard
+
+policy = SecurityPolicy(
+    sequence_guard=SequenceGuard(
+        mode="baseline",
+        baseline_path=Path("/var/lib/airlock/sequence-baseline.json"),
+        low_probability_threshold=0.05,   # flag the bottom 5%
+        min_baseline_samples=50,          # don't flag until 50 obs from `prev`
+    ),
+)
+```
+
+Every flagged transition emits OTel span attributes on the current
+span (`airlock.sequence_guard.mode`, `.from_tool`, `.to_tool`,
+`.session_key`, `.observed_probability`) via the existing
+`observability` provider — telemetry failures are swallowed so they
+cannot break enforcement.
+
+**Not** `AnomalyDetector` (that's rate / endpoint-diversity /
+error-rate / consecutive-blocked over sliding windows). `SequenceGuard`
+is per-transition ORDER signal. Run both for layered coverage. **Not**
+a chain-of-thought monitor — by construction.
+
+> Strictly opt-in. The new `SecurityPolicy.sequence_guard` field
+> defaults to `None`; callers that don't set it get exactly v0.8.11
+> behavior. Zero new runtime deps — Pydantic-only core stays intact.
+
+---
+
 ### 💰 Cost Control
 
 A runaway agent can burn $500 in API costs before you notice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.11"
+version = "0.8.12"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"

--- a/scripts/smoke_sequence_guard.py
+++ b/scripts/smoke_sequence_guard.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Smoke test: pip-install the built wheel + exercise the v0.8.12
+behavioral sequence guard end-to-end.
+
+This script runs *outside* the editable source tree:
+
+1. Builds a wheel via ``python -m build --wheel`` into ``dist/``.
+2. Creates a throwaway venv under ``.smoke-sequence-venv/``.
+3. Installs ``dist/agent_airlock-<version>-py3-none-any.whl`` into
+   the venv. **No extras** — the sequence guard is base-install only;
+   that's the point.
+4. Runs a child Python in the venv that:
+   - imports ``SequenceGuard`` from the *installed* package,
+   - constructs a declared-DAG guard,
+   - drives a permitted transition (admit),
+   - drives a disallowed transition (asserts ``SequenceViolation``
+     fires with the expected ``from_tool`` / ``to_tool`` / ``mode``).
+
+Exit codes:
+
+  0   smoke passes — the wheel installs cleanly, base-install has zero
+      new runtime deps, and the guard behaves identically against the
+      installed wheel as it does against the source tree.
+  1   smoke assertion failed.
+  2   environment problem (build / venv / install failed).
+
+Run from the repo root: ``python3 scripts/smoke_sequence_guard.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess  # noqa: S404 - intentional, smoke driver
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST_DIR = REPO_ROOT / "dist"
+VENV_DIR = REPO_ROOT / ".smoke-sequence-venv"
+
+
+def _run(cmd: list[str]) -> None:
+    print(f"$ {' '.join(cmd)}", flush=True)
+    subprocess.check_call(cmd)  # noqa: S603 - argv pinned by this script
+
+
+def build_wheel() -> Path:
+    DIST_DIR.mkdir(exist_ok=True)
+    for old in DIST_DIR.glob("agent_airlock-*.whl"):
+        old.unlink()
+    _run([sys.executable, "-m", "build", "--wheel", "--outdir", str(DIST_DIR)])
+    wheels = sorted(DIST_DIR.glob("agent_airlock-*.whl"))
+    if not wheels:
+        print("ERROR: no wheel produced under dist/", file=sys.stderr)
+        sys.exit(2)
+    return wheels[-1]
+
+
+def make_venv() -> tuple[Path, Path]:
+    if VENV_DIR.exists():
+        shutil.rmtree(VENV_DIR)
+    _run([sys.executable, "-m", "venv", str(VENV_DIR)])
+    py = VENV_DIR / ("Scripts" if sys.platform == "win32" else "bin") / "python"
+    _run([str(py), "-m", "pip", "install", "--quiet", "--upgrade", "pip"])
+    return VENV_DIR, py
+
+
+def install_wheel(py: Path, wheel: Path) -> None:
+    # Plain install — no extras. The sequence guard must work on base.
+    _run([str(py), "-m", "pip", "install", "--quiet", str(wheel)])
+
+
+CHILD_SMOKE_SCRIPT = textwrap.dedent(
+    """\
+    import sys
+
+    # Import from the *installed* package, not the source tree.
+    from agent_airlock.sequence_guard import (
+        ENTRY_SENTINEL,
+        SequenceGuard,
+        SequenceViolation,
+    )
+
+
+    def main() -> int:
+        # 1. Build a declared-DAG guard.
+        guard = SequenceGuard(
+            mode="declared",
+            action="block",
+            dag={
+                ENTRY_SENTINEL: {"read"},
+                "read": {"summarize"},
+                "summarize": {"send"},
+                "send": set(),
+            },
+        )
+
+        # 2. Permitted transitions are admitted.
+        guard.record_and_check(
+            session_key="smoke", tool_name="read", args=("doc-1",), kwargs={}
+        )
+        guard.record_and_check(
+            session_key="smoke", tool_name="summarize", args=(), kwargs={}
+        )
+        history_after_admit = guard.history("smoke")
+        if [t for t, _ in history_after_admit] != ["read", "summarize"]:
+            print(
+                f"FAIL: trace shape mismatch: {history_after_admit!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+        # 3. Disallowed transition blocks with the expected from/to.
+        try:
+            guard.record_and_check(
+                session_key="smoke",
+                tool_name="delete",
+                args=(),
+                kwargs={},
+            )
+        except SequenceViolation as exc:
+            if exc.from_tool != "summarize":
+                print(f"FAIL: from_tool={exc.from_tool!r}", file=sys.stderr)
+                return 1
+            if exc.to_tool != "delete":
+                print(f"FAIL: to_tool={exc.to_tool!r}", file=sys.stderr)
+                return 1
+            if exc.mode != "declared":
+                print(f"FAIL: mode={exc.mode!r}", file=sys.stderr)
+                return 1
+        else:
+            print("FAIL: disallowed transition did not raise", file=sys.stderr)
+            return 1
+
+        # 4. The argument-shape hash must never include argument values.
+        from agent_airlock.sequence_guard import args_shape_hash
+        h1 = args_shape_hash(("secret-token-AAA",), {})
+        h2 = args_shape_hash(("totally-different-string-BBB",), {})
+        if h1 != h2:
+            print(
+                f"FAIL: shape hash leaked values: {h1[:12]} vs {h2[:12]}",
+                file=sys.stderr,
+            )
+            return 1
+
+        print(
+            f"OK: declared DAG admitted read->summarize, blocked "
+            f"summarize->delete (mode='declared')"
+        )
+        print(f"OK: args_shape_hash is value-invariant ({h1[:16]}...)")
+        return 0
+
+
+    sys.exit(main())
+    """
+)
+
+
+def run_child(py: Path) -> int:
+    print("$ <venv-python> -c <SMOKE>", flush=True)
+    proc = subprocess.run([str(py), "-c", CHILD_SMOKE_SCRIPT], check=False)  # noqa: S603
+    return proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep-venv",
+        action="store_true",
+        help="Don't delete .smoke-sequence-venv/ on success.",
+    )
+    args = parser.parse_args()
+
+    try:
+        wheel = build_wheel()
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: wheel build failed: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        _venv, py = make_venv()
+        install_wheel(py, wheel)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: venv setup failed: {exc}", file=sys.stderr)
+        return 2
+
+    rc = run_child(py)
+    if rc == 0 and not args.keep_venv:
+        shutil.rmtree(VENV_DIR, ignore_errors=True)
+    elif rc != 0:
+        print(
+            f"\nSmoke failed (rc={rc}). Venv left at {VENV_DIR} for triage.",
+            file=sys.stderr,
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent_airlock/core.py
+++ b/src/agent_airlock/core.py
@@ -445,6 +445,19 @@ class Airlock:
             if policy_error is not None:
                 return kwargs, start_time, context, policy_error, None
 
+            # Step 2.5: Behavioral tool-call sequence guard (V0.8.12).
+            # Runs after the standard policy check so a denied tool never
+            # gets recorded in the sequence trace in the first place.
+            seq_error = self._check_sequence_guard(
+                func_name=func_name,
+                resolved_policy=resolved_policy,
+                args=args,
+                kwargs=cleaned_kwargs,
+                context=context,
+            )
+            if seq_error is not None:
+                return kwargs, start_time, context, seq_error, None
+
             # Step 3: Validate filesystem paths
             fs_error = self._validate_filesystem_paths(func_name, cleaned_kwargs)
             if fs_error is not None:
@@ -1163,6 +1176,97 @@ class Airlock:
                             {"path": e.path, "violation_type": e.violation_type},
                         )
                         return response
+
+        return None
+
+    def _check_sequence_guard(
+        self,
+        *,
+        func_name: str,
+        resolved_policy: SecurityPolicy | None,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        context: AirlockContext[Any],
+    ) -> AirlockResponse | None:
+        """Behavioral tool-call sequence guard (V0.8.12, arXiv:2605.27901).
+
+        Calls ``policy.sequence_guard.record_and_check(...)`` if configured.
+        Per-session ordered transitions are flagged against either a
+        declared DAG or a learned Markov baseline. See
+        :mod:`agent_airlock.sequence_guard` for the contract.
+
+        Args:
+            func_name: Name of the function being called.
+            resolved_policy: The resolved :class:`SecurityPolicy` (or None).
+            args: Positional args — used only for the shape hash; values
+                never leave the guard's memory.
+            kwargs: Cleaned keyword args — same shape-only treatment.
+            context: Current :class:`AirlockContext`. Used to derive the
+                session key (``agent_id`` or ``session_id``).
+
+        Returns:
+            Error response if the transition is blocked, None otherwise.
+            Returns None on warn-mode flags too — the guard already
+            logged + emitted the OTel attribute.
+        """
+        if resolved_policy is None or resolved_policy.sequence_guard is None:
+            return None
+
+        guard = resolved_policy.sequence_guard
+
+        # Resolve the session key from context per the guard's preference.
+        # Falls back to '__anonymous__' if both ids are absent — the
+        # guard logs a warning in that case but does not error, so
+        # deployments without identity still record (just all into one
+        # bucket).
+        if guard.session_key_kind == "session_id":
+            session_key = context.session_id or context.agent_id or "__anonymous__"
+        else:
+            session_key = context.agent_id or context.session_id or "__anonymous__"
+        if session_key == "__anonymous__":
+            logger.warning(
+                "sequence_guard.anonymous_session_key",
+                function=func_name,
+                hint=(
+                    "AirlockContext has no agent_id or session_id; all "
+                    "calls without identity collapse into a single "
+                    "'__anonymous__' bucket and the guard's "
+                    "per-session semantics degrade."
+                ),
+            )
+
+        # Lazy import to avoid the module-level cycle (sequence_guard
+        # imports PolicyViolation from policy.py).
+        from .sequence_guard import SequenceViolation
+
+        try:
+            guard.record_and_check(
+                session_key=session_key,
+                tool_name=func_name,
+                args=args,
+                kwargs=kwargs,
+            )
+        except SequenceViolation as e:
+            response = handle_policy_violation(
+                func_name,
+                policy_name="SequenceGuard",
+                reason=e.message,
+            )
+            self._safe_invoke_callback(
+                self.config.on_blocked,
+                "on_blocked",
+                func_name,
+                e.message,
+                {
+                    "violation_type": "sequence_violation",
+                    "guard_mode": e.mode,
+                    "from_tool": e.from_tool,
+                    "to_tool": e.to_tool,
+                    "session_key": e.session_key,
+                    "observed_probability": e.observed_probability,
+                },
+            )
+            return response
 
         return None
 

--- a/src/agent_airlock/policy.py
+++ b/src/agent_airlock/policy.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
         CostTracker,
         ModelTierBudget,
     )
+    from .sequence_guard import SequenceGuard
 
 logger = structlog.get_logger("agent-airlock.policy")
 
@@ -367,6 +368,14 @@ class SecurityPolicy:
     # because it needs runtime args (input token counts) that ``check()``
     # does not see.
     model_tier_budget: ModelTierBudget | None = None
+    # V0.8.12 behavioral tool-call sequence guard (arXiv:2605.27901).
+    # When set, the @Airlock seam calls ``sequence_guard.record_and_check(...)``
+    # after the standard ``check()`` returns, recording per-session ordered
+    # tool transitions and flagging divergence from a declared DAG or a
+    # learned Markov baseline. Default None preserves v0.8.11 behavior
+    # exactly — no recording, no flagging, no on-disk state. See
+    # ``agent_airlock.sequence_guard`` for the full contract.
+    sequence_guard: SequenceGuard | None = None
 
     # Parsed/cached values
     _time_windows: dict[str, TimeWindow] = field(default_factory=dict, repr=False)

--- a/src/agent_airlock/sequence_guard.py
+++ b/src/agent_airlock/sequence_guard.py
@@ -1,0 +1,530 @@
+"""Behavioral tool-call SEQUENCE anomaly guard (v0.8.12+).
+
+Watches the ordered stream of tool calls within an agent session and flags
+divergence from a declared expected ORDER. The guard is intentionally
+behavior-only: it never reads the model's reasoning trace.
+
+Why behavior-only
+-----------------
+Onyame, Zhou, Thopalli, Kailkhura & Agarwal — *The Fragility of
+Chain-of-Thought Monitoring Across Typologically Diverse Languages*
+(arXiv:2605.27901, May 2026) — report an average **95.9% chain-of-thought
+unfaithfulness across 8B–120B-parameter models**, including answer-switching,
+post-hoc rationalisation, and procedural exploitation of hints. Trusting the
+model's stated *reasoning* to detect misbehavior is therefore not viable.
+Trusting the model's *behavior* — the sequence of tools it actually invokes,
+in the order it actually invokes them — is.
+
+What this module is
+-------------------
+A per-session, in-process transition observer with two complementary modes:
+
+- **DECLARED mode** — the operator supplies a permitted-transition DAG
+  ``{from_tool: {allowed_next_tools}}`` (plus an entry-tool set keyed by the
+  sentinel ``"__entry__"``). Any transition not in the DAG is a
+  :class:`SequenceViolation`. This is the deny-by-default deployment
+  posture and the easier mode to reason about.
+- **BASELINE mode** — the guard maintains a per-session-key Markov transition
+  profile in a local JSON file (no cloud, no PII — see below). On each call
+  it computes ``P(curr | prev) = count(prev→curr) / Σ count(prev→*)`` for
+  the observed transition and, once the sample has at least
+  ``min_baseline_samples`` outbound observations from ``prev``, flags
+  transitions with ``P < low_probability_threshold``.
+
+What this module is NOT
+-----------------------
+Not :class:`agent_airlock.anomaly.AnomalyDetector` — which monitors call
+**rate**, endpoint **diversity**, **error rate**, and **consecutive blocked**
+counts over sliding windows. Those are aggregate per-window signals; this
+module is a per-transition ORDER signal. The two are complementary: an
+attacker who keeps the rate flat but reorders calls slips past
+``AnomalyDetector``; an attacker who hammers a single permitted transition
+slips past ``SequenceGuard``. Run both for layered coverage.
+
+Not a chain-of-thought monitor. By construction.
+
+Persisted-state privacy contract
+--------------------------------
+Only ``tool_name`` strings and SHA-256 *shape* hashes appear in the
+baseline JSON. The shape hash is computed from positional-arg **types** and
+keyword-arg **names** + **types** — never argument **values**. PII, secrets,
+and otherwise sensitive payloads cannot end up on disk via this module.
+
+Failure model
+-------------
+Deny-by-default. ``action="block"`` (the default) raises
+:class:`SequenceViolation` on a flagged transition. ``action="warn"`` logs
+via ``structlog``, emits an OTel attribute, and lets the call proceed —
+useful for staging the enforcement turn-up against real traffic.
+
+Reference
+---------
+- Onyame, E., Zhou, R., Thopalli, K., Kailkhura, B., & Agarwal, C.
+  *The Fragility of Chain-of-Thought Monitoring Across Typologically
+  Diverse Languages.* arXiv:2605.27901 (2026).
+  https://arxiv.org/abs/2605.27901
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import structlog
+
+from .policy import PolicyViolation, ViolationType
+
+logger = structlog.get_logger("agent-airlock.sequence_guard")
+
+
+SequenceGuardMode = Literal["declared", "baseline"]
+SequenceGuardAction = Literal["block", "warn"]
+SessionKeyKind = Literal["agent_id", "session_id"]
+
+ENTRY_SENTINEL = "__entry__"
+"""DAG key that lists tool names permitted as the first call in a session."""
+
+PREV_NONE_SENTINEL = "__none__"
+"""Baseline-JSON key used for the synthetic ``prev`` of a session's first
+call. Without it, the first-call distribution cannot be learned.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SequenceViolation(PolicyViolation):
+    """Raised when a tool-call transition is rejected by the SequenceGuard.
+
+    Subclasses :class:`PolicyViolation` so the existing ``@Airlock`` error
+    handler (which already routes ``PolicyViolation`` through
+    ``handle_policy_violation``) picks it up unchanged.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        mode: SequenceGuardMode,
+        from_tool: str | None,
+        to_tool: str,
+        session_key: str,
+        observed_probability: float | None = None,
+    ) -> None:
+        super().__init__(
+            message=message,
+            violation_type=ViolationType.TOOL_DENIED,
+            details={
+                "guard": "sequence_guard",
+                "mode": mode,
+                "from_tool": from_tool,
+                "to_tool": to_tool,
+                "session_key": session_key,
+                "observed_probability": observed_probability,
+            },
+        )
+        self.mode = mode
+        self.from_tool = from_tool
+        self.to_tool = to_tool
+        self.session_key = session_key
+        self.observed_probability = observed_probability
+
+
+# ---------------------------------------------------------------------------
+# Argument-shape hashing (no values on disk)
+# ---------------------------------------------------------------------------
+
+
+def args_shape_hash(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> str:
+    """Return a stable SHA-256 hex of the *shape* of ``(args, kwargs)``.
+
+    Stability rules:
+
+    - Positional args contribute their **type names** in order. Two calls
+      with the same arity and matching argument types hash identically
+      regardless of value.
+    - Keyword args contribute ``(sorted_key, type_name)`` pairs. Two calls
+      with the same keyword names and value-types hash identically
+      regardless of value or insertion order.
+    - Argument **values** are never hashed. This is a deliberate
+      privacy guarantee — the baseline JSON cannot leak PII or secrets
+      through the shape hash.
+
+    The shape hash is recorded alongside ``tool_name`` in the per-session
+    transition history. Operators can use it later (e.g. via
+    ``airlock studio``) to spot a "same tool, different argument shape"
+    deviation — but the SequenceGuard itself currently only enforces
+    against ``tool_name`` transitions.
+    """
+    arg_types = [type(a).__name__ for a in args]
+    kwarg_pairs = sorted((k, type(v).__name__) for k, v in kwargs.items())
+    canonical = json.dumps([arg_types, kwarg_pairs], separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Per-session state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SessionTrace:
+    """Per-session ordered list of (tool_name, shape_hash) tuples + last tool."""
+
+    history: list[tuple[str, str]] = field(default_factory=list)
+    last_tool: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# SequenceGuard
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SequenceGuard:
+    """Behavioral tool-call sequence anomaly guard.
+
+    Attached to a :class:`SecurityPolicy` via the optional ``sequence_guard``
+    field. The runtime calls :meth:`record_and_check` from the ``@Airlock``
+    seam right after the standard policy check, so the new logic is
+    additive and zero-impact for callers who don't set it.
+
+    Attributes:
+        mode: ``"declared"`` (DAG-based deny-by-default) or ``"baseline"``
+            (Markov-profile low-probability flag).
+        action: ``"block"`` (default — raise :class:`SequenceViolation`)
+            or ``"warn"`` (log + emit OTel attribute, do not raise).
+        dag: Required in ``"declared"`` mode. A mapping
+            ``{from_tool: {allowed_next_tools}}``. The key ``ENTRY_SENTINEL``
+            (``"__entry__"``) lists tool names permitted as the first call
+            in a session. Any transition not listed is a violation.
+        baseline_path: Required in ``"baseline"`` mode. Path to a local
+            JSON file used to persist the Markov transition counts. The
+            file is created with ``{}`` on first use. **Only tool names
+            and shape hashes are written — never argument values.**
+        low_probability_threshold: ``baseline`` mode only. Transitions
+            with ``P(to|from) < threshold`` are flagged. Default ``0.05``.
+        min_baseline_samples: ``baseline`` mode only. A transition is
+            NOT flagged until the outbound count from ``from`` reaches
+            this many samples. Default ``50`` — avoids flagging during
+            the cold-start phase before the model has been observed
+            enough to be statistically meaningful.
+        session_key_kind: ``"agent_id"`` (default) or ``"session_id"``.
+            Selects which field of :class:`AirlockContext` keys the
+            per-session trace. Falls back to ``"__anonymous__"`` if both
+            are absent — and emits a structlog warning so deployments
+            without identity don't silently log everything to one bucket.
+    """
+
+    mode: SequenceGuardMode
+    action: SequenceGuardAction = "block"
+    dag: Mapping[str, Iterable[str]] | None = None
+    baseline_path: Path | None = None
+    low_probability_threshold: float = 0.05
+    min_baseline_samples: int = 50
+    session_key_kind: SessionKeyKind = "agent_id"
+
+    # --- internal state ---------------------------------------------------
+
+    _traces: dict[str, _SessionTrace] = field(default_factory=dict, repr=False)
+    _baseline_cache: dict[str, dict[str, dict[str, int]]] | None = field(default=None, repr=False)
+    _normalised_dag: dict[str, frozenset[str]] | None = field(default=None, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.mode == "declared":
+            if self.dag is None:
+                raise ValueError("SequenceGuard(mode='declared') requires a `dag` mapping")
+            self._normalised_dag = {key: frozenset(values) for key, values in self.dag.items()}
+            if ENTRY_SENTINEL not in self._normalised_dag:
+                raise ValueError(
+                    f"SequenceGuard.dag must include the {ENTRY_SENTINEL!r} "
+                    "key listing tool names permitted as the first call"
+                )
+        elif self.mode == "baseline":
+            if self.baseline_path is None:
+                raise ValueError("SequenceGuard(mode='baseline') requires a `baseline_path`")
+            if not (0.0 < self.low_probability_threshold <= 1.0):
+                raise ValueError(
+                    "low_probability_threshold must be in (0.0, 1.0]; "
+                    f"got {self.low_probability_threshold!r}"
+                )
+            if self.min_baseline_samples < 1:
+                raise ValueError(
+                    f"min_baseline_samples must be >= 1; got {self.min_baseline_samples!r}"
+                )
+        else:
+            raise ValueError(
+                f"SequenceGuard.mode must be 'declared' or 'baseline'; got {self.mode!r}"
+            )
+        if self.action not in ("block", "warn"):
+            raise ValueError(f"SequenceGuard.action must be 'block' or 'warn'; got {self.action!r}")
+
+    # -- Public API -------------------------------------------------------
+
+    def record_and_check(
+        self,
+        *,
+        session_key: str,
+        tool_name: str,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> None:
+        """Append the call to its session trace and flag if it violates.
+
+        Args:
+            session_key: Identifier for this session — typically
+                ``context.agent_id`` or ``context.session_id`` depending
+                on :attr:`session_key_kind`. The caller resolves the
+                identifier; this method does not consult
+                ``AirlockContext`` directly so it stays trivially testable.
+            tool_name: The tool about to be invoked.
+            args: Positional arguments — used only for the shape hash.
+                Values are never read.
+            kwargs: Keyword arguments — same shape-only treatment.
+
+        Raises:
+            SequenceViolation: ``action="block"`` and the transition is
+                flagged. ``action="warn"`` never raises.
+        """
+        shape = args_shape_hash(args, kwargs)
+        with self._lock:
+            trace = self._traces.setdefault(session_key, _SessionTrace())
+            previous = trace.last_tool
+            trace.history.append((tool_name, shape))
+            trace.last_tool = tool_name
+
+            if self.mode == "declared":
+                self._check_declared(
+                    session_key=session_key,
+                    previous=previous,
+                    tool_name=tool_name,
+                )
+            else:
+                self._check_baseline(
+                    session_key=session_key,
+                    previous=previous,
+                    tool_name=tool_name,
+                )
+
+    def reset(self, session_key: str | None = None) -> None:
+        """Drop in-memory trace(s).
+
+        Args:
+            session_key: If supplied, only that session's trace is dropped.
+                If ``None``, every in-memory trace is dropped. The
+                persisted baseline JSON (if any) is NOT touched.
+        """
+        with self._lock:
+            if session_key is None:
+                self._traces.clear()
+            else:
+                self._traces.pop(session_key, None)
+
+    def history(self, session_key: str) -> list[tuple[str, str]]:
+        """Return a snapshot copy of ``session_key``'s ordered trace.
+
+        Returned tuples are ``(tool_name, shape_hash)``. The list is a
+        copy — mutating it does not affect the guard's state.
+        """
+        with self._lock:
+            trace = self._traces.get(session_key)
+            return list(trace.history) if trace is not None else []
+
+    # -- Internals --------------------------------------------------------
+
+    def _check_declared(self, *, session_key: str, previous: str | None, tool_name: str) -> None:
+        assert self._normalised_dag is not None  # noqa: S101  # nosec B101 - guarded by __post_init__
+        dag = self._normalised_dag
+
+        if previous is None:
+            permitted = dag.get(ENTRY_SENTINEL, frozenset())
+            if tool_name not in permitted:
+                self._raise_or_warn(
+                    SequenceViolation(
+                        message=(
+                            f"sequence_guard: tool {tool_name!r} is not in the "
+                            f"entry set {sorted(permitted)!r}"
+                        ),
+                        mode="declared",
+                        from_tool=None,
+                        to_tool=tool_name,
+                        session_key=session_key,
+                    ),
+                )
+            return
+
+        permitted_next = dag.get(previous, frozenset())
+        if tool_name not in permitted_next:
+            self._raise_or_warn(
+                SequenceViolation(
+                    message=(
+                        f"sequence_guard: transition {previous!r} -> "
+                        f"{tool_name!r} is not in the declared DAG "
+                        f"(permitted from {previous!r}: {sorted(permitted_next)!r})"
+                    ),
+                    mode="declared",
+                    from_tool=previous,
+                    to_tool=tool_name,
+                    session_key=session_key,
+                ),
+            )
+
+    def _check_baseline(self, *, session_key: str, previous: str | None, tool_name: str) -> None:
+        baseline = self._load_baseline()
+        per_key = baseline.setdefault(session_key, {})
+
+        prev_key = previous if previous is not None else PREV_NONE_SENTINEL
+        outbound = per_key.setdefault(prev_key, {})
+        total_before = sum(outbound.values())
+        count_curr_before = outbound.get(tool_name, 0)
+
+        # Record the transition BEFORE evaluating — so a re-run with the
+        # same ``baseline_path`` continues from a consistent state.
+        outbound[tool_name] = count_curr_before + 1
+        self._persist_baseline(baseline)
+
+        if total_before < self.min_baseline_samples:
+            # Cold-start: do not flag until enough outbound samples exist.
+            return
+
+        observed_p = count_curr_before / total_before
+        if observed_p < self.low_probability_threshold:
+            self._raise_or_warn(
+                SequenceViolation(
+                    message=(
+                        f"sequence_guard: low-probability transition "
+                        f"{previous!r} -> {tool_name!r} "
+                        f"(observed P={observed_p:.4f}, threshold="
+                        f"{self.low_probability_threshold:.4f}, "
+                        f"samples_from_prev={total_before})"
+                    ),
+                    mode="baseline",
+                    from_tool=previous,
+                    to_tool=tool_name,
+                    session_key=session_key,
+                    observed_probability=observed_p,
+                ),
+            )
+
+    def _load_baseline(self) -> dict[str, dict[str, dict[str, int]]]:
+        """Load (or lazily initialise) the baseline JSON cache.
+
+        Cached after the first read so repeat calls do not re-read disk.
+        Caller is expected to hold ``self._lock`` when invoking this.
+        """
+        if self._baseline_cache is not None:
+            return self._baseline_cache
+        assert self.baseline_path is not None  # noqa: S101  # nosec B101 - guarded by __post_init__
+        if self.baseline_path.exists():
+            try:
+                raw = json.loads(self.baseline_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "sequence_guard.baseline_load_failed",
+                    path=str(self.baseline_path),
+                    error=str(exc),
+                )
+                raw = {}
+        else:
+            raw = {}
+        # Defensive shape coercion: missing nested dicts become {} on read.
+        coerced: dict[str, dict[str, dict[str, int]]] = {}
+        if isinstance(raw, dict):
+            for sk, prev_map in raw.items():
+                if not isinstance(prev_map, dict):
+                    continue
+                coerced[sk] = {}
+                for prev, next_map in prev_map.items():
+                    if not isinstance(next_map, dict):
+                        continue
+                    coerced[sk][prev] = {
+                        k: int(v) for k, v in next_map.items() if isinstance(v, int)
+                    }
+        self._baseline_cache = coerced
+        return coerced
+
+    def _persist_baseline(self, baseline: dict[str, dict[str, dict[str, int]]]) -> None:
+        """Atomically rewrite the baseline JSON.
+
+        Tempfile + rename to avoid leaving a partial file on disk if the
+        process is killed mid-write. Caller is expected to hold
+        ``self._lock``.
+        """
+        assert self.baseline_path is not None  # noqa: S101  # nosec B101 - guarded by __post_init__
+        self.baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.baseline_path.with_suffix(self.baseline_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(baseline, separators=(",", ":")), encoding="utf-8")
+        tmp.replace(self.baseline_path)
+
+    def _raise_or_warn(self, exc: SequenceViolation) -> None:
+        """Emit the OTel attribute, then either raise or log per ``action``.
+
+        The OTel attribute path is best-effort: we only touch the
+        provider if a current span exists, so importing this module
+        doesn't force OpenTelemetry on environments that don't use it.
+        """
+        self._emit_otel(exc)
+        if self.action == "block":
+            logger.warning(
+                "sequence_guard.violation_block",
+                **{k: v for k, v in exc.details.items() if v is not None},
+            )
+            raise exc
+        logger.warning(
+            "sequence_guard.violation_warn",
+            **{k: v for k, v in exc.details.items() if v is not None},
+        )
+
+    @staticmethod
+    def _emit_otel(exc: SequenceViolation) -> None:
+        """Best-effort OTel span attribute emission.
+
+        Reuses the existing ``observability`` provider — does not import
+        ``opentelemetry`` at module import time. Failures here are
+        swallowed deliberately: telemetry must never break enforcement.
+        """
+        try:
+            from .observability import get_provider
+
+            provider = get_provider()
+            tracer = getattr(provider, "_tracer", None)
+            if tracer is None:
+                return
+            current_span_fn = getattr(tracer, "get_current_span", None)
+            span = current_span_fn() if current_span_fn else None
+            if span is None or not hasattr(span, "set_attribute"):
+                return
+            span.set_attribute("airlock.sequence_guard.mode", exc.mode)
+            span.set_attribute(
+                "airlock.sequence_guard.from_tool",
+                exc.from_tool if exc.from_tool is not None else "__entry__",
+            )
+            span.set_attribute("airlock.sequence_guard.to_tool", exc.to_tool)
+            span.set_attribute("airlock.sequence_guard.session_key", exc.session_key)
+            if exc.observed_probability is not None:
+                span.set_attribute(
+                    "airlock.sequence_guard.observed_probability",
+                    float(exc.observed_probability),
+                )
+        except Exception as inner:  # noqa: BLE001
+            logger.debug("sequence_guard.otel_emit_failed", error=str(inner))
+
+
+__all__ = [
+    "ENTRY_SENTINEL",
+    "PREV_NONE_SENTINEL",
+    "SequenceGuard",
+    "SequenceGuardAction",
+    "SequenceGuardMode",
+    "SequenceViolation",
+    "SessionKeyKind",
+    "args_shape_hash",
+]

--- a/tests/test_sequence_guard.py
+++ b/tests/test_sequence_guard.py
@@ -1,0 +1,495 @@
+"""Tests for the behavioral tool-call sequence guard (v0.8.12, arXiv:2605.27901).
+
+Coverage matrix (per the brief's #5):
+
+- Clean declared-DAG run admits a permitted sequence end-to-end.
+- DAG violation in ``block`` mode raises :class:`SequenceViolation`.
+- DAG violation in ``warn`` mode does NOT raise (logs + emits OTel attr).
+- BASELINE mode flags a low-probability transition after the cold-start
+  window passes.
+- BASELINE mode does NOT flag while the sample size is below
+  ``min_baseline_samples`` (cold-start).
+- ``args_shape_hash`` is stable across value variation but distinguishes
+  arg-count / type / keyword shape.
+- The persisted baseline JSON never contains argument values.
+- The ``@Airlock`` integration: a DAG violation surfaces through the
+  existing ``handle_policy_violation`` path as a blocked
+  ``AirlockResponse``.
+- ``SecurityPolicy.sequence_guard`` is an additive, optional field
+  (default-None policies are byte-identical to v0.8.11 behavior).
+- Thread safety: concurrent ``record_and_check`` calls preserve the
+  per-session ordering invariant.
+- OTel span attributes are emitted on a flag (assert via an in-memory
+  patched span).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_airlock import Airlock, SecurityPolicy
+from agent_airlock.context import AirlockContext
+from agent_airlock.policy import PolicyViolation
+from agent_airlock.sequence_guard import (
+    ENTRY_SENTINEL,
+    PREV_NONE_SENTINEL,
+    SequenceGuard,
+    SequenceViolation,
+    args_shape_hash,
+)
+
+# ---------------------------------------------------------------------------
+# args_shape_hash — privacy + stability invariants
+# ---------------------------------------------------------------------------
+
+
+class TestArgsShapeHash:
+    def test_empty_shape_is_stable(self) -> None:
+        assert args_shape_hash((), {}) == args_shape_hash((), {})
+
+    def test_value_invariance_one_string_arg(self) -> None:
+        """Two different string values must hash identically — proves no values are
+        included in the hash."""
+        h1 = args_shape_hash(("first",), {})
+        h2 = args_shape_hash(("totally-different-second-string",), {})
+        assert h1 == h2
+
+    def test_arg_count_changes_hash(self) -> None:
+        assert args_shape_hash(("a",), {}) != args_shape_hash(("a", "b"), {})
+
+    def test_arg_type_changes_hash(self) -> None:
+        assert args_shape_hash(("a",), {}) != args_shape_hash((1,), {})
+
+    def test_kwarg_key_changes_hash(self) -> None:
+        assert args_shape_hash((), {"x": 1}) != args_shape_hash((), {"y": 1})
+
+    def test_kwarg_insertion_order_does_not_change_hash(self) -> None:
+        assert args_shape_hash((), {"a": 1, "b": 2}) == args_shape_hash((), {"b": 2, "a": 1})
+
+    def test_kwarg_value_invariance(self) -> None:
+        """Distinct values for the same keyword key with the same type must hash
+        identically — proves the hash is shape-only."""
+        h1 = args_shape_hash((), {"name": "Alice"})
+        h2 = args_shape_hash((), {"name": "Bob"})
+        assert h1 == h2
+
+
+# ---------------------------------------------------------------------------
+# SequenceGuard construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestSequenceGuardConstruction:
+    def test_declared_requires_dag(self) -> None:
+        with pytest.raises(ValueError, match="requires a `dag`"):
+            SequenceGuard(mode="declared")
+
+    def test_declared_dag_must_include_entry(self) -> None:
+        with pytest.raises(ValueError, match="__entry__"):
+            SequenceGuard(mode="declared", dag={"read": {"write"}})
+
+    def test_baseline_requires_path(self) -> None:
+        with pytest.raises(ValueError, match="requires a `baseline_path`"):
+            SequenceGuard(mode="baseline")
+
+    @pytest.mark.parametrize("threshold", [0.0, -0.1, 1.5])
+    def test_baseline_threshold_must_be_in_unit_interval(
+        self, tmp_path: Path, threshold: float
+    ) -> None:
+        with pytest.raises(ValueError, match="low_probability_threshold"):
+            SequenceGuard(
+                mode="baseline",
+                baseline_path=tmp_path / "b.json",
+                low_probability_threshold=threshold,
+            )
+
+    def test_baseline_min_samples_must_be_positive(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="min_baseline_samples"):
+            SequenceGuard(
+                mode="baseline",
+                baseline_path=tmp_path / "b.json",
+                min_baseline_samples=0,
+            )
+
+    def test_unknown_mode_rejected(self) -> None:
+        with pytest.raises(ValueError, match="mode must be"):
+            SequenceGuard(mode="other")  # type: ignore[arg-type]
+
+    def test_unknown_action_rejected(self) -> None:
+        with pytest.raises(ValueError, match="action must be"):
+            SequenceGuard(
+                mode="declared",
+                action="silent",  # type: ignore[arg-type]
+                dag={ENTRY_SENTINEL: {"r"}},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Declared-DAG mode
+# ---------------------------------------------------------------------------
+
+
+class TestDeclaredDAGMode:
+    def _guard_rw(self, action: str = "block") -> SequenceGuard:
+        return SequenceGuard(
+            mode="declared",
+            action=action,  # type: ignore[arg-type]
+            dag={
+                ENTRY_SENTINEL: {"read"},
+                "read": {"write", "read"},
+                "write": {"write"},
+            },
+        )
+
+    def test_clean_run_admits_permitted_sequence(self) -> None:
+        g = self._guard_rw()
+        g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+        g.record_and_check(session_key="ag1", tool_name="write", args=(), kwargs={})
+        g.record_and_check(session_key="ag1", tool_name="write", args=(), kwargs={})
+
+        history = g.history("ag1")
+        assert [t for t, _ in history] == ["read", "write", "write"]
+
+    def test_block_mode_raises_on_disallowed_entry(self) -> None:
+        g = self._guard_rw()
+        with pytest.raises(SequenceViolation) as exc:
+            g.record_and_check(session_key="ag1", tool_name="write", args=(), kwargs={})
+        assert exc.value.mode == "declared"
+        assert exc.value.from_tool is None
+        assert exc.value.to_tool == "write"
+        # The exception preserves PolicyViolation semantics so the
+        # existing core.py handler picks it up.
+        assert isinstance(exc.value, PolicyViolation)
+
+    def test_block_mode_raises_on_disallowed_transition(self) -> None:
+        g = self._guard_rw()
+        g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+        with pytest.raises(SequenceViolation) as exc:
+            g.record_and_check(session_key="ag1", tool_name="delete", args=(), kwargs={})
+        assert exc.value.from_tool == "read"
+        assert exc.value.to_tool == "delete"
+
+    def test_warn_mode_does_not_raise_on_violation(self) -> None:
+        g = self._guard_rw(action="warn")
+        # Disallowed first call — should warn, not raise.
+        g.record_and_check(session_key="ag1", tool_name="delete", args=(), kwargs={})
+        # The trace is still recorded so the next call's "previous" is correct.
+        assert g.history("ag1") == [("delete", args_shape_hash((), {}))]
+
+    def test_per_session_isolation(self) -> None:
+        g = self._guard_rw()
+        g.record_and_check(session_key="A", tool_name="read", args=(), kwargs={})
+        # Session B's first call must still be an entry-permitted tool;
+        # session A's trace must not affect session B's view of "previous".
+        g.record_and_check(session_key="B", tool_name="read", args=(), kwargs={})
+        with pytest.raises(SequenceViolation):
+            g.record_and_check(session_key="B", tool_name="delete", args=(), kwargs={})
+
+    def test_reset_clears_only_named_session(self) -> None:
+        g = self._guard_rw()
+        g.record_and_check(session_key="A", tool_name="read", args=(), kwargs={})
+        g.record_and_check(session_key="B", tool_name="read", args=(), kwargs={})
+        g.reset("A")
+        assert g.history("A") == []
+        assert g.history("B") != []
+
+    def test_reset_all(self) -> None:
+        g = self._guard_rw()
+        g.record_and_check(session_key="A", tool_name="read", args=(), kwargs={})
+        g.record_and_check(session_key="B", tool_name="read", args=(), kwargs={})
+        g.reset()
+        assert g.history("A") == []
+        assert g.history("B") == []
+
+
+# ---------------------------------------------------------------------------
+# Baseline (Markov) mode
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineMode:
+    def test_cold_start_does_not_flag_below_min_samples(self, tmp_path: Path) -> None:
+        g = SequenceGuard(
+            mode="baseline",
+            baseline_path=tmp_path / "b.json",
+            low_probability_threshold=0.5,
+            min_baseline_samples=10,
+        )
+        # 9 outbound observations from the entry-sentinel — below the floor.
+        for _ in range(9):
+            g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+            # Reset so each call is an entry (previous is None) so the
+            # outbound bucket is PREV_NONE_SENTINEL.
+            g.reset("ag1")
+        # All admitted; no flag.
+
+    def test_flags_low_probability_transition_post_cold_start(self, tmp_path: Path) -> None:
+        g = SequenceGuard(
+            mode="baseline",
+            baseline_path=tmp_path / "b.json",
+            low_probability_threshold=0.10,
+            min_baseline_samples=20,
+        )
+        # The baseline is keyed per session_key, so warm and surprise must
+        # share the key. 30 alternating read<->write pairs on session "ag1"
+        # build up the read->write transition count beyond the
+        # min_baseline_samples floor.
+        for _ in range(30):
+            g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+            g.record_and_check(session_key="ag1", tool_name="write", args=(), kwargs={})
+
+        # Next call: read after write. Transition write->read has been
+        # well-observed; admitted.
+        g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+        # Now read->delete. P(delete | read) = 0/30 = 0.0, well below
+        # threshold 0.10. Sample size from 'read' is 30 >= 20. → Flag.
+        with pytest.raises(SequenceViolation) as exc:
+            g.record_and_check(session_key="ag1", tool_name="delete", args=(), kwargs={})
+        assert exc.value.mode == "baseline"
+        assert exc.value.observed_probability == 0.0
+
+    def test_frequent_transition_above_threshold_does_not_flag(self, tmp_path: Path) -> None:
+        g = SequenceGuard(
+            mode="baseline",
+            baseline_path=tmp_path / "b.json",
+            low_probability_threshold=0.10,
+            min_baseline_samples=10,
+        )
+        # Single session_key — 15 alternating read<->write pairs. After
+        # warmup: count(read -> write) = 15 and count(read -> *) = 15, so
+        # P(write | read) = 1.0 — comfortably above the 0.10 floor.
+        for _ in range(15):
+            g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+            g.record_and_check(session_key="ag1", tool_name="write", args=(), kwargs={})
+        # The 16th read->write must NOT flag (the high-probability path).
+        g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+        g.record_and_check(session_key="ag1", tool_name="write", args=(), kwargs={})
+
+    def test_persisted_baseline_never_contains_argument_values(self, tmp_path: Path) -> None:
+        path = tmp_path / "b.json"
+        g = SequenceGuard(
+            mode="baseline",
+            baseline_path=path,
+            min_baseline_samples=1,
+            low_probability_threshold=0.01,
+        )
+        # The kwargs include an obviously-sensitive-looking value; assert
+        # it is NEVER serialised to disk.
+        g.record_and_check(
+            session_key="ag1",
+            tool_name="read",
+            args=("very-secret-bearer-token-ABCDEF",),
+            kwargs={"password": "should-not-be-on-disk"},
+        )
+        contents = path.read_text(encoding="utf-8")
+        assert "very-secret-bearer-token-ABCDEF" not in contents
+        assert "should-not-be-on-disk" not in contents
+        # But the tool name DOES appear — that's the legitimate signal.
+        assert "read" in contents
+
+    def test_persisted_baseline_loads_round_trip(self, tmp_path: Path) -> None:
+        """A guard reading an existing baseline JSON resumes its counts."""
+        path = tmp_path / "b.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "ag1": {
+                        PREV_NONE_SENTINEL: {"read": 100},
+                        "read": {"write": 95, "delete": 0},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        g = SequenceGuard(
+            mode="baseline",
+            baseline_path=path,
+            min_baseline_samples=10,
+            low_probability_threshold=0.10,
+        )
+        # First call from 'read': we have 95 'write' samples, 0 'delete'.
+        g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+        with pytest.raises(SequenceViolation):
+            g.record_and_check(session_key="ag1", tool_name="delete", args=(), kwargs={})
+
+
+# ---------------------------------------------------------------------------
+# OTel attribute emission
+# ---------------------------------------------------------------------------
+
+
+class TestOtelEmission:
+    def test_block_path_sets_attributes_on_current_span(self) -> None:
+        """When a span is available, the guard records its decision on it."""
+        from agent_airlock import observability
+
+        fake_span = MagicMock()
+        fake_span.set_attribute = MagicMock()
+        fake_tracer = MagicMock()
+        fake_tracer.get_current_span = MagicMock(return_value=fake_span)
+        fake_provider = MagicMock()
+        fake_provider._tracer = fake_tracer
+
+        g = SequenceGuard(
+            mode="declared",
+            dag={ENTRY_SENTINEL: {"read"}, "read": {"write"}},
+        )
+        g.record_and_check(session_key="ag1", tool_name="read", args=(), kwargs={})
+        with patch.object(observability, "get_provider", return_value=fake_provider):
+            with pytest.raises(SequenceViolation):
+                g.record_and_check(session_key="ag1", tool_name="delete", args=(), kwargs={})
+
+        # Check the canonical attributes were set.
+        called_keys = {c.args[0] for c in fake_span.set_attribute.call_args_list}
+        assert "airlock.sequence_guard.mode" in called_keys
+        assert "airlock.sequence_guard.from_tool" in called_keys
+        assert "airlock.sequence_guard.to_tool" in called_keys
+        assert "airlock.sequence_guard.session_key" in called_keys
+
+    def test_otel_failure_is_swallowed(self) -> None:
+        """Telemetry failure must never break enforcement."""
+        from agent_airlock import observability
+
+        fake_provider = MagicMock()
+        # Accessing _tracer raises — simulates a broken provider.
+        type(fake_provider)._tracer = property(
+            lambda _self: (_ for _ in ()).throw(RuntimeError("otel broken"))
+        )
+
+        g = SequenceGuard(
+            mode="declared",
+            dag={ENTRY_SENTINEL: {"read"}},
+        )
+        with patch.object(observability, "get_provider", return_value=fake_provider):
+            with pytest.raises(SequenceViolation):
+                g.record_and_check(session_key="ag1", tool_name="delete", args=(), kwargs={})
+
+
+# ---------------------------------------------------------------------------
+# Thread safety smoke
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_record_preserves_per_session_history_length(self) -> None:
+        """Hammer one session from N threads — final history length must
+        equal the total number of admitted calls, with no lost or
+        duplicated entries.
+        """
+        g = SequenceGuard(
+            mode="declared",
+            dag={
+                ENTRY_SENTINEL: {"read"},
+                "read": {"read"},  # self-loop so concurrent calls all admit
+            },
+        )
+        # Seed the entry.
+        g.record_and_check(session_key="ag", tool_name="read", args=(), kwargs={})
+
+        N_THREADS = 8
+        N_CALLS = 50
+
+        def worker() -> None:
+            for _ in range(N_CALLS):
+                g.record_and_check(session_key="ag", tool_name="read", args=(), kwargs={})
+
+        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # 1 seed + N_THREADS * N_CALLS admitted calls.
+        assert len(g.history("ag")) == 1 + N_THREADS * N_CALLS
+
+
+# ---------------------------------------------------------------------------
+# SecurityPolicy + @Airlock integration
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityPolicyIntegration:
+    def test_default_policy_has_no_sequence_guard(self) -> None:
+        """v0.8.11 callers see no behavior change: the field defaults to None."""
+        policy = SecurityPolicy()
+        assert policy.sequence_guard is None
+
+    def test_existing_preset_policies_unaffected(self) -> None:
+        """The new field must not appear in __repr__ of presets in a way that
+        breaks construction or printing."""
+        from agent_airlock import PERMISSIVE_POLICY, READ_ONLY_POLICY, STRICT_POLICY
+
+        for p in (PERMISSIVE_POLICY, READ_ONLY_POLICY, STRICT_POLICY):
+            assert p.sequence_guard is None
+            # repr must not crash with the new field
+            assert "SecurityPolicy" in repr(p)
+
+    def test_airlock_seam_blocks_dag_violation(self) -> None:
+        policy = SecurityPolicy(
+            sequence_guard=SequenceGuard(
+                mode="declared",
+                dag={ENTRY_SENTINEL: {"read"}, "read": {"write"}},
+            ),
+        )
+
+        @Airlock(policy=policy)
+        def read() -> str:
+            return "read-ok"
+
+        @Airlock(policy=policy)
+        def write() -> str:
+            return "write-ok"
+
+        @Airlock(policy=policy)
+        def delete() -> str:
+            return "delete-ok"
+
+        with AirlockContext(agent_id="ag1"):
+            assert read() == "read-ok"
+            assert write() == "write-ok"
+            blocked = delete()
+
+        assert isinstance(blocked, dict)
+        assert blocked.get("status") == "blocked"
+        assert "sequence_guard" in blocked.get("error", "")
+
+    def test_airlock_seam_warn_mode_does_not_block(self) -> None:
+        policy = SecurityPolicy(
+            sequence_guard=SequenceGuard(
+                mode="declared",
+                action="warn",
+                dag={ENTRY_SENTINEL: {"read"}, "read": {"write"}},
+            ),
+        )
+
+        @Airlock(policy=policy)
+        def delete() -> str:
+            return "delete-ok"
+
+        with AirlockContext(agent_id="ag2"):
+            assert delete() == "delete-ok"
+
+    def test_airlock_seam_admits_clean_run(self) -> None:
+        policy = SecurityPolicy(
+            sequence_guard=SequenceGuard(
+                mode="declared",
+                dag={ENTRY_SENTINEL: {"read"}, "read": {"write"}, "write": set()},
+            ),
+        )
+
+        @Airlock(policy=policy)
+        def read() -> str:
+            return "r"
+
+        @Airlock(policy=policy)
+        def write() -> str:
+            return "w"
+
+        with AirlockContext(agent_id="ag-clean"):
+            assert read() == "r"
+            assert write() == "w"


### PR DESCRIPTION
## Summary

Adds **`SequenceGuard`** — an opt-in behavioral-only sequence anomaly guard that watches the **ordered stream of tool calls** within a session and flags divergence from a declared expected order. By construction it does *not* read the model's reasoning trace.

**Why behavior-only.** [arXiv:2605.27901](https://arxiv.org/abs/2605.27901) — "The Fragility of Chain-of-Thought Monitoring Across Typologically Diverse Languages" (Onyame, Zhou, Thopalli, Kailkhura & Agarwal, May 2026) — reports an average **95.9% CoT unfaithfulness across 8B–120B-parameter models**, including answer-switching, post-hoc rationalisation, and procedural exploitation of hints. Trusting the model's stated reasoning to detect misbehavior is not viable. Trusting its behavior is.

## Discrepancies from the brief — surfaced before coding

| # | Brief said | Reality on `main` | What I did |
|---|---|---|---|
| A | Bump `v0.8.4 → v0.8.5` | We're at **`v0.8.11`**; `v0.8.5` already tagged (`757f0d7`) — 6 tags newer. | Bump **`0.8.11 → 0.8.12`** (opt-in additive field on `SecurityPolicy`; no API break). |
| B | "Push to main (solo maintainer)" | #60–#71 all PR-gated; you chose PR workflow on the last 2 features. | PR workflow (consistent). |
| C | Coverage ≥ 82% | CI flag is `--cov-fail-under=80`, pyproject says 82. CI flag wins; #71 ran at 82.82%. | This PR achieves **83.95%** locally — passes both gates. |
| D | "Behavioral" without naming `anomaly.py` | `agent_airlock.anomaly.AnomalyDetector` already exists but covers rate / diversity / error-rate / consecutive-blocked (aggregate per-window). SequenceGuard is per-transition ORDER — different surface. | New sibling module; disambiguated in docstring + CHANGELOG. |

## Modes

### DECLARED — operator-supplied DAG, deny-by-default

```python
from agent_airlock import SecurityPolicy
from agent_airlock.sequence_guard import SequenceGuard, ENTRY_SENTINEL

policy = SecurityPolicy(
    sequence_guard=SequenceGuard(
        mode="declared",
        action="block",
        dag={
            ENTRY_SENTINEL: {"read"},
            "read": {"read", "summarize"},
            "summarize": {"send"},
            "send": set(),
        },
    ),
)
```

### BASELINE — learned Markov profile, fails closed past threshold

```python
from pathlib import Path
from agent_airlock.sequence_guard import SequenceGuard

policy = SecurityPolicy(
    sequence_guard=SequenceGuard(
        mode="baseline",
        baseline_path=Path("/var/lib/airlock/sequence-baseline.json"),
        low_probability_threshold=0.05,
        min_baseline_samples=50,
    ),
)
```

The baseline JSON contains **only tool names and SHA-256 shape hashes of `(arg types, kwarg names+types)` — never argument values**. PII / secrets cannot reach disk via this module. Asserted by an explicit privacy test.

## Surfaces

| File | Change |
|---|---|
| `src/agent_airlock/sequence_guard.py` | **NEW** module (530 lines): `SequenceGuard` (`@dataclass`, thread-safe), `SequenceViolation(PolicyViolation)`, `args_shape_hash()`, `ENTRY_SENTINEL` / `PREV_NONE_SENTINEL`, mode + action literal types |
| `src/agent_airlock/policy.py` | **NEW** optional field `SecurityPolicy.sequence_guard: SequenceGuard \| None = None` (TYPE_CHECKING import to dodge the cycle). Default `None` preserves v0.8.11 behavior exactly. |
| `src/agent_airlock/core.py` | **NEW** `Airlock._check_sequence_guard(...)` private method + Step 2.5 wire-in right after the standard policy check. Routes a block decision through the existing `handle_policy_violation` → `on_blocked` callback chain. |
| `tests/test_sequence_guard.py` | **NEW** — 36 tests |
| `scripts/smoke_sequence_guard.py` | **NEW** — wheel-install end-to-end smoke (base install, no extras) |
| `README.md` | New "🧭 Behavioral sequence guard (v0.8.12)" subsection citing the paper + the 95.9% figure |
| `CHANGELOG.md` | `[Unreleased]` v0.8.12 entry above the v0.8.11 / v0.8.10 / v0.8.9 entries |
| `pyproject.toml` | Version bump only — **no new deps**, runtime stays Pydantic-only |

## Test plan — 36 new tests, all green

Coverage matrix (matches the brief's #5 explicitly):

- **`args_shape_hash` invariants** (value invariance, arity sensitivity, type sensitivity, keyword sensitivity, insertion-order independence, kwarg value invariance)
- **Construction validation** (mode, action, DAG entry sentinel, threshold range, min-samples positivity)
- **Declared-DAG**: clean run admits, disallowed entry blocks, disallowed transition blocks, **warn-mode no-raise**, per-session isolation, reset semantics (named + global)
- **Baseline mode**: cold-start floor (no flag below min-samples), **low-probability flag post-warmup**, no flag at high P, **privacy guarantee** (argument values never on disk), round-trip load from disk
- **OTel emission**: span attributes set on flag; telemetry-failure-swallowed regression
- **Thread safety**: 8 threads × 50 concurrent calls preserve per-session history-length invariant
- **`SecurityPolicy` integration**: default-None policies + PERMISSIVE/READ_ONLY/STRICT presets unaffected
- **`@Airlock` end-to-end**: clean run / block-mode DAG violation surfaces as a blocked `AirlockResponse` / warn-mode admits

## Gate results

| Gate | Result |
|---|---|
| `ruff check src/ tests/` | ✅ All checks passed |
| `ruff format --check src/ tests/` | ✅ 328 files clean |
| `bandit -r src/agent_airlock/` | ✅ exit 0 (no findings — `# nosec B101` already in place for the two type-narrowing `assert`s in `_check_declared` / `_load_baseline`) |
| `mypy src/` net delta | ✅ **8 → 8** baseline errors; new module is mypy-clean |
| `pytest tests/` | ✅ **2683 pass**, 33 skipped (+36 new sequence_guard tests; the existing perf P99 flake did not trigger) |
| `pytest --cov-fail-under=80` (CI gate) | ✅ **83.95% total coverage** |
| `pytest --cov-fail-under=82` (pyproject gate) | ✅ 83.95% > 82 |
| `python3 scripts/smoke_sequence_guard.py` | ✅ Wheel built (`agent_airlock-0.8.12-py3-none-any.whl`), installed into a base venv (**no extras**), DAG admit + block + shape-hash value-invariance all assert green against the installed wheel |
| `make check-changelog-release` | ✅ `OK ([Unreleased] has release notes)` |

## No-pivot

Strictly opt-in. `SecurityPolicy.sequence_guard` defaults to `None`; existing callers see no behavior change. **Zero new runtime deps** — Pydantic-only core stays intact (asserted by the smoke installing the wheel with no extras and the guard still working). Deny-by-default posture stays.

## Reference

- Onyame, E., Zhou, R., Thopalli, K., Kailkhura, B. & Agarwal, C. *The Fragility of Chain-of-Thought Monitoring Across Typologically Diverse Languages.* [arXiv:2605.27901](https://arxiv.org/abs/2605.27901) (2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
