### PR TITLE
feat(cli): add `airlock explain --unused-scopes` for privilege right-sizing (read-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `airlock-explain --unused-scopes` privilege right-sizing reporter (v0.8.13)
+
+`airlock-explain` — a new **read-only** CLI that surfaces
+over-permissioning by diffing `SecurityPolicy.allowed_tools` (granted
+scopes) against the tools an agent actually called (extracted from a
+run trace), per `AgentIdentity`. Prints, per agent: granted-but-never-
+used scopes (the dead-weight set), the observed tool set, and (with
+`--suggest-policy`) a *proposed* tightened allow-list as a stdout
+preview.
+
+```bash
+pip install "agent-airlock>=0.8.13"
+airlock-explain --unused-scopes \
+    --policy ./security-policy.toml \
+    --trace  ./agent.audit.jsonl \
+    --format json \
+    --suggest-policy
+```
+
+**Read-only contract.** This command **never** mutates a
+`SecurityPolicy`, **never** writes the policy file, and **never**
+installs itself into the deny-by-default enforcement path. The
+`--suggest-policy` output is intentionally a stdout preview so a human
+reviews the tightened allow-list before adopting it by hand. A
+regression test (`test_read_only_contract_policy_file_unchanged`)
+asserts byte-equality of the policy file before and after a
+`--suggest-policy` run.
+
+**Trace formats** — auto-detected by inspecting the file head:
+
+- **Audit JSONL** — the format `agent_airlock.audit.AuditLogger` already
+  emits. Lines starting with `#` are header-skipped; lines with
+  `blocked: true` are excluded (a blocked call is not an exercise of
+  a granted scope); missing `agent_id` falls back to `__anonymous__`.
+- **OTLP JSON** — the format `opentelemetry-exporter-otlp` writes
+  (top-level `resourceSpans[*].scopeSpans[*].spans[*]`). Span `name`
+  is the tool name; the OTLP `AnyValue` union (`stringValue` /
+  `boolValue` / `intValue` / `doubleValue`) is decoded for attribute
+  lookup. `agent_id` is resolved span-attrs → resource-attrs →
+  `__anonymous__`. Spans carrying `airlock.blocked=true` are skipped.
+
+**Diff semantics.** The matcher is `fnmatch.fnmatch` — the same glob
+semantics `SecurityPolicy.check_tool_allowed` uses internally, so the
+suggested tightened allow-list admits exactly the tools the agent was
+observed calling (asserted by
+`test_glob_matching_matches_securitypolicy_semantics`). Denied-list
+patterns are forwarded unchanged to the suggestion — denials are
+*intent*, not usage data.
+
+Surfaces:
+
+- `agent_airlock.cli.explain` — new module:
+  - `main(argv) -> int` argparse entrypoint with `--unused-scopes`,
+    `--policy <file>`, `--trace <file>`, `--format {table,json}`,
+    `--suggest-policy`.
+  - `CallObservation`, `AgentUsageReport`, `PolicySnapshot` dataclasses.
+  - `load_trace(path)`, `load_policy(path)`,
+    `diff_granted_vs_used(policy, observations)`,
+    `suggest_tightened_policy(report, denied_tools)` as testable
+    pure-function building blocks.
+- `pyproject.toml` — **new** `[project.scripts]` block. This is the
+  project's first installable console-script; it wires **only**
+  `airlock-explain`. Existing `airlock <subcommand>` invocations
+  (baseline / attest / corpus-bench / etc.) remain invocable only via
+  `python -m agent_airlock.cli.<name>` — wiring those is a separate
+  larger PR.
+
+**Tests.** 28 new tests in `tests/cli/test_explain.py` cover format
+detection (JSONL vs OTLP auto-detect, including the
+"starts-with-`{`-but-isn't-OTLP" edge case), policy loader (TOML +
+JSON, root + nested `[policy]` section, schema rejection), trace
+loader (JSONL header / blank skip, missing agent_id fallback, OTLP
+attribute kinds, blocked-call exclusion under both formats), the
+per-agent unused-set diff (incl. parity with
+`SecurityPolicy.check_tool_allowed`), the suggested-policy shape, and
+the CLI end-to-end (table format, JSON format, OTLP-vs-JSONL output
+parity, `--suggest-policy` appends without truncating, **read-only
+contract: policy file is byte-identical before and after**, error
+paths for missing files / missing flag).
+
+Zero new runtime deps. The base install grows by one optional dep
+nothing — Python 3.10 falls back to `tomli` via the existing
+`[project.dependencies]` entry; 3.11+ uses stdlib `tomllib`.
+
+Version bump 0.8.12 → 0.8.13 (additive new CLI surface; no API break).
+
 ### Added — Behavioral tool-call sequence guard (v0.8.12)
 
 `SequenceGuard` — an opt-in behavioral-only sequence anomaly guard that

--- a/README.md
+++ b/README.md
@@ -523,6 +523,64 @@ a chain-of-thought monitor — by construction.
 
 ---
 
+### 🔎 Privilege right-sizing — `airlock-explain --unused-scopes` (v0.8.13)
+
+A read-only CLI that surfaces **over-permissioning**: it diffs the
+`SecurityPolicy`'s **granted** tool scopes against the tools the agent
+**actually called** (from an OTLP export OR a native audit JSONL),
+per `AgentIdentity`, and prints the dead-weight set plus a *suggested*
+tightened allow-list.
+
+```bash
+# Install the v0.8.13 wheel; airlock-explain becomes available
+pip install "agent-airlock>=0.8.13"
+
+# Diff granted vs used; print a table
+airlock-explain --unused-scopes \
+    --policy ./security-policy.toml \
+    --trace  ./agent.audit.jsonl
+
+# Same, machine-readable, plus a proposed tightened policy preview
+airlock-explain --unused-scopes \
+    --policy ./security-policy.toml \
+    --trace  ./otel-export.json \
+    --format json \
+    --suggest-policy
+```
+
+**Observability-only.** This command **never mutates** the
+`SecurityPolicy`, **never writes** the policy file, and **never
+auto-applies** the suggestion. The deny-by-default posture is
+unchanged — the right-size CLI is a *review aid*, not an enforcement
+primitive. The `--suggest-policy` output is intentionally a stdout
+preview so a human reviews the tightened allow-list before adopting
+it by hand.
+
+**Trace formats** (auto-detected by inspecting the file head):
+
+- **Audit JSONL** — the format `AuditLogger` already emits. One JSON
+  object per line, with `tool_name` / `agent_id` / `blocked`. Blocked
+  calls are excluded from the "actually called" set — a blocked call
+  is not an exercise of a granted scope.
+- **OTLP JSON** — the format `opentelemetry-exporter-otlp` writes.
+  Span `name` is the tool name; `attributes.agent_id` keys the per-
+  agent diff. If a span carries `airlock.blocked=true` it is skipped,
+  same as JSONL.
+
+**Diff semantics.** The matcher is `fnmatch` — the same glob semantics
+`SecurityPolicy.check_tool_allowed` uses internally, so the suggested
+tightened allow-list admits exactly the tools the agent was observed
+calling (no surprises at adoption time). Denied-list patterns are
+forwarded unchanged to the suggestion: denials are *intent*, not
+usage data.
+
+> Strictly observability. No new runtime deps. The new console-script
+> entry `airlock-explain` is the project's first installable CLI;
+> existing `python -m agent_airlock.cli.<name>` invocations are
+> unaffected.
+
+---
+
 ### 💰 Cost Control
 
 A runaway agent can burn $500 in API costs before you notice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.12"
+version = "0.8.13"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"
@@ -144,6 +144,14 @@ docs = [
     "pymdown-extensions>=10.0",
 ]
 
+[project.scripts]
+# v0.8.13+ — read-only privilege right-sizing reporter. NOTE: this is
+# the project's first installable console-script entry; the existing
+# `airlock <subcommand>` invocations (baseline / attest / corpus-bench
+# / etc.) remain invocable only via `python -m
+# agent_airlock.cli.<name>`. Wiring those is a separate, larger PR.
+airlock-explain = "agent_airlock.cli.explain:main"
+
 [project.urls]
 Homepage = "https://github.com/sattyamjjain/agent-airlock"
 Documentation = "https://github.com/sattyamjjain/agent-airlock#readme"
@@ -229,6 +237,7 @@ module = [
     "mcp.*",
     "tomli",
     "tomli.*",
+    "tomllib",
     "docker",
     "docker.*",
     "opentelemetry",

--- a/scripts/smoke_explain.py
+++ b/scripts/smoke_explain.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Smoke test: pip-install the v0.8.13 wheel + exercise ``airlock-explain``
+end-to-end against a fixture trace and policy.
+
+Runs *outside* the editable source tree:
+
+1. Builds a wheel via ``python -m build --wheel`` into ``dist/``.
+2. Creates a throwaway venv under ``.smoke-explain-venv/``.
+3. Installs ``dist/agent_airlock-<version>-py3-none-any.whl`` into
+   the venv. **No extras** — the new CLI is base-install only.
+4. Confirms that ``airlock-explain`` is installed as a console-script
+   (proves the new ``[project.scripts]`` block in ``pyproject.toml``
+   actually shipped).
+5. Writes a fixture policy + audit JSONL trace to disk and runs the
+   CLI with ``--format json``. Parses the output and asserts that
+   the per-agent ``unused_patterns`` set is exactly the expected
+   dead-weight set.
+
+Exit codes:
+
+  0   smoke passes — wheel installs, console-script registers, CLI
+      produces the expected diff against the installed wheel.
+  1   smoke assertion failed.
+  2   environment problem (build / venv / install / shutil.which).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess  # noqa: S404 - intentional, smoke driver
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST_DIR = REPO_ROOT / "dist"
+VENV_DIR = REPO_ROOT / ".smoke-explain-venv"
+
+
+def _run(cmd: list[str]) -> None:
+    print(f"$ {' '.join(cmd)}", flush=True)
+    subprocess.check_call(cmd)  # noqa: S603 - argv pinned by this script
+
+
+def build_wheel() -> Path:
+    DIST_DIR.mkdir(exist_ok=True)
+    for old in DIST_DIR.glob("agent_airlock-*.whl"):
+        old.unlink()
+    _run([sys.executable, "-m", "build", "--wheel", "--outdir", str(DIST_DIR)])
+    wheels = sorted(DIST_DIR.glob("agent_airlock-*.whl"))
+    if not wheels:
+        print("ERROR: no wheel produced under dist/", file=sys.stderr)
+        sys.exit(2)
+    return wheels[-1]
+
+
+def make_venv() -> tuple[Path, Path]:
+    if VENV_DIR.exists():
+        shutil.rmtree(VENV_DIR)
+    _run([sys.executable, "-m", "venv", str(VENV_DIR)])
+    py = VENV_DIR / ("Scripts" if sys.platform == "win32" else "bin") / "python"
+    _run([str(py), "-m", "pip", "install", "--quiet", "--upgrade", "pip"])
+    return VENV_DIR, py
+
+
+def install_wheel(py: Path, wheel: Path) -> None:
+    _run([str(py), "-m", "pip", "install", "--quiet", str(wheel)])
+
+
+def write_fixtures(workdir: Path) -> tuple[Path, Path]:
+    """Write a deterministic fixture policy + JSONL trace.
+
+    The trace mixes admitted + blocked calls across two agents. The
+    smoke assertion is keyed off the deterministic ``unused_patterns``
+    sets the diff must produce against this fixture.
+    """
+    policy = workdir / "policy.toml"
+    policy.write_text(
+        textwrap.dedent(
+            """\
+            allowed_tools = ["read_*", "search_*", "write_*", "delete_*"]
+            denied_tools  = ["rm_-rf", "drop_database"]
+            """
+        ),
+        encoding="utf-8",
+    )
+    trace = workdir / "trace.jsonl"
+    records = [
+        "# Agent-Airlock Audit Log",
+        json.dumps(
+            {"tool_name": "read_file", "blocked": False, "agent_id": "ag1"}
+        ),
+        json.dumps(
+            {"tool_name": "search_kb", "blocked": False, "agent_id": "ag1"}
+        ),
+        json.dumps(
+            {
+                "tool_name": "delete_user",  # blocked — must be ignored
+                "blocked": True,
+                "agent_id": "ag1",
+                "block_reason": "denylisted",
+            }
+        ),
+        json.dumps(
+            {"tool_name": "read_file", "blocked": False, "agent_id": "ag2"}
+        ),
+    ]
+    trace.write_text("\n".join(records) + "\n", encoding="utf-8")
+    return policy, trace
+
+
+def run_cli_against_installed_wheel(
+    venv_dir: Path, policy: Path, trace: Path
+) -> tuple[int, str, str]:
+    """Resolve ``airlock-explain`` from the venv bin/ dir and invoke it.
+
+    Does NOT add the venv to PATH — we resolve the absolute path of
+    the console-script directly. This proves the console-script
+    actually got installed by the wheel, not just that the source tree
+    happens to be importable.
+    """
+    script_name = "airlock-explain.exe" if sys.platform == "win32" else "airlock-explain"
+    script_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    script_path = script_dir / script_name
+    if not script_path.exists():
+        print(
+            f"FAIL: console-script {script_path} not installed by the wheel",
+            file=sys.stderr,
+        )
+        return 1, "", ""
+    print(f"$ {script_path} --unused-scopes --policy {policy} --trace {trace} --format json")
+    proc = subprocess.run(  # noqa: S603 - argv pinned
+        [
+            str(script_path),
+            "--unused-scopes",
+            "--policy",
+            str(policy),
+            "--trace",
+            str(trace),
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def assert_unused_sets(stdout: str) -> int:
+    try:
+        doc = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: CLI stdout is not valid JSON: {exc}\nstdout={stdout!r}", file=sys.stderr)
+        return 1
+
+    expected = {
+        "ag1": {"unused": ["delete_*", "write_*"], "used": ["read_*", "search_*"]},
+        "ag2": {"unused": ["delete_*", "search_*", "write_*"], "used": ["read_*"]},
+    }
+    for r in doc:
+        agent = r["agent_id"]
+        if agent not in expected:
+            print(f"FAIL: unexpected agent {agent!r}", file=sys.stderr)
+            return 1
+        if sorted(r["unused_patterns"]) != expected[agent]["unused"]:
+            print(
+                f"FAIL: {agent} unused={r['unused_patterns']!r} "
+                f"expected={expected[agent]['unused']!r}",
+                file=sys.stderr,
+            )
+            return 1
+        if sorted(r["used_patterns"]) != expected[agent]["used"]:
+            print(
+                f"FAIL: {agent} used={r['used_patterns']!r} "
+                f"expected={expected[agent]['used']!r}",
+                file=sys.stderr,
+            )
+            return 1
+    print(
+        f"OK: ag1 unused={expected['ag1']['unused']!r}, used={expected['ag1']['used']!r}"
+    )
+    print(
+        f"OK: ag2 unused={expected['ag2']['unused']!r}, used={expected['ag2']['used']!r}"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keep-venv", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        wheel = build_wheel()
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: wheel build failed: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        venv_dir, py = make_venv()
+        install_wheel(py, wheel)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: venv setup failed: {exc}", file=sys.stderr)
+        return 2
+
+    fixtures_dir = VENV_DIR.parent / ".smoke-explain-fixtures"
+    fixtures_dir.mkdir(exist_ok=True)
+    policy, trace = write_fixtures(fixtures_dir)
+
+    rc, stdout, stderr = run_cli_against_installed_wheel(venv_dir, policy, trace)
+    if rc != 0:
+        print(f"FAIL: CLI returned {rc}\nstderr={stderr!r}", file=sys.stderr)
+        return 1
+    assert_rc = assert_unused_sets(stdout)
+    if assert_rc != 0:
+        return assert_rc
+
+    # Read-only contract: the policy file must be byte-identical after the run.
+    if (fixtures_dir / "policy.toml").read_bytes() != policy.read_bytes():
+        print("FAIL: policy file changed after CLI run", file=sys.stderr)
+        return 1
+    print("OK: policy file byte-identical after CLI run (read-only contract held)")
+
+    if not args.keep_venv:
+        shutil.rmtree(VENV_DIR, ignore_errors=True)
+        shutil.rmtree(fixtures_dir, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent_airlock/cli/explain.py
+++ b/src/agent_airlock/cli/explain.py
@@ -1,0 +1,508 @@
+"""``airlock explain`` CLI (v0.8.13+) — privilege right-sizing reporter.
+
+Surfaces over-permissioning by diffing **granted** tool scopes (the
+SecurityPolicy's allow-list) against **actually-called** tool scopes
+(extracted from a run trace), per :class:`AgentIdentity`. Prints, per
+agent, the granted-but-never-used set (the dead-weight scopes) and a
+suggested tightened allow-list.
+
+**This module is strictly read-only.** It never mutates a
+:class:`SecurityPolicy`, never writes a policy file, and never installs
+itself into the deny-by-default enforcement path. The output is
+operator-facing observability, intended to be reviewed by a human
+before any policy is tightened by hand.
+
+Inputs
+------
+- ``--policy <file>``: a TOML or JSON file with SecurityPolicy fields
+  (currently consumes ``allowed_tools`` and ``denied_tools`` — the
+  scope-relevant subset).
+- ``--trace <file>``: a run trace, in one of two formats:
+
+  1. **Audit JSONL** (the native format emitted by
+     :class:`agent_airlock.audit.AuditLogger`). One JSON object per
+     line, each carrying ``tool_name`` + ``agent_id`` + ``blocked``.
+     Lines starting with ``#`` are treated as header comments.
+  2. **OTLP JSON** (a single JSON document with a top-level
+     ``resourceSpans`` array — the format
+     ``opentelemetry-exporter-otlp`` writes). Span ``name`` is taken
+     as the tool name; ``attributes`` are searched for ``agent_id``
+     and an optional ``airlock.blocked`` flag.
+
+Auto-detected by inspecting the first non-blank bytes of the file.
+
+Outputs
+-------
+``--format table`` (default) prints a human-readable per-agent report.
+``--format json`` prints a machine-readable object with the same
+content. ``--suggest-policy`` ADDS a proposed tightened
+``SecurityPolicy`` block to stdout — never to the policy file.
+
+Failure model
+-------------
+Errors return a non-zero exit code and a structured message on stderr;
+no partial output to stdout. Empty traces (no admitted calls) are
+*reported* (the unused set is the full allow-list) rather than treated
+as an error — a fresh deployment with no recorded traffic genuinely
+has zero used scopes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:  # Python 3.11+ stdlib
+    import tomllib as _tomllib
+except ImportError:  # pragma: no cover - <3.11 fallback (tomli pulled via base deps)
+    import tomli as _tomllib  # type: ignore[no-redef, unused-ignore]
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CallObservation:
+    """One admitted tool call extracted from a trace."""
+
+    tool_name: str
+    agent_id: str
+
+
+@dataclass
+class AgentUsageReport:
+    """Per-agent diff of granted vs used scopes."""
+
+    agent_id: str
+    granted_patterns: list[str]
+    used_tools: list[str] = field(default_factory=list)
+    used_patterns: list[str] = field(default_factory=list)
+    unused_patterns: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "granted_patterns": list(self.granted_patterns),
+            "used_tools": sorted(self.used_tools),
+            "used_patterns": sorted(self.used_patterns),
+            "unused_patterns": sorted(self.unused_patterns),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Trace loaders
+# ---------------------------------------------------------------------------
+
+
+def _peek_format(text: str) -> str:
+    """Best-effort format detect: 'otlp' if the document is a JSON object
+    whose first non-whitespace structure has a ``resourceSpans`` key;
+    otherwise 'jsonl' (the native audit format)."""
+    stripped = text.lstrip()
+    if not stripped:
+        return "jsonl"
+    if stripped[0] == "{":
+        # Try a real JSON load — cheap on small files; the alternative
+        # is a regex that could misclassify a JSONL line that happens
+        # to start with '{'.
+        try:
+            head = json.loads(stripped)
+        except json.JSONDecodeError:
+            return "jsonl"
+        if isinstance(head, dict) and "resourceSpans" in head:
+            return "otlp"
+        # A single JSON object without resourceSpans is treated as
+        # JSONL with a single record (one tool call). Fine.
+        return "jsonl"
+    return "jsonl"
+
+
+def load_trace(path: Path) -> list[CallObservation]:
+    """Parse a run trace, returning the list of admitted tool calls.
+
+    Skipped:
+
+    - Blank lines, lines starting with ``#`` (audit JSONL headers).
+    - Records with ``blocked=True`` — the brief is "what was *actually
+      called*"; a blocked call is by definition not a granted scope's
+      exercise.
+    - Records missing both ``tool_name`` and an OTLP span ``name``.
+    """
+    text = path.read_text(encoding="utf-8")
+    fmt = _peek_format(text)
+    if fmt == "otlp":
+        return _load_otlp(text)
+    return _load_jsonl(text)
+
+
+def _load_jsonl(text: str) -> list[CallObservation]:
+    out: list[CallObservation] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        if record.get("blocked") is True:
+            continue
+        tool_name = record.get("tool_name")
+        agent_id = record.get("agent_id")
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        if not isinstance(agent_id, str) or not agent_id:
+            agent_id = "__anonymous__"
+        out.append(CallObservation(tool_name=tool_name, agent_id=agent_id))
+    return out
+
+
+def _load_otlp(text: str) -> list[CallObservation]:
+    doc = json.loads(text)
+    out: list[CallObservation] = []
+    if not isinstance(doc, dict):
+        return out
+    for resource_span in doc.get("resourceSpans", []) or []:
+        if not isinstance(resource_span, dict):
+            continue
+        # OTLP attribute lookup: resource-level attrs can carry agent_id
+        # too — we read them as a default and let span-level override.
+        res_attrs = _otlp_attrs(resource_span.get("resource", {}))
+        for scope_span in resource_span.get("scopeSpans", []) or []:
+            if not isinstance(scope_span, dict):
+                continue
+            for span in scope_span.get("spans", []) or []:
+                if not isinstance(span, dict):
+                    continue
+                span_attrs = _otlp_attrs(span)
+                # Honour an explicit blocked flag if the producer set
+                # one; otherwise assume the call was admitted.
+                blocked = span_attrs.get("airlock.blocked")
+                if isinstance(blocked, bool) and blocked:
+                    continue
+                tool_name = span_attrs.get("tool.name") or span.get("name")
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                agent_id = (
+                    span_attrs.get("agent_id") or res_attrs.get("agent_id") or "__anonymous__"
+                )
+                if not isinstance(agent_id, str):
+                    agent_id = "__anonymous__"
+                out.append(CallObservation(tool_name=tool_name, agent_id=agent_id))
+    return out
+
+
+def _otlp_attrs(node: Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten an OTLP ``attributes`` array into a plain ``{key: value}``.
+
+    OTLP encodes attributes as ``[{"key": "x", "value": {"stringValue": "v"}}]``;
+    this helper turns that into ``{"x": "v"}``. Unsupported value
+    shapes return ``None`` for that key.
+    """
+    out: dict[str, Any] = {}
+    for entry in node.get("attributes", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get("key")
+        if not isinstance(key, str):
+            continue
+        value = entry.get("value")
+        if not isinstance(value, dict):
+            out[key] = None
+            continue
+        # OTLP AnyValue union — accept the common shapes.
+        if "stringValue" in value:
+            out[key] = value["stringValue"]
+        elif "boolValue" in value:
+            out[key] = value["boolValue"]
+        elif "intValue" in value:
+            out[key] = int(value["intValue"])
+        elif "doubleValue" in value:
+            out[key] = float(value["doubleValue"])
+        else:
+            out[key] = None
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Policy loader
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicySnapshot:
+    """The scope-relevant slice of a SecurityPolicy.
+
+    We deliberately do NOT load the full :class:`SecurityPolicy` here —
+    the CLI is read-only and only needs the allow / deny lists. Pulling
+    the full policy (with capability gating, rate limits, etc.) would
+    couple this command to every field that ever ships and complicate
+    the file-format contract.
+    """
+
+    allowed_tools: tuple[str, ...]
+    denied_tools: tuple[str, ...]
+
+
+def load_policy(path: Path) -> PolicySnapshot:
+    """Load a ``SecurityPolicy`` snapshot from a TOML or JSON file.
+
+    The loader looks for ``allowed_tools`` and ``denied_tools`` either
+    at the document root OR under a ``[policy]`` / ``"policy"`` section
+    (for files that bundle the policy alongside other config).
+    """
+    raw = path.read_bytes()
+    if path.suffix.lower() in {".toml"}:
+        doc = _tomllib.loads(raw.decode("utf-8"))
+    else:
+        doc = json.loads(raw.decode("utf-8"))
+    if not isinstance(doc, dict):
+        raise ValueError(f"policy file {path} did not parse to an object")
+    section = doc
+    if "policy" in doc and isinstance(doc["policy"], dict):
+        section = doc["policy"]
+    allowed = section.get("allowed_tools", []) or []
+    denied = section.get("denied_tools", []) or []
+    if not isinstance(allowed, list) or not all(isinstance(x, str) for x in allowed):
+        raise ValueError("policy.allowed_tools must be a list[str]")
+    if not isinstance(denied, list) or not all(isinstance(x, str) for x in denied):
+        raise ValueError("policy.denied_tools must be a list[str]")
+    return PolicySnapshot(
+        allowed_tools=tuple(allowed),
+        denied_tools=tuple(denied),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diff algorithm
+# ---------------------------------------------------------------------------
+
+
+def diff_granted_vs_used(
+    policy: PolicySnapshot,
+    observations: Iterable[CallObservation],
+) -> list[AgentUsageReport]:
+    """Compute the granted-vs-used scope diff, per agent.
+
+    A granted pattern is "used" if at least one observed tool name
+    matches it via :func:`fnmatch.fnmatch` (the same matcher
+    :class:`SecurityPolicy` uses internally). A pattern with **zero**
+    matches is "unused" and is reported as dead-weight.
+
+    For agents that share a granted policy but have different observed
+    sets, each agent gets its own per-agent unused set. This is the
+    typical multi-agent case — one role grant, N agents using different
+    subsets of it.
+
+    Args:
+        policy: The granted scopes.
+        observations: All admitted tool calls in the trace.
+
+    Returns:
+        One :class:`AgentUsageReport` per ``agent_id`` observed. Agents
+        that never made an admitted call still appear (with the full
+        granted set as "unused") iff they show up in any observation
+        record — agents absent from the trace entirely are not
+        synthesised, since the CLI has no agent registry to enumerate
+        them from.
+    """
+    by_agent: dict[str, set[str]] = {}
+    for obs in observations:
+        by_agent.setdefault(obs.agent_id, set()).add(obs.tool_name)
+
+    granted_patterns = list(policy.allowed_tools)
+    reports: list[AgentUsageReport] = []
+    for agent_id, used_tools in sorted(by_agent.items()):
+        used_patterns: list[str] = []
+        unused_patterns: list[str] = []
+        for pattern in granted_patterns:
+            if any(fnmatch.fnmatch(tool, pattern) for tool in used_tools):
+                used_patterns.append(pattern)
+            else:
+                unused_patterns.append(pattern)
+        reports.append(
+            AgentUsageReport(
+                agent_id=agent_id,
+                granted_patterns=list(granted_patterns),
+                used_tools=sorted(used_tools),
+                used_patterns=used_patterns,
+                unused_patterns=unused_patterns,
+            )
+        )
+    return reports
+
+
+def suggest_tightened_policy(
+    report: AgentUsageReport, denied_tools: tuple[str, ...]
+) -> dict[str, list[str]]:
+    """Return a *suggested* tightened policy payload for one agent.
+
+    Heuristic: keep only the patterns that actually matched observed
+    calls (``used_patterns``). The denied-list is forwarded unchanged
+    — denials are policy intent, not usage data. The output is a
+    plain dict so callers can serialise to TOML / JSON / whatever
+    review surface they want.
+
+    **This function never writes to disk** and never modifies the
+    in-memory :class:`SecurityPolicy`.
+    """
+    return {
+        "allowed_tools": list(report.used_patterns),
+        "denied_tools": list(denied_tools),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_table(reports: list[AgentUsageReport]) -> str:
+    if not reports:
+        return "(no agents observed in trace)\n"
+    lines: list[str] = []
+    for r in reports:
+        lines.append(f"agent: {r.agent_id}")
+        lines.append(f"  granted patterns ({len(r.granted_patterns)}):")
+        for p in r.granted_patterns:
+            mark = "✓" if p in r.used_patterns else "✗"
+            lines.append(f"    {mark} {p}")
+        lines.append(f"  used tools ({len(r.used_tools)}):")
+        for t in r.used_tools:
+            lines.append(f"      {t}")
+        if r.unused_patterns:
+            lines.append(f"  unused (dead-weight) patterns ({len(r.unused_patterns)}):")
+            for p in r.unused_patterns:
+                lines.append(f"      - {p}")
+        else:
+            lines.append("  unused (dead-weight) patterns: (none)")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _format_json(reports: list[AgentUsageReport]) -> str:
+    return json.dumps([r.to_dict() for r in reports], indent=2, sort_keys=True) + "\n"
+
+
+def _format_suggested_policies(
+    reports: list[AgentUsageReport], denied: tuple[str, ...], fmt: str
+) -> str:
+    """Render the per-agent suggested-tightened-policy block."""
+    payload = {r.agent_id: suggest_tightened_policy(r, denied) for r in reports}
+    if fmt == "json":
+        return json.dumps({"suggested_policies": payload}, indent=2, sort_keys=True) + "\n"
+    lines = ["", "# === Suggested tightened policies (REVIEW BEFORE ADOPTING) ===", ""]
+    for agent_id, body in payload.items():
+        lines.append(f"## agent: {agent_id}")
+        lines.append("[policy]")
+        lines.append("allowed_tools = [")
+        for p in body["allowed_tools"]:
+            lines.append(f"    {json.dumps(p)},")
+        lines.append("]")
+        lines.append("denied_tools = [")
+        for p in body["denied_tools"]:
+            lines.append(f"    {json.dumps(p)},")
+        lines.append("]")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="airlock-explain",
+        description=(
+            "Read-only privilege right-sizing reporter. Diffs granted "
+            "vs actually-called tool scopes per agent and prints the "
+            "dead-weight set. NEVER mutates or auto-applies any policy."
+        ),
+    )
+    parser.add_argument(
+        "--unused-scopes",
+        action="store_true",
+        help=(
+            "Show granted scopes that were never matched by any observed "
+            "tool call. Currently the only analysis mode — included as a "
+            "flag so future analyses (e.g. --unused-roles) can be added "
+            "without changing the entrypoint."
+        ),
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        required=True,
+        help="Path to a SecurityPolicy snapshot file (TOML or JSON).",
+    )
+    parser.add_argument(
+        "--trace",
+        type=Path,
+        required=True,
+        help=("Path to a run trace: audit JSONL (native) or OTLP JSON (auto-detected)."),
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format. Default: table.",
+    )
+    parser.add_argument(
+        "--suggest-policy",
+        action="store_true",
+        help=(
+            "Also emit a proposed tightened SecurityPolicy to stdout. "
+            "Never writes the policy file — review the suggestion by hand "
+            "before adopting."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.unused_scopes:
+        parser.error("at least one analysis mode required (e.g. --unused-scopes)")
+        return 2  # argparse.error already exits, but keep mypy happy
+
+    try:
+        policy = load_policy(args.policy)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: cannot load policy {args.policy}: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        observations = load_trace(args.trace)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: cannot load trace {args.trace}: {exc}", file=sys.stderr)
+        return 2
+
+    reports = diff_granted_vs_used(policy, observations)
+
+    if args.format == "json":
+        print(_format_json(reports), end="")
+    else:
+        print(_format_table(reports), end="")
+
+    if args.suggest_policy:
+        print(_format_suggested_policies(reports, policy.denied_tools, args.format), end="")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/cli/test_explain.py
+++ b/tests/cli/test_explain.py
@@ -1,0 +1,591 @@
+"""Tests for ``airlock explain`` (v0.8.13+, read-only privilege right-sizing).
+
+Covers the granted-vs-used diff on fixture traces, the format flags,
+the auto-detected OTLP-vs-JSONL loader, the denied-call exclusion
+invariant, the ``--suggest-policy`` preview shape, and the read-only
+contract (no policy file is ever written).
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_airlock.cli.explain import (
+    AgentUsageReport,
+    CallObservation,
+    PolicySnapshot,
+    _peek_format,
+    diff_granted_vs_used,
+    load_policy,
+    load_trace,
+    main,
+    suggest_tightened_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixture_policy(tmp_path: Path) -> Path:
+    path = tmp_path / "policy.toml"
+    path.write_text(
+        "\n".join(
+            [
+                'allowed_tools = ["read_*", "search_*", "write_*", "delete_*"]',
+                'denied_tools  = ["rm_-rf", "drop_database"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def fixture_jsonl_trace(tmp_path: Path) -> Path:
+    """A native audit JSONL trace with two agents.
+
+    agent 'ag1' admitted: read_file, search_kb. blocked: delete_user.
+    agent 'ag2' admitted: read_file.
+    """
+    path = tmp_path / "trace.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                "# Agent-Airlock Audit Log",
+                "# Created: 2026-05-31T00:00:00Z",
+                json.dumps(
+                    {
+                        "timestamp": "2026-05-31T10:00:00Z",
+                        "tool_name": "read_file",
+                        "blocked": False,
+                        "agent_id": "ag1",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-05-31T10:00:01Z",
+                        "tool_name": "search_kb",
+                        "blocked": False,
+                        "agent_id": "ag1",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-05-31T10:00:02Z",
+                        "tool_name": "delete_user",
+                        "blocked": True,
+                        "agent_id": "ag1",
+                        "block_reason": "denylisted",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-05-31T10:00:03Z",
+                        "tool_name": "read_file",
+                        "blocked": False,
+                        "agent_id": "ag2",
+                    }
+                ),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def fixture_otlp_trace(tmp_path: Path) -> Path:
+    """An OTLP-JSON trace covering the same two agents."""
+    path = tmp_path / "trace.otlp.json"
+    doc = {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": [{"key": "agent_id", "value": {"stringValue": "ag1"}}]},
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "name": "read_file",
+                                "attributes": [
+                                    {
+                                        "key": "agent_id",
+                                        "value": {"stringValue": "ag1"},
+                                    }
+                                ],
+                            },
+                            {
+                                "name": "search_kb",
+                                "attributes": [
+                                    {
+                                        "key": "agent_id",
+                                        "value": {"stringValue": "ag1"},
+                                    }
+                                ],
+                            },
+                            {
+                                # Blocked spans must not contribute to
+                                # the "actually called" set.
+                                "name": "delete_user",
+                                "attributes": [
+                                    {
+                                        "key": "agent_id",
+                                        "value": {"stringValue": "ag1"},
+                                    },
+                                    {
+                                        "key": "airlock.blocked",
+                                        "value": {"boolValue": True},
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                ],
+            },
+            {
+                "resource": {"attributes": [{"key": "agent_id", "value": {"stringValue": "ag2"}}]},
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "name": "read_file",
+                                "attributes": [
+                                    {
+                                        "key": "agent_id",
+                                        "value": {"stringValue": "ag2"},
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ],
+            },
+        ]
+    }
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetection:
+    def test_jsonl_default(self) -> None:
+        assert _peek_format('{"tool_name": "x"}\n{"tool_name": "y"}\n') == "jsonl"
+
+    def test_otlp_doc(self) -> None:
+        assert _peek_format('{"resourceSpans": [{}]}') == "otlp"
+
+    def test_empty(self) -> None:
+        assert _peek_format("") == "jsonl"
+
+    def test_garbage_does_not_misclassify(self) -> None:
+        # Begins with '{' but is not valid JSON; should fall through to jsonl
+        # so the line-by-line loader can ignore it.
+        assert _peek_format("{not valid json") == "jsonl"
+
+    def test_jsonl_starting_with_object_line(self) -> None:
+        """A JSONL file's first line is a JSON object — that's fine. The
+        detector should only flip to OTLP when ``resourceSpans`` is present."""
+        assert _peek_format('{"tool_name": "x"}\n') == "jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Policy loader
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyLoader:
+    def test_toml_root(self, fixture_policy: Path) -> None:
+        snap = load_policy(fixture_policy)
+        assert snap.allowed_tools == ("read_*", "search_*", "write_*", "delete_*")
+        assert snap.denied_tools == ("rm_-rf", "drop_database")
+
+    def test_json_root(self, tmp_path: Path) -> None:
+        path = tmp_path / "policy.json"
+        path.write_text(
+            json.dumps({"allowed_tools": ["a", "b"], "denied_tools": ["c"]}),
+            encoding="utf-8",
+        )
+        snap = load_policy(path)
+        assert snap.allowed_tools == ("a", "b")
+        assert snap.denied_tools == ("c",)
+
+    def test_nested_policy_section(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "other": {"unrelated": True},
+                    "policy": {"allowed_tools": ["read_*"], "denied_tools": []},
+                }
+            ),
+            encoding="utf-8",
+        )
+        snap = load_policy(path)
+        assert snap.allowed_tools == ("read_*",)
+        assert snap.denied_tools == ()
+
+    def test_rejects_non_list_allowed_tools(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"allowed_tools": "not-a-list"}), encoding="utf-8")
+        with pytest.raises(ValueError, match="allowed_tools must be a list"):
+            load_policy(path)
+
+
+# ---------------------------------------------------------------------------
+# Trace loader
+# ---------------------------------------------------------------------------
+
+
+class TestTraceLoader:
+    def test_jsonl_excludes_blocked_calls(self, fixture_jsonl_trace: Path) -> None:
+        obs = load_trace(fixture_jsonl_trace)
+        # 4 records in the fixture, 1 blocked → 3 admitted.
+        assert len(obs) == 3
+        tools = {(o.agent_id, o.tool_name) for o in obs}
+        assert tools == {
+            ("ag1", "read_file"),
+            ("ag1", "search_kb"),
+            ("ag2", "read_file"),
+        }
+
+    def test_jsonl_skips_blank_and_header_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "trace.jsonl"
+        path.write_text(
+            "# header\n\n  \n"
+            + json.dumps({"tool_name": "x", "blocked": False, "agent_id": "ag"})
+            + "\n",
+            encoding="utf-8",
+        )
+        obs = load_trace(path)
+        assert [(o.agent_id, o.tool_name) for o in obs] == [("ag", "x")]
+
+    def test_jsonl_missing_agent_id_falls_back(self, tmp_path: Path) -> None:
+        path = tmp_path / "trace.jsonl"
+        path.write_text(
+            json.dumps({"tool_name": "x", "blocked": False}) + "\n",
+            encoding="utf-8",
+        )
+        obs = load_trace(path)
+        assert obs == [CallObservation(tool_name="x", agent_id="__anonymous__")]
+
+    def test_otlp_excludes_blocked_spans(self, fixture_otlp_trace: Path) -> None:
+        obs = load_trace(fixture_otlp_trace)
+        tools = {(o.agent_id, o.tool_name) for o in obs}
+        assert tools == {
+            ("ag1", "read_file"),
+            ("ag1", "search_kb"),
+            ("ag2", "read_file"),
+        }
+
+    def test_otlp_attribute_value_kinds(self, tmp_path: Path) -> None:
+        """OTLP AnyValue shapes (string/bool/int/double) all decode cleanly."""
+        path = tmp_path / "trace.otlp.json"
+        doc = {
+            "resourceSpans": [
+                {
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "name": "tool",
+                                    "attributes": [
+                                        {
+                                            "key": "agent_id",
+                                            "value": {"stringValue": "ag"},
+                                        },
+                                        {
+                                            "key": "airlock.blocked",
+                                            "value": {"boolValue": False},
+                                        },
+                                    ],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        obs = load_trace(path)
+        assert obs == [CallObservation(tool_name="tool", agent_id="ag")]
+
+
+# ---------------------------------------------------------------------------
+# Diff algorithm
+# ---------------------------------------------------------------------------
+
+
+class TestDiffGrantedVsUsed:
+    def test_per_agent_unused_set_is_correct(self) -> None:
+        policy = PolicySnapshot(
+            allowed_tools=("read_*", "search_*", "write_*", "delete_*"),
+            denied_tools=(),
+        )
+        obs = [
+            CallObservation("read_file", "ag1"),
+            CallObservation("search_kb", "ag1"),
+            CallObservation("read_file", "ag2"),
+        ]
+        reports = diff_granted_vs_used(policy, obs)
+        assert {r.agent_id for r in reports} == {"ag1", "ag2"}
+
+        ag1 = next(r for r in reports if r.agent_id == "ag1")
+        assert set(ag1.used_patterns) == {"read_*", "search_*"}
+        assert set(ag1.unused_patterns) == {"write_*", "delete_*"}
+
+        ag2 = next(r for r in reports if r.agent_id == "ag2")
+        assert set(ag2.used_patterns) == {"read_*"}
+        assert set(ag2.unused_patterns) == {"search_*", "write_*", "delete_*"}
+
+    def test_glob_matching_matches_securitypolicy_semantics(self) -> None:
+        """The diff must use the same fnmatch semantics SecurityPolicy.check_tool_allowed
+        uses internally, otherwise the suggested tightened policy could
+        admit / deny different tools than the diff implied."""
+        from agent_airlock.policy import SecurityPolicy
+
+        policy_for_check = SecurityPolicy(allowed_tools=["data_*", "read_?"])
+
+        # SecurityPolicy admits these:
+        for t in ("data_x", "data_anything", "read_a"):
+            policy_for_check.check_tool_allowed(t)  # would raise if not admitted
+
+        snap = PolicySnapshot(allowed_tools=("data_*", "read_?"), denied_tools=())
+        reports = diff_granted_vs_used(
+            snap,
+            [
+                CallObservation("data_x", "ag"),
+                CallObservation("data_anything", "ag"),
+                CallObservation("read_a", "ag"),
+            ],
+        )
+        assert set(reports[0].used_patterns) == {"data_*", "read_?"}
+        assert reports[0].unused_patterns == []
+
+    def test_empty_trace_reports_no_agents(self) -> None:
+        snap = PolicySnapshot(allowed_tools=("read_*",), denied_tools=())
+        assert diff_granted_vs_used(snap, []) == []
+
+    def test_unmatched_pattern_appears_in_unused(self) -> None:
+        snap = PolicySnapshot(allowed_tools=("read_*", "rare_admin_tool"), denied_tools=())
+        reports = diff_granted_vs_used(snap, [CallObservation("read_file", "ag")])
+        assert reports[0].unused_patterns == ["rare_admin_tool"]
+
+
+# ---------------------------------------------------------------------------
+# Suggested tightened policy
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestTightenedPolicy:
+    def test_keeps_only_used_patterns(self) -> None:
+        report = AgentUsageReport(
+            agent_id="ag",
+            granted_patterns=["read_*", "write_*", "delete_*"],
+            used_tools=["read_file"],
+            used_patterns=["read_*"],
+            unused_patterns=["write_*", "delete_*"],
+        )
+        out = suggest_tightened_policy(report, denied_tools=("drop_db",))
+        assert out["allowed_tools"] == ["read_*"]
+        assert out["denied_tools"] == ["drop_db"]
+
+    def test_denied_tools_passthrough_unchanged(self) -> None:
+        """Denials are intent, not usage data — the suggestion forwards them."""
+        report = AgentUsageReport(
+            agent_id="ag",
+            granted_patterns=["read_*"],
+            used_tools=["read_file"],
+            used_patterns=["read_*"],
+            unused_patterns=[],
+        )
+        out = suggest_tightened_policy(report, denied_tools=("rm_-rf", "drop_db"))
+        assert out["denied_tools"] == ["rm_-rf", "drop_db"]
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end (main()) + read-only contract
+# ---------------------------------------------------------------------------
+
+
+class TestCLIEndToEnd:
+    def test_table_format_lists_unused_set(
+        self, fixture_policy: Path, fixture_jsonl_trace: Path
+    ) -> None:
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(fixture_jsonl_trace),
+                    "--format",
+                    "table",
+                ]
+            )
+        assert rc == 0
+        s = out.getvalue()
+        assert "agent: ag1" in s
+        assert "agent: ag2" in s
+        # ag1 unused dead-weight is write_* + delete_*
+        ag1_block = s.split("agent: ag2")[0]
+        assert "write_*" in ag1_block
+        assert "delete_*" in ag1_block
+        assert "✓ read_*" in ag1_block
+        assert "✓ search_*" in ag1_block
+
+    def test_json_format_emits_valid_document(
+        self, fixture_policy: Path, fixture_jsonl_trace: Path
+    ) -> None:
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(fixture_jsonl_trace),
+                    "--format",
+                    "json",
+                ]
+            )
+        assert rc == 0
+        doc = json.loads(out.getvalue())
+        assert isinstance(doc, list)
+        ag1 = next(r for r in doc if r["agent_id"] == "ag1")
+        assert sorted(ag1["unused_patterns"]) == ["delete_*", "write_*"]
+        assert sorted(ag1["used_patterns"]) == ["read_*", "search_*"]
+        assert sorted(ag1["used_tools"]) == ["read_file", "search_kb"]
+
+    def test_otlp_input_produces_same_report(
+        self, fixture_policy: Path, fixture_otlp_trace: Path
+    ) -> None:
+        """OTLP and JSONL inputs of the same logical trace must produce the
+        same report — proves the format autodetect + decode is honest."""
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(fixture_otlp_trace),
+                    "--format",
+                    "json",
+                ]
+            )
+        assert rc == 0
+        doc = json.loads(out.getvalue())
+        ag1 = next(r for r in doc if r["agent_id"] == "ag1")
+        assert sorted(ag1["used_tools"]) == ["read_file", "search_kb"]
+        assert sorted(ag1["unused_patterns"]) == ["delete_*", "write_*"]
+
+    def test_suggest_policy_appends_proposed_block(
+        self, fixture_policy: Path, fixture_jsonl_trace: Path
+    ) -> None:
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(fixture_jsonl_trace),
+                    "--format",
+                    "json",
+                    "--suggest-policy",
+                ]
+            )
+        assert rc == 0
+        # Output has two JSON documents now (report list + suggestions
+        # object). They are emitted back-to-back; pull each out.
+        text = out.getvalue()
+        decoder = json.JSONDecoder()
+        first, idx = decoder.raw_decode(text)
+        rest = text[idx:].lstrip()
+        second, _ = decoder.raw_decode(rest)
+        assert isinstance(first, list)
+        assert "suggested_policies" in second
+        sugg = second["suggested_policies"]
+        # ag1's suggestion drops write_* / delete_*; keeps read_* / search_*.
+        assert set(sugg["ag1"]["allowed_tools"]) == {"read_*", "search_*"}
+        assert sugg["ag1"]["denied_tools"] == ["rm_-rf", "drop_database"]
+
+    def test_read_only_contract_policy_file_unchanged(
+        self, fixture_policy: Path, fixture_jsonl_trace: Path
+    ) -> None:
+        """The CLI must never write to the policy file. Re-read the file
+        before and after a --suggest-policy run and assert byte-equality."""
+        before = fixture_policy.read_bytes()
+        with patch("sys.stdout", new_callable=StringIO):
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(fixture_jsonl_trace),
+                    "--suggest-policy",
+                ]
+            )
+        assert rc == 0
+        assert fixture_policy.read_bytes() == before
+
+    def test_missing_unused_scopes_flag_errors(
+        self, fixture_policy: Path, fixture_jsonl_trace: Path
+    ) -> None:
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(fixture_jsonl_trace),
+                ]
+            )
+        # argparse.error exits 2 by convention.
+        assert exc.value.code == 2
+
+    def test_unreadable_policy_returns_nonzero(
+        self, tmp_path: Path, fixture_jsonl_trace: Path
+    ) -> None:
+        bad = tmp_path / "does-not-exist.toml"
+        with patch("sys.stderr", new_callable=StringIO) as err:
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(bad),
+                    "--trace",
+                    str(fixture_jsonl_trace),
+                ]
+            )
+        assert rc == 2
+        assert "cannot load policy" in err.getvalue()
+
+    def test_unreadable_trace_returns_nonzero(self, fixture_policy: Path, tmp_path: Path) -> None:
+        bad = tmp_path / "does-not-exist.jsonl"
+        with patch("sys.stderr", new_callable=StringIO) as err:
+            rc = main(
+                [
+                    "--unused-scopes",
+                    "--policy",
+                    str(fixture_policy),
+                    "--trace",
+                    str(bad),
+                ]
+            )
+        assert rc == 2
+        assert "cannot load trace" in err.getvalue()


### PR DESCRIPTION
## Summary

Adds **`airlock-explain`** — a new **read-only** CLI that surfaces over-permissioning by diffing `SecurityPolicy.allowed_tools` (granted scopes) against the tools an agent actually called, per `AgentIdentity`. Prints the dead-weight set and (with `--suggest-policy`) a *proposed* tightened allow-list as a stdout preview.

```bash
pip install "agent-airlock>=0.8.13"
airlock-explain --unused-scopes \
    --policy ./security-policy.toml \
    --trace  ./agent.audit.jsonl \
    --format json \
    --suggest-policy
```

**Read-only contract.** This command **never** mutates a `SecurityPolicy`, **never** writes the policy file, and **never** installs into the deny-by-default enforcement path. A regression test (`test_read_only_contract_policy_file_unchanged`) asserts byte-equality of the policy file before and after a `--suggest-policy` run.

## Discrepancies from the brief — surfaced before coding

| # | Brief said | Reality on `main` | What I did |
|---|---|---|---|
| **A** | Bump `v0.7.5 → v0.7.6` | We're at **`v0.8.12`** (just merged sequence guard); `v0.7.6` already tagged 6 versions ago. | Bump **`0.8.12 → 0.8.13`** (additive CLI surface; no API break). |
| **B** | "Push to main (solo-maintainer)" | #60–#72 all PR-gated; consistent across the last 4 features. | PR workflow. |
| **C** | "Install built wheel… run `airlock explain --unused-scopes`" — assumes an installed `airlock` command | **`pyproject.toml` has NO `[project.scripts]` block.** The wheel ships zero console-scripts. README documents `airlock baseline` / `airlock attest` / etc. but those are invocable only via `python -m agent_airlock.cli.<name>`. | Added **only** `airlock-explain` (hyphen) as the new console-script. This is the project's first installable CLI; wiring the rest of the `airlock <subcommand>` surface is intentionally out of scope (bigger blast radius). Smoke proves the console-script resolves from the venv `bin/`. |
| **D** | `pytest && ruff check . && mypy src` | Project's actual gate set (per Makefile + pyproject) is `pytest`, `ruff check src/ tests/`, `ruff format --check`, `mypy src/`, `bandit -r src/agent_airlock/`. | Ran the full set; all green. |

## What's in the PR

| File | Change |
|---|---|
| `src/agent_airlock/cli/explain.py` | **NEW** module — `main(argv)`, `load_trace`, `load_policy`, `diff_granted_vs_used`, `suggest_tightened_policy`, dataclasses `CallObservation` / `AgentUsageReport` / `PolicySnapshot`, both `_load_jsonl` and `_load_otlp` parsers |
| `tests/cli/test_explain.py` | **NEW** — 28 tests |
| `scripts/smoke_explain.py` | **NEW** — wheel-install + console-script-resolves-in-bin + diff-correctness + read-only-contract smoke |
| `pyproject.toml` | **NEW** `[project.scripts] airlock-explain = "agent_airlock.cli.explain:main"`; bump `0.8.12 → 0.8.13`; `tomllib` added to the existing mypy `ignore_missing_imports` override block |
| `README.md` | NEW "🔎 Privilege right-sizing" subsection under the policy section |
| `CHANGELOG.md` | `[Unreleased]` v0.8.13 block above the v0.8.12 / v0.8.11 / v0.8.10 / v0.8.9 entries |

## How the diff works

Granted patterns are read from a `SecurityPolicy` snapshot (`allowed_tools`, `denied_tools`) loaded from TOML or JSON — either at the document root OR under a `[policy]` section. Observations come from one of two trace formats, **auto-detected** by inspecting the file head:

- **Audit JSONL** (the native format `agent_airlock.audit.AuditLogger` already emits). One JSON object per line, with `tool_name` / `agent_id` / `blocked`. Lines starting with `#` are header-skipped; `blocked: true` records are excluded (a blocked call is not an exercise of a granted scope); missing `agent_id` falls back to `__anonymous__`.
- **OTLP JSON** (the format `opentelemetry-exporter-otlp` writes — top-level `resourceSpans[*].scopeSpans[*].spans[*]`). Span `name` is the tool name; the OTLP `AnyValue` union (`stringValue` / `boolValue` / `intValue` / `doubleValue`) is decoded for attribute lookup. `agent_id` resolves span-attrs → resource-attrs → `__anonymous__`. Spans with `airlock.blocked=true` are skipped.

The matcher is `fnmatch.fnmatch` — **the same matcher `SecurityPolicy.check_tool_allowed` uses internally**. The test `test_glob_matching_matches_securitypolicy_semantics` pins this: a suggestion will admit exactly the tools the agent was observed calling, no surprises at adoption time.

## Smoke against the installed wheel

```
Successfully built agent_airlock-0.8.13-py3-none-any.whl
$ <venv>/bin/airlock-explain --unused-scopes --policy ... --trace ... --format json
OK: ag1 unused=['delete_*', 'write_*'], used=['read_*', 'search_*']
OK: ag2 unused=['delete_*', 'search_*', 'write_*'], used=['read_*']
OK: policy file byte-identical after CLI run (read-only contract held)
```

The smoke (`scripts/smoke_explain.py`):

1. Builds the wheel.
2. Creates a fresh venv with **no extras** — confirms zero new runtime deps.
3. Installs the wheel.
4. **Resolves `airlock-explain` from `<venv>/bin/`** — proves the new `[project.scripts]` entry actually ships in the wheel (not just that the source tree happens to be importable).
5. Writes a fixture policy + audit JSONL trace.
6. Runs the CLI with `--format json`, asserts the per-agent `unused_patterns` sets match the deterministic expectation.
7. Re-reads the policy file and asserts byte-equality — read-only contract held.

## Gate results

| Gate | Result |
|---|---|
| `ruff check src/ tests/` | ✅ All checks passed |
| `ruff format --check src/ tests/` | ✅ 330 files clean |
| `bandit -r src/agent_airlock/` | ✅ exit 0 |
| `mypy src/` net delta | ✅ **8 → 8** baseline errors; the new module is mypy-clean (`tomllib` was added to the optional-deps override block in `pyproject.toml`) |
| `pytest tests/` | ✅ **2711 pass**, 33 skipped (+28 new explain tests; existing perf P99 flake did not trigger) |
| `pytest --cov-fail-under=80` (CI gate) | ✅ **83.99% total coverage** |
| `pytest --cov-fail-under=82` (pyproject gate) | ✅ 83.99% > 82 |
| `python3 scripts/smoke_explain.py` | ✅ Wheel install + console-script resolve + diff correctness + read-only contract |
| `make check-changelog-release` | ✅ `OK ([Unreleased] has release notes)` |

## Anti-pivot held

- ✅ **Observability-only.** No enforcement path. Deny-by-default posture unchanged.
- ✅ **Read-only contract.** Policy files never written; the suggested tightened policy is a stdout preview.
- ✅ **Anti-duplicate.** This is *discovery / reporting*, not enforcement — distinct from the existing presets that *enforce* allow-lists at the seam.
- ✅ **Zero new runtime deps.** Base install footprint unchanged; `tomllib` is stdlib on 3.11+ and `tomli` is already a base dep on 3.10.

## Reference

The new console-script is the project's first installable CLI entry. The remaining `airlock <subcommand>` surface (baseline / attest / corpus-bench / etc.) currently relies on `python -m agent_airlock.cli.<name>` invocation — wiring those is intentionally out of scope for this PR; a follow-up "ship the CLI dispatcher" PR can wire the rest under a single `airlock` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
