### PR TITLE
feat(0.8.15): action-time contradiction gate (arXiv:2605.27157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,120 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Action-time contradiction gate (v0.8.15, arXiv:2605.27157)
+
+`ActionContradictionGate` — an opt-in, off-by-default policy hook that
+gates privileged / irreversible actions when the session has signalled
+acknowledged-contradiction evidence. Closes the "detecting is not
+resolving" monitoring-control gap reported by Yu et al.,
+[*Detecting Is Not Resolving: The Monitoring Control Gap in
+Retrieval Augmented LLMs*](https://arxiv.org/abs/2605.27157) (2026):
+*"Models exhibit a monitoring-control gap: they readily acknowledge
+contradictory evidence, yet this awareness fails to constrain their
+final recommendations."* The paper localises the deficit at action
+selection; this module is the action-time control.
+
+**Three pluggable, orthogonal detectors** (any one trips the gate):
+
+- `signal_field_key`: a key into `AirlockContext.metadata`; the gate
+  trips iff the value at that key is **strict `True`** (the
+  unambiguous boolean-flag shape).
+- `marker_regex`: a pre-compiled regex run against the value at the
+  same key **when that value is a string** (operator's narrative
+  marker shape). Reads only operator-supplied marker strings — never
+  the model's full reasoning trace.
+- `predicate`: a fully pluggable `Callable[[AirlockContext], bool]`.
+  A predicate that raises is swallowed (the gate logs
+  `predicate_error` and treats as no-vote — telemetry never breaks
+  enforcement).
+
+**Privileged-sink glob set.** Default canonical set covers send /
+publish / dispatch (`send_*`, `publish_*`, `post_to_*`, `webhook_*`,
+`dispatch_*`), export / share / upload (`export_*`, `share_*`,
+`upload_*`), state-mutating commits and transfers (`commit_*`,
+`transfer_*`, `wire_*`, `pay_*`, `create_payment_*`), irreversible
+deletes (`delete_*`, `drop_*`, `destroy_*`, `purge_*`), and the
+v0.8.14 outbound-integration set (`outlook_*`, `smtp_*`,
+`salesforce_send_email`, `create_case`, `create_lead`). Operators can
+narrow via `privileged_sinks=(...)`.
+
+**Explicit-allow primitive reused, not duplicated.** The gate's
+allow path is the existing `AirlockContext.authorize_once(tool_name)`
+introduced for the v0.8.6 reauth flow. After a one-shot is consumed
+the gate **re-locks** (sticky-trip invariant) — the harness must mint
+a fresh `authorize_once` for each privileged action.
+
+**Off-by-default invariant.** `SecurityPolicy.action_contradiction_gate`
+defaults to `None`; non-RAG flows pay **zero false-positive tax** (no
+detector runs, no log lines, no metadata reads). Even when wired, the
+gate is **inert until at least one detector is configured** — a
+partial roll-out (gate attached but detectors flipped off) admits
+everything.
+
+**Fail-closed `action`.** `action="block"` (default) raises
+`ActionContradictionViolation` — a `PolicyViolation` subclass, so the
+existing `handle_policy_violation` chain in `core.py` picks it up
+unchanged. `action="warn"` logs via structlog + admits, for staged
+turn-up against real traffic.
+
+Disambiguation:
+
+- **Not** `agent_airlock.sequence_guard.SequenceGuard` (v0.8.12) —
+  that flags unusual call **order**.
+- **Not** `SecurityPolicy.reauth_on_untrusted_reinvocation` (v0.8.6)
+  — that's **count-driven** on a per-tool counter once any untrusted
+  output has flowed back.
+- This gate is **signal-driven** and targets a specific **privileged-
+  sink glob set**. The three compose; run all three for layered
+  coverage.
+
+Surfaces:
+
+- `agent_airlock.action_contradiction_gate` — new module:
+  - `ActionContradictionGate` (`@dataclass`, thread-safe,
+    `threading.Lock`-protected sticky state).
+  - `ActionContradictionViolation(PolicyViolation)`.
+  - `DEFAULT_PRIVILEGED_SINKS: tuple[str, ...]` — the canonical set.
+  - `ContradictionGateAction = Literal["block", "warn"]`.
+- `agent_airlock.policy.SecurityPolicy.action_contradiction_gate:
+  ActionContradictionGate | None = None` — new optional field;
+  default `None` preserves v0.8.14 behavior exactly.
+- `agent_airlock.core.Airlock._check_action_contradiction_gate(...)`
+  — new private **Step 2.6** in the `@Airlock` pre-execution
+  pipeline. Runs right after the v0.8.12 sequence-guard hook (Step
+  2.5) so a transition-blocked tool never advances the
+  contradiction state.
+
+Tests: 53 in `tests/test_action_contradiction_gate.py` covering
+construction validation (action / privileged_sinks /
+no-detectors-inert), all 3 detector kinds (incl. predicate-raise
+swallowed + any-detector-trips), 22 default privileged-sink globs
+parametrized blocked when tripped, 4 non-sink tools admitted under
+tripped state, operator override of `privileged_sinks`,
+authorize_once one-shot flow, sticky-trip invariant after one-shot
+consumed, per-tool grant isolation, warn vs block, reset
+(per-session + global), exception payload shape (subclass of
+`PolicyViolation`, audit-friendly `details`), thread safety (20
+concurrent calls all blocked), and `@Airlock` end-to-end (privileged
+sink blocked via the positional-context-wrapper pattern, non-sink
+admitted under contradiction, clean session admits).
+
+Smoke
+
+`scripts/smoke_action_contradiction_gate.py` builds the wheel,
+installs into a fresh venv with **no extras**, imports the gate from
+the *installed* package, simulates an "acknowledged contradiction"
+trace by passing a `RunContextWrapper`-shaped wrapper carrying
+`metadata={"evidence_contradiction": True}`, asserts a dummy
+`send_email` tool returns a blocked `AirlockResponse`, asserts a
+dummy `read_kb` (non-sink) is admitted, asserts a clean session
+(`evidence_contradiction=False`) admits the privileged tool, and
+asserts `__version__ == "0.8.15"` on the installed package.
+
+Version bump 0.8.14 → 0.8.15 (additive new module + additive
+optional `SecurityPolicy` field; no API break; zero new runtime
+deps).
+
 ### Added — Capsule ShareLeak / PipeLeak preset (v0.8.14, CVE-2026-21520)
 
 `capsule_indirect_injection_cve_2026_21520_defaults()` — a deny-by-

--- a/README.md
+++ b/README.md
@@ -523,6 +523,78 @@ a chain-of-thought monitor — by construction.
 
 ---
 
+### 🛑 Action-time contradiction gate (v0.8.15)
+
+[arXiv:2605.27157](https://arxiv.org/abs/2605.27157) ("Detecting Is
+Not Resolving: The Monitoring Control Gap in Retrieval Augmented
+LLMs", Yu et al., 2026) shows that LLMs **readily acknowledge
+contradictory evidence** in their reasoning trace yet "this awareness
+fails to constrain their final recommendations". The deficit is at
+*action selection* — single-turn diagnostics overestimate RAG safety,
+and detection alone is not a control.
+
+`ActionContradictionGate` is an opt-in policy hook that wraps three
+**pluggable detectors** (any one trips) and a **privileged-sink glob
+set**. When a detector trips AND the dispatched tool matches a
+privileged sink AND the harness has not issued an explicit allow,
+the gate blocks the call (or warns, depending on `action=`).
+
+The explicit-allow primitive **is not new** — the gate reuses the
+existing `AirlockContext.authorize_once(tool_name)` (introduced for
+the v0.8.6 reauth flow). Same one-shot grant, same semantics. After
+a one-shot is consumed the gate **re-locks** — the harness must mint
+a fresh `authorize_once` for each privileged action.
+
+```python
+import re
+from agent_airlock import Airlock, SecurityPolicy
+from agent_airlock.action_contradiction_gate import ActionContradictionGate
+
+policy = SecurityPolicy(
+    action_contradiction_gate=ActionContradictionGate(
+        # Detector 1: a boolean flag the RAG pipeline flips on after
+        # it sees an evidence-vs-claim conflict the agent discussed.
+        signal_field_key="evidence_contradiction",
+        # Detector 2: pluggable regex against the SAME key when its
+        # value is a string (operator-controlled marker — never the
+        # model's full reasoning trace).
+        marker_regex=re.compile(r"contradict|conflict|disagree", re.I),
+        # Detector 3: fully pluggable callable; receives the context.
+        # predicate=lambda ctx: ctx.metadata.get("conflict_count", 0) > 1,
+        # Default privileged sinks: send_* / export_* / commit_* /
+        # transfer_* / delete_* + the v0.8.14 outbound-integration set.
+        # Operators can narrow via `privileged_sinks=(...)`.
+        action="block",  # or "warn" for staged turn-up
+    ),
+)
+```
+
+**Off-by-default invariant.** `SecurityPolicy.action_contradiction_gate`
+defaults to `None`; non-RAG flows pay **zero false-positive tax**
+(no detector runs, no log lines, no metadata reads). Even when wired,
+the gate is **inert until at least one detector slot is configured**
+— so a partial roll-out (gate attached but detectors flipped off)
+admits everything.
+
+**Not a chain-of-thought monitor.** The gate reads **operator-
+controlled signals** only (a metadata field, an operator regex, an
+operator predicate). It never reads the model's own claim that it
+has or has not noticed a contradiction — the paper's whole point is
+that those claims do not gate behavior.
+
+**Not** `sequence_guard` (v0.8.12) — that flags unusual call ORDER.
+**Not** `reauth_on_untrusted_reinvocation` (v0.8.6) — that's
+count-driven on a per-tool counter. This gate is signal-driven and
+targets a specific privileged-sink glob set. They compose; run all
+three for layered coverage.
+
+> Strictly opt-in. Zero new runtime deps — Pydantic-only core stays
+> intact. The new `SecurityPolicy.action_contradiction_gate` field
+> defaults to `None`; callers that don't set it get exactly v0.8.14
+> behavior.
+
+---
+
 ### 🔎 Privilege right-sizing — `airlock-explain --unused-scopes` (v0.8.13)
 
 A read-only CLI that surfaces **over-permissioning**: it diffs the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.14"
+version = "0.8.15"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"

--- a/scripts/smoke_action_contradiction_gate.py
+++ b/scripts/smoke_action_contradiction_gate.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Smoke test: pip-install the v0.8.15 wheel + exercise the action-time
+contradiction gate end-to-end against a simulated "acknowledged
+contradiction" trace.
+
+Runs *outside* the editable source tree:
+
+1. Builds a wheel via ``python -m build --wheel`` into ``dist/``.
+2. Creates a throwaway venv under ``.smoke-acg-venv/``.
+3. Installs ``dist/agent_airlock-<version>-py3-none-any.whl`` into
+   the venv. **No extras** — the gate is base-install only.
+4. Runs a child Python in the venv that:
+   - imports ``ActionContradictionGate`` from the *installed* package,
+   - attaches it to a ``SecurityPolicy`` with the ``signal_field``
+     detector keyed on ``"evidence_contradiction"``,
+   - applies it to a dummy ``send_email`` tool decorated with
+     ``@Airlock``,
+   - passes a positional context-wrapper carrying
+     ``metadata={"evidence_contradiction": True}`` — the simulated
+     "acknowledged contradiction" trace,
+   - asserts the dummy tool returns a blocked ``AirlockResponse``,
+   - re-runs with a non-privileged tool and asserts it is admitted,
+   - re-runs the privileged tool with the contradiction signal
+     OFF and asserts it is admitted.
+
+Exit codes:
+
+  0   smoke passes.
+  1   smoke assertion failed.
+  2   environment problem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess  # noqa: S404 - smoke driver
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST_DIR = REPO_ROOT / "dist"
+VENV_DIR = REPO_ROOT / ".smoke-acg-venv"
+
+
+def _run(cmd: list[str]) -> None:
+    print(f"$ {' '.join(cmd)}", flush=True)
+    subprocess.check_call(cmd)  # noqa: S603 - argv pinned
+
+
+def build_wheel() -> Path:
+    DIST_DIR.mkdir(exist_ok=True)
+    for old in DIST_DIR.glob("agent_airlock-*.whl"):
+        old.unlink()
+    _run([sys.executable, "-m", "build", "--wheel", "--outdir", str(DIST_DIR)])
+    wheels = sorted(DIST_DIR.glob("agent_airlock-*.whl"))
+    if not wheels:
+        print("ERROR: no wheel produced under dist/", file=sys.stderr)
+        sys.exit(2)
+    return wheels[-1]
+
+
+def make_venv() -> tuple[Path, Path]:
+    if VENV_DIR.exists():
+        shutil.rmtree(VENV_DIR)
+    _run([sys.executable, "-m", "venv", str(VENV_DIR)])
+    py = VENV_DIR / ("Scripts" if sys.platform == "win32" else "bin") / "python"
+    _run([str(py), "-m", "pip", "install", "--quiet", "--upgrade", "pip"])
+    return VENV_DIR, py
+
+
+def install_wheel(py: Path, wheel: Path) -> None:
+    _run([str(py), "-m", "pip", "install", "--quiet", str(wheel)])
+
+
+CHILD_SMOKE_SCRIPT = textwrap.dedent(
+    """\
+    import sys
+    from dataclasses import dataclass, field
+    from typing import Any
+
+    # Imports from the *installed* package, not the source tree.
+    from agent_airlock import Airlock, SecurityPolicy, __version__
+    from agent_airlock.action_contradiction_gate import (
+        ActionContradictionGate,
+        ActionContradictionViolation,
+    )
+
+
+    @dataclass
+    class _Inner:
+        agent_id: str
+        metadata: dict = field(default_factory=dict)
+
+
+    @dataclass
+    class _Wrapper:
+        # RunContextWrapper-style: the seam reads .context off the
+        # first positional arg and pulls agent_id + metadata.
+        context: _Inner
+
+
+    def main() -> int:
+        if __version__ != "0.8.15":
+            print(f"FAIL: __version__={__version__!r}, expected 0.8.15", file=sys.stderr)
+            return 1
+
+        policy = SecurityPolicy(
+            action_contradiction_gate=ActionContradictionGate(
+                signal_field_key="evidence_contradiction",
+            ),
+        )
+
+        @Airlock(policy=policy)
+        def send_email(_ctx: _Wrapper, to: str, body: str) -> str:
+            return f"sent to {to}"
+
+        @Airlock(policy=policy)
+        def read_kb(_ctx: _Wrapper, query: str) -> str:
+            return f"results for {query}"
+
+        # 1. Simulated 'acknowledged contradiction' trace — privileged
+        #    sink blocked by default.
+        contradicted = _Wrapper(
+            context=_Inner(
+                agent_id="ag-rag",
+                metadata={"evidence_contradiction": True},
+            )
+        )
+        blocked = send_email(contradicted, to="x@x", body="<sensitive>")
+        if not isinstance(blocked, dict):
+            print(f"FAIL: expected blocked dict, got {type(blocked).__name__}", file=sys.stderr)
+            return 1
+        if blocked.get("status") != "blocked":
+            print(f"FAIL: status={blocked.get('status')!r}", file=sys.stderr)
+            return 1
+        if "send_email" not in blocked.get("error", ""):
+            print(f"FAIL: error did not mention sink: {blocked.get('error')!r}", file=sys.stderr)
+            return 1
+        print("OK: privileged sink BLOCKED under simulated contradiction trace")
+
+        # 2. Non-privileged tool admitted under the same contradiction state.
+        result = read_kb(contradicted, query="alpha")
+        if result != "results for alpha":
+            print(f"FAIL: non-sink unexpectedly blocked: {result!r}", file=sys.stderr)
+            return 1
+        print("OK: non-sink ADMITTED under same contradiction state")
+
+        # 3. Clean session — no contradiction → privileged tool admits.
+        clean = _Wrapper(
+            context=_Inner(
+                agent_id="ag-clean",
+                metadata={"evidence_contradiction": False},
+            )
+        )
+        result = send_email(clean, to="ok@ok", body="hi")
+        if result != "sent to ok@ok":
+            print(f"FAIL: clean session blocked: {result!r}", file=sys.stderr)
+            return 1
+        print("OK: clean session admits the privileged tool")
+
+        return 0
+
+
+    sys.exit(main())
+    """
+)
+
+
+def run_child(py: Path) -> int:
+    print("$ <venv-python> -c <SMOKE>", flush=True)
+    proc = subprocess.run([str(py), "-c", CHILD_SMOKE_SCRIPT], check=False)  # noqa: S603
+    return proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keep-venv", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        wheel = build_wheel()
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: wheel build failed: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        _venv, py = make_venv()
+        install_wheel(py, wheel)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: venv setup failed: {exc}", file=sys.stderr)
+        return 2
+
+    rc = run_child(py)
+    if rc == 0 and not args.keep_venv:
+        shutil.rmtree(VENV_DIR, ignore_errors=True)
+    elif rc != 0:
+        print(
+            f"\nSmoke failed (rc={rc}). Venv left at {VENV_DIR} for triage.",
+            file=sys.stderr,
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -570,7 +570,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.8.14"
+__version__ = "0.8.15"
 
 __all__ = [
     # Core

--- a/src/agent_airlock/action_contradiction_gate.py
+++ b/src/agent_airlock/action_contradiction_gate.py
@@ -1,0 +1,428 @@
+"""Action-time contradiction gate (v0.8.15+, arXiv:2605.27157).
+
+Why a *separate* gate at action time
+-------------------------------------
+Yu et al., *Detecting Is Not Resolving: The Monitoring Control Gap in
+Retrieval Augmented LLMs* (`arXiv:2605.27157`_, 2026), show that LLMs
+**readily acknowledge contradictory evidence** in their reasoning trace
+yet "this awareness fails to constrain their final recommendations".
+The paper localises the deficit at *action selection*: the danger-
+relevant information receives attention during generation but does not
+gate the output behaviour. Single-turn diagnostics therefore
+overestimate RAG safety, and detection alone is not a control.
+
+agent-airlock already detects many things (sequence anomalies, ghost
+args, schema mismatches, untrusted re-invocation). The thing it was
+*not* doing before this module is: when the harness or the agent
+itself signals that contradictory evidence has been seen, **gate the
+privileged / irreversible action** that comes next. This module is
+that gate.
+
+What this module is
+-------------------
+``ActionContradictionGate`` — an opt-in, off-by-default policy hook
+that wraps three **pluggable detectors** (any one trips the gate) and a
+**privileged-sink glob set**. When a detector trips AND the dispatched
+tool matches a privileged sink AND no explicit allow has been issued,
+the gate raises :class:`ActionContradictionViolation` (a
+:class:`PolicyViolation` subclass, so the existing
+``handle_policy_violation`` chain in ``core.py`` picks it up unchanged).
+
+The three detector slots are intentionally narrow — each is a single
+field, single regex, or single callable — so the gate stays
+auditable. Composing them is the operator's job.
+
+The explicit-allow primitive is **not new**: this module reuses the
+existing :meth:`AirlockContext.authorize_once` (introduced for the
+v0.8.6 reauth flow). Same one-shot grant, same semantics.
+
+What this module is NOT
+-----------------------
+- Not a "trust the model's reasoning trace" monitor. The paper's
+  whole point is that the trace is unreliable; we read **operator-
+  controlled signals** (a metadata field, an operator regex, an
+  operator predicate) — never the model's own claim that it has or
+  has not "noticed" a contradiction.
+- Not :mod:`agent_airlock.sequence_guard` (v0.8.12) — that flags
+  *unusual transitions* in the call ORDER. This gate flags
+  *contradiction-acknowledged + privileged-action* coupling at a
+  *single* call boundary. The two compose.
+- Not :attr:`SecurityPolicy.reauth_on_untrusted_reinvocation` (v0.8.6)
+  — that flags re-invocation past a threshold once any untrusted tool
+  output has flowed back into context. This gate is signal-driven, not
+  count-driven, and targets a specific privileged-sink glob set.
+
+Failure model
+-------------
+Fail closed by default. ``action="block"`` (the default) raises on a
+flagged action. ``action="warn"`` logs via structlog and lets the call
+proceed — useful for staging.
+
+Off-by-default invariant
+------------------------
+``SecurityPolicy.action_contradiction_gate`` defaults to ``None``. A
+caller who never sets the field sees zero overhead in the seam — no
+detector runs, no log lines, no metadata reads. Specifically: a non-
+RAG flow that has no notion of "evidence" pays no false-positive tax.
+
+.. _arXiv:2605.27157: https://arxiv.org/abs/2605.27157
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import structlog
+
+from .policy import PolicyViolation, ViolationType
+
+logger = structlog.get_logger("agent-airlock.action_contradiction_gate")
+
+
+ContradictionGateAction = Literal["block", "warn"]
+
+
+# The deny-by-default privileged-sink corpus. These are the tool-name
+# globs the brief calls out: privileged or irreversible actions
+# (send / export / commit / transfer) — plus the family of agentic
+# exfil sinks the project already targets in the Capsule v0.8.14
+# preset, kept in sync deliberately so the two presets compose without
+# the operator having to re-declare the universe of risky sinks.
+DEFAULT_PRIVILEGED_SINKS: tuple[str, ...] = (
+    # Send / publish / dispatch
+    "send_*",
+    "publish_*",
+    "post_to_*",
+    "webhook_*",
+    "dispatch_*",
+    # Export / share / upload
+    "export_*",
+    "share_*",
+    "upload_*",
+    # State-mutating commits and transfers
+    "commit_*",
+    "transfer_*",
+    "wire_*",
+    "pay_*",
+    "create_payment_*",
+    # Delete / overwrite — irreversible
+    "delete_*",
+    "drop_*",
+    "destroy_*",
+    "purge_*",
+    # Specific outbound integrations already canonicalised in v0.8.14
+    "outlook_*",
+    "smtp_*",
+    "salesforce_send_email",
+    "create_case",
+    "create_lead",
+)
+
+
+# ---------------------------------------------------------------------------
+# Exception
+# ---------------------------------------------------------------------------
+
+
+class ActionContradictionViolation(PolicyViolation):
+    """Raised when a privileged action is blocked because contradictory
+    evidence was acknowledged earlier in the session.
+
+    Subclasses :class:`PolicyViolation` so the existing ``@Airlock``
+    error handler (which routes ``PolicyViolation`` through
+    ``handle_policy_violation``) picks it up unchanged.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool_name: str,
+        detector_kind: str,
+        session_key: str | None,
+    ) -> None:
+        super().__init__(
+            message=message,
+            violation_type=ViolationType.TOOL_DENIED,
+            details={
+                "guard": "action_contradiction_gate",
+                "tool_name": tool_name,
+                "detector_kind": detector_kind,
+                "session_key": session_key,
+            },
+        )
+        self.tool_name = tool_name
+        self.detector_kind = detector_kind
+        self.session_key = session_key
+
+
+# ---------------------------------------------------------------------------
+# Per-session contradiction state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ContradictionState:
+    """Per-session sticky flag: once tripped, stays tripped until an
+    explicit ``authorize_once`` consumes a one-shot grant for the next
+    privileged call. The flag stays set across the rest of the session
+    so subsequent privileged calls (after the consumed grant) are
+    re-blocked — the operator must mint a fresh ``authorize_once`` for
+    each privileged action."""
+
+    tripped: bool = False
+    last_detector_kind: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ActionContradictionGate:
+    """Gate that requires an explicit allow before a privileged action
+    when the session has signalled acknowledged-contradiction evidence.
+
+    Attach via :attr:`SecurityPolicy.action_contradiction_gate`. The
+    ``@Airlock`` seam runs the gate as Step 2.6 of the pre-execution
+    pipeline (right after the v0.8.12 sequence guard). When **all** of
+    the following hold:
+
+    1. At least one configured detector reports a contradiction
+       (operator-controlled signal — never the model's own trace).
+    2. The dispatched tool name matches one of
+       :attr:`privileged_sinks` (glob).
+    3. The :class:`AirlockContext` has not issued
+       :meth:`authorize_once` for this tool.
+
+    …then the gate raises :class:`ActionContradictionViolation` (or
+    logs + admits if ``action="warn"``).
+
+    All three detectors are optional and orthogonal. Set any one or
+    any combination; "any detector trips" semantics. If **none** are
+    set, the gate is inert (it will never raise) — useful when an
+    operator wants to wire the gate but flip the actual detectors on
+    later via :meth:`SecurityPolicy.with_metadata`-style overrides.
+
+    Attributes:
+        signal_field_key: Key the gate looks up in
+            ``AirlockContext.metadata``. A truthy value at that key
+            means "the harness has detected acknowledged contradictory
+            evidence in this session". Typical usage: a RAG retrieval
+            pipeline flips this on after it sees an evidence-vs-claim
+            conflict the agent has discussed.
+        marker_regex: Pre-compiled regex run against the value the
+            gate finds at :attr:`signal_field_key` *when that value is
+            a string*. Lets the operator key the gate on a textual
+            marker (e.g. ``re.compile(r"\\b(however|but|conflict)\\b",
+            re.I)``) without changing application code. The regex is
+            **never** run against the model's full reasoning trace —
+            only against operator-supplied marker strings.
+        predicate: Fully pluggable detector. Receives the
+            :class:`AirlockContext` and returns ``True`` to flag.
+            Run last so a bug in the predicate cannot prevent the
+            other two detectors from voting.
+        privileged_sinks: Glob-matched (``fnmatch``) tool-name globs
+            this gate covers. Defaults to
+            :data:`DEFAULT_PRIVILEGED_SINKS` (send / export / commit /
+            transfer / delete + the v0.8.14 outbound-integration set).
+        action: ``"block"`` (default) → raise
+            :class:`ActionContradictionViolation`. ``"warn"`` → log +
+            admit, useful for staged turn-up.
+        session_key_kind: ``"agent_id"`` (default) or ``"session_id"``
+            — selects which field of :class:`AirlockContext` the
+            per-session state is keyed on.
+
+    Failure model: fail closed by default. ``action="warn"`` is
+    explicitly off-policy in production and is only there for
+    operators staging the gate against real traffic.
+
+    Thread safety: per-session state lives behind ``threading.Lock``;
+    concurrent detectors and ``authorize_once`` calls preserve the
+    sticky-trip invariant.
+    """
+
+    signal_field_key: str | None = None
+    marker_regex: re.Pattern[str] | None = None
+    predicate: Callable[[Any], bool] | None = None
+    privileged_sinks: tuple[str, ...] = DEFAULT_PRIVILEGED_SINKS
+    action: ContradictionGateAction = "block"
+    session_key_kind: Literal["agent_id", "session_id"] = "agent_id"
+
+    # Internal sticky state, per session key.
+    _states: dict[str, _ContradictionState] = field(default_factory=dict, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.action not in ("block", "warn"):
+            raise ValueError(f"action must be 'block' or 'warn'; got {self.action!r}")
+        if not self.privileged_sinks:
+            raise ValueError(
+                "privileged_sinks must be non-empty; use the deny-by-default "
+                "DEFAULT_PRIVILEGED_SINKS or pass your own glob tuple"
+            )
+
+    # -- Public API -------------------------------------------------------
+
+    def reset(self, session_key: str | None = None) -> None:
+        """Drop in-memory state. If ``session_key`` is None, drop all."""
+        with self._lock:
+            if session_key is None:
+                self._states.clear()
+            else:
+                self._states.pop(session_key, None)
+
+    def is_tripped(self, session_key: str) -> bool:
+        """Return whether the gate is currently sticky-tripped for the
+        given session. Public so the harness can inspect (e.g. to
+        decide whether to issue an out-of-band approval prompt)."""
+        with self._lock:
+            return self._states.get(session_key, _ContradictionState()).tripped
+
+    def check_action(
+        self,
+        *,
+        context: Any,
+        tool_name: str,
+        session_key: str,
+    ) -> None:
+        """Run all configured detectors against the context; if any
+        trips and the tool is a privileged sink, enforce the gate.
+
+        Args:
+            context: The :class:`AirlockContext` for the current call.
+                Duck-typed (we read ``.metadata`` + ``._authorized_once``)
+                so this module does not hard-import ``context.py``.
+            tool_name: Tool being dispatched.
+            session_key: Operator-resolved session identifier. The
+                caller derives it from
+                ``context.agent_id``/``session_id`` per
+                :attr:`session_key_kind` to keep this method pure.
+
+        Raises:
+            ActionContradictionViolation: ``action="block"`` and the
+                gate is enforced. ``action="warn"`` never raises.
+        """
+        # Detect — refresh state. We always run the detectors (even when
+        # the tool is not a privileged sink) so that the sticky flag
+        # accumulates across the session even if non-privileged tools
+        # are called between the contradiction-signal moment and the
+        # eventual privileged action.
+        detector_kind = self._run_detectors(context)
+        with self._lock:
+            state = self._states.setdefault(session_key, _ContradictionState())
+            if detector_kind is not None:
+                state.tripped = True
+                state.last_detector_kind = detector_kind
+            tripped = state.tripped
+            last_kind = state.last_detector_kind or "unknown"
+
+        if not tripped:
+            return
+        if not self._is_privileged_sink(tool_name):
+            return
+
+        # Privileged sink + tripped session → check the one-shot grant.
+        authorized: set[str] = getattr(context, "_authorized_once", set())
+        if tool_name in authorized:
+            # Consume the grant; do NOT clear the sticky flag — the
+            # next privileged call must mint a fresh authorize_once.
+            authorized.discard(tool_name)
+            logger.info(
+                "action_contradiction_gate.authorize_once_consumed",
+                tool_name=tool_name,
+                session_key=session_key,
+                detector_kind=last_kind,
+            )
+            return
+
+        violation = ActionContradictionViolation(
+            message=(
+                f"action_contradiction_gate: tool {tool_name!r} is a "
+                f"privileged sink and the session has acknowledged "
+                f"contradictory evidence (detector={last_kind!r}); "
+                f"call context.authorize_once({tool_name!r}) to grant "
+                f"a single privileged invocation. Rationale: "
+                f"arXiv:2605.27157 — acknowledging a contradiction is "
+                f"not the same as resolving it."
+            ),
+            tool_name=tool_name,
+            detector_kind=last_kind,
+            session_key=session_key,
+        )
+        if self.action == "warn":
+            logger.warning(
+                "action_contradiction_gate.violation_warn",
+                **{k: v for k, v in violation.details.items() if v is not None},
+            )
+            return
+        logger.warning(
+            "action_contradiction_gate.violation_block",
+            **{k: v for k, v in violation.details.items() if v is not None},
+        )
+        raise violation
+
+    # -- Internals --------------------------------------------------------
+
+    def _run_detectors(self, context: Any) -> str | None:
+        """Return the name of the first detector that trips, or
+        ``None`` if none do.
+
+        Detector kinds are deliberately orthogonal on the SAME metadata
+        key (``signal_field_key``) so an operator can use one
+        well-known key for any detector shape they pick:
+
+        - ``signal_field`` trips iff ``metadata[signal_field_key] is True``
+          (strict boolean — booleans are the unambiguous "flag" shape).
+        - ``marker_regex`` trips iff the value at the same key is a
+          ``str`` AND ``marker_regex.search(value)`` is truthy
+          (strings are the operator's narrative marker shape).
+        - ``predicate`` is the catch-all — reads anything off context.
+
+        This split means an operator who uses the same key for either
+        a flag OR a marker string gets unambiguous detector_kind in
+        the audit verdict.
+        """
+        metadata: dict[str, Any] = getattr(context, "metadata", {}) or {}
+
+        if self.signal_field_key is not None:
+            if metadata.get(self.signal_field_key) is True:
+                return "signal_field"
+
+        if self.marker_regex is not None and self.signal_field_key is not None:
+            value = metadata.get(self.signal_field_key)
+            if isinstance(value, str) and self.marker_regex.search(value):
+                return "marker_regex"
+
+        if self.predicate is not None:
+            try:
+                if self.predicate(context):
+                    return "predicate"
+            except Exception as exc:  # noqa: BLE001
+                # A buggy predicate must not crash the gate — log and
+                # treat as no-vote. Operators get the structlog event
+                # so the bug is visible without breaking enforcement.
+                logger.warning(
+                    "action_contradiction_gate.predicate_error",
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+
+        return None
+
+    def _is_privileged_sink(self, tool_name: str) -> bool:
+        return any(fnmatch.fnmatch(tool_name, pattern) for pattern in self.privileged_sinks)
+
+
+__all__ = [
+    "DEFAULT_PRIVILEGED_SINKS",
+    "ActionContradictionGate",
+    "ActionContradictionViolation",
+    "ContradictionGateAction",
+]

--- a/src/agent_airlock/core.py
+++ b/src/agent_airlock/core.py
@@ -458,6 +458,18 @@ class Airlock:
             if seq_error is not None:
                 return kwargs, start_time, context, seq_error, None
 
+            # Step 2.6: Action-time contradiction gate (V0.8.15,
+            # arXiv:2605.27157). Runs after the sequence guard so a
+            # transition-blocked tool never advances the contradiction
+            # state. Inert when policy.action_contradiction_gate is None.
+            acg_error = self._check_action_contradiction_gate(
+                func_name=func_name,
+                resolved_policy=resolved_policy,
+                context=context,
+            )
+            if acg_error is not None:
+                return kwargs, start_time, context, acg_error, None
+
             # Step 3: Validate filesystem paths
             fs_error = self._validate_filesystem_paths(func_name, cleaned_kwargs)
             if fs_error is not None:
@@ -1264,6 +1276,83 @@ class Airlock:
                     "to_tool": e.to_tool,
                     "session_key": e.session_key,
                     "observed_probability": e.observed_probability,
+                },
+            )
+            return response
+
+        return None
+
+    def _check_action_contradiction_gate(
+        self,
+        *,
+        func_name: str,
+        resolved_policy: SecurityPolicy | None,
+        context: AirlockContext[Any],
+    ) -> AirlockResponse | None:
+        """Action-time contradiction gate (V0.8.15, arXiv:2605.27157).
+
+        Calls ``policy.action_contradiction_gate.check_action(...)`` if
+        configured. The gate's pluggable detectors (signal field,
+        marker regex, predicate) decide whether the session has
+        signalled acknowledged-contradiction evidence; if so AND the
+        dispatched tool is a privileged sink, the gate raises
+        :class:`ActionContradictionViolation` unless the caller has
+        issued :meth:`AirlockContext.authorize_once` for this tool.
+
+        See :mod:`agent_airlock.action_contradiction_gate` for the
+        full contract.
+
+        Args:
+            func_name: Name of the function being called.
+            resolved_policy: The resolved :class:`SecurityPolicy` (or None).
+            context: Current :class:`AirlockContext` — read for the
+                detector inputs (``metadata``) and the explicit-allow
+                grant (``_authorized_once``).
+
+        Returns:
+            Error response if the action is blocked, None otherwise.
+            Returns None on warn-mode flags too — the gate has already
+            logged the warn event.
+        """
+        if resolved_policy is None or resolved_policy.action_contradiction_gate is None:
+            return None
+
+        gate = resolved_policy.action_contradiction_gate
+
+        # Resolve the session key the same way the sequence guard does:
+        # caller-preferred id first, fall back, fall back to anonymous.
+        if gate.session_key_kind == "session_id":
+            session_key = context.session_id or context.agent_id or "__anonymous__"
+        else:
+            session_key = context.agent_id or context.session_id or "__anonymous__"
+
+        # Lazy import to avoid the module-level cycle
+        # (action_contradiction_gate imports PolicyViolation from
+        # policy.py).
+        from .action_contradiction_gate import ActionContradictionViolation
+
+        try:
+            gate.check_action(
+                context=context,
+                tool_name=func_name,
+                session_key=session_key,
+            )
+        except ActionContradictionViolation as e:
+            response = handle_policy_violation(
+                func_name,
+                policy_name="ActionContradictionGate",
+                reason=e.message,
+            )
+            self._safe_invoke_callback(
+                self.config.on_blocked,
+                "on_blocked",
+                func_name,
+                e.message,
+                {
+                    "violation_type": "action_contradiction_violation",
+                    "tool_name": e.tool_name,
+                    "detector_kind": e.detector_kind,
+                    "session_key": e.session_key,
                 },
             )
             return response

--- a/src/agent_airlock/policy.py
+++ b/src/agent_airlock/policy.py
@@ -27,6 +27,7 @@ import structlog
 from .exceptions import AirlockError
 
 if TYPE_CHECKING:
+    from .action_contradiction_gate import ActionContradictionGate
     from .capabilities import CapabilityPolicy
     from .cost_tracking import (
         BudgetEstimate,
@@ -376,6 +377,14 @@ class SecurityPolicy:
     # exactly — no recording, no flagging, no on-disk state. See
     # ``agent_airlock.sequence_guard`` for the full contract.
     sequence_guard: SequenceGuard | None = None
+    # V0.8.15 action-time contradiction gate (arXiv:2605.27157).
+    # When set, the @Airlock seam runs the gate as Step 2.6, right
+    # after the v0.8.12 sequence guard. The gate is OFF by default
+    # (None preserves v0.8.14 behavior exactly) and even when wired
+    # is inert until at least one detector slot is configured — so
+    # non-RAG flows pay no false-positive tax. See
+    # :mod:`agent_airlock.action_contradiction_gate` for the contract.
+    action_contradiction_gate: ActionContradictionGate | None = None
 
     # Parsed/cached values
     _time_windows: dict[str, TimeWindow] = field(default_factory=dict, repr=False)

--- a/tests/test_action_contradiction_gate.py
+++ b/tests/test_action_contradiction_gate.py
@@ -1,0 +1,455 @@
+"""Tests for the action-time contradiction gate (v0.8.15, arXiv:2605.27157).
+
+Pins the off-by-default + pluggable-detectors + privileged-sink +
+authorize_once posture of :class:`ActionContradictionGate` end-to-end:
+
+- Off-by-default invariant: ``SecurityPolicy()`` without the gate is
+  zero-overhead and observationally equivalent to v0.8.14.
+- All three detector slots (signal_field, marker_regex, predicate)
+  trip the gate independently; "any detector trips" semantics.
+- Predicate that raises is swallowed (no crash, no false-trip).
+- Privileged-sink glob match (default set + operator override).
+- Non-privileged tool admitted even with contradiction state set.
+- ``authorize_once`` consumes one privileged call, then re-locks
+  (sticky-trip invariant).
+- ``action="warn"`` logs but does NOT raise.
+- ``session_key_kind`` selects which AirlockContext field keys state.
+- Thread-safe concurrent ``check_action``.
+- ``@Airlock`` end-to-end with the positional context-wrapper pattern
+  (the seam's documented context-extraction surface).
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from agent_airlock import Airlock, SecurityPolicy
+from agent_airlock.action_contradiction_gate import (
+    DEFAULT_PRIVILEGED_SINKS,
+    ActionContradictionGate,
+    ActionContradictionViolation,
+)
+from agent_airlock.context import AirlockContext
+from agent_airlock.policy import PolicyViolation
+
+# ---------------------------------------------------------------------------
+# Test wrappers — the established positional-context pattern the
+# @Airlock seam extracts from (OpenAI Agents SDK / RunContextWrapper).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Inner:
+    """Inner context the seam pulls fields off via ContextExtractor."""
+
+    agent_id: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _Wrapper:
+    """RunContextWrapper-style wrapper; the seam reads ``.context``."""
+
+    context: _Inner
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_rejects_unknown_action(self) -> None:
+        with pytest.raises(ValueError, match="action must be"):
+            ActionContradictionGate(action="silent")  # type: ignore[arg-type]
+
+    def test_rejects_empty_privileged_sinks(self) -> None:
+        with pytest.raises(ValueError, match="privileged_sinks must be non-empty"):
+            ActionContradictionGate(privileged_sinks=())
+
+    def test_defaults_inert_when_no_detectors_configured(self) -> None:
+        """Construction with all detectors unset is legal — and the gate
+        is inert. Lets operators wire the gate and flip detectors on
+        later via config-driven overrides."""
+        gate = ActionContradictionGate()
+        ctx = AirlockContext(agent_id="ag1", metadata={})
+        # Even a privileged sink admits when no detector is configured.
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag1")
+        assert gate.is_tripped("ag1") is False
+
+
+# ---------------------------------------------------------------------------
+# Detector pluggability — three independent slots
+# ---------------------------------------------------------------------------
+
+
+class TestDetectors:
+    def test_signal_field_trips_on_truthy_value(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="contradiction_seen")
+        ctx = AirlockContext(agent_id="ag", metadata={"contradiction_seen": True})
+        with pytest.raises(ActionContradictionViolation) as exc:
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert exc.value.detector_kind == "signal_field"
+        # Sticky-trip persists even after a check.
+        assert gate.is_tripped("ag") is True
+
+    def test_signal_field_does_not_trip_on_falsy(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="contradiction_seen")
+        ctx = AirlockContext(agent_id="ag", metadata={"contradiction_seen": False})
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert gate.is_tripped("ag") is False
+
+    def test_signal_field_absent_key_does_not_trip(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="contradiction_seen")
+        ctx = AirlockContext(agent_id="ag", metadata={})
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert gate.is_tripped("ag") is False
+
+    def test_marker_regex_trips_on_match(self) -> None:
+        gate = ActionContradictionGate(
+            signal_field_key="trace_excerpt",
+            marker_regex=re.compile(r"contradict|conflict", re.IGNORECASE),
+        )
+        ctx = AirlockContext(
+            agent_id="ag",
+            metadata={"trace_excerpt": "The retrieved doc conflicts with the claim"},
+        )
+        with pytest.raises(ActionContradictionViolation) as exc:
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert exc.value.detector_kind == "marker_regex"
+
+    def test_marker_regex_no_match_does_not_trip(self) -> None:
+        gate = ActionContradictionGate(
+            signal_field_key="trace_excerpt",
+            marker_regex=re.compile(r"\bDISAGREE\b"),
+        )
+        ctx = AirlockContext(agent_id="ag", metadata={"trace_excerpt": "all consistent"})
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert gate.is_tripped("ag") is False
+
+    def test_predicate_trips_when_true(self) -> None:
+        gate = ActionContradictionGate(
+            predicate=lambda c: bool(c.metadata.get("conflicting_evidence_count", 0))
+        )
+        ctx = AirlockContext(agent_id="ag", metadata={"conflicting_evidence_count": 2})
+        with pytest.raises(ActionContradictionViolation) as exc:
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert exc.value.detector_kind == "predicate"
+
+    def test_predicate_that_raises_is_swallowed(self) -> None:
+        """A buggy predicate must NOT crash the gate; the audit log
+        carries the predicate_error event but enforcement continues."""
+
+        def buggy_predicate(_ctx: Any) -> bool:
+            raise RuntimeError("predicate misconfigured")
+
+        gate = ActionContradictionGate(predicate=buggy_predicate)
+        ctx = AirlockContext(agent_id="ag", metadata={})
+        # Buggy predicate → no trip → admit even on privileged sink.
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert gate.is_tripped("ag") is False
+
+    def test_any_detector_trips(self) -> None:
+        """Multiple detectors configured — any one triggers."""
+        gate = ActionContradictionGate(
+            signal_field_key="never_set",
+            predicate=lambda c: True,  # always trips
+        )
+        ctx = AirlockContext(agent_id="ag", metadata={})
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+
+# ---------------------------------------------------------------------------
+# Privileged-sink semantics
+# ---------------------------------------------------------------------------
+
+
+class TestPrivilegedSinks:
+    @pytest.fixture
+    def tripped_gate(self) -> ActionContradictionGate:
+        return ActionContradictionGate(signal_field_key="x")
+
+    @pytest.fixture
+    def tripped_ctx(self) -> AirlockContext[Any]:
+        return AirlockContext(agent_id="ag", metadata={"x": True})
+
+    @pytest.mark.parametrize(
+        "sink_tool",
+        [
+            "send_email",
+            "send_mail",
+            "publish_event",
+            "post_to_chatter",
+            "webhook_dispatch",
+            "dispatch_alert",
+            "export_records",
+            "share_with_external",
+            "upload_to_drive",
+            "commit_transaction",
+            "transfer_funds",
+            "wire_payment",
+            "pay_invoice",
+            "delete_user",
+            "drop_table",
+            "destroy_resource",
+            "purge_cache",
+            "outlook_send_email",
+            "smtp_relay",
+            "salesforce_send_email",
+            "create_case",
+            "create_lead",
+        ],
+    )
+    def test_all_default_privileged_sinks_blocked_when_tripped(
+        self,
+        tripped_gate: ActionContradictionGate,
+        tripped_ctx: AirlockContext[Any],
+        sink_tool: str,
+    ) -> None:
+        with pytest.raises(ActionContradictionViolation):
+            tripped_gate.check_action(context=tripped_ctx, tool_name=sink_tool, session_key="ag")
+
+    @pytest.mark.parametrize(
+        "non_sink_tool", ["read_kb", "lookup_doc", "search_index", "fetch_kb_entry"]
+    )
+    def test_non_privileged_tool_admitted_even_when_tripped(
+        self,
+        tripped_gate: ActionContradictionGate,
+        tripped_ctx: AirlockContext[Any],
+        non_sink_tool: str,
+    ) -> None:
+        # No raise — non-sink calls admit even under tripped state.
+        tripped_gate.check_action(context=tripped_ctx, tool_name=non_sink_tool, session_key="ag")
+        # Sticky state remains true for the eventual privileged sink.
+        assert tripped_gate.is_tripped("ag") is True
+
+    def test_operator_can_narrow_privileged_sinks(self) -> None:
+        """Operator override: only ``transfer_*`` matters in this app."""
+        gate = ActionContradictionGate(
+            signal_field_key="x",
+            privileged_sinks=("transfer_*",),
+        )
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+        # send_email is NOT in this app's privileged set — admitted.
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        # But transfer_funds is.
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="transfer_funds", session_key="ag")
+
+    def test_default_sink_set_is_non_empty_and_documented(self) -> None:
+        """Defensive invariant — the constant must exist + be non-empty
+        so an operator who imports it for documentation never sees
+        an empty tuple."""
+        assert isinstance(DEFAULT_PRIVILEGED_SINKS, tuple)
+        assert len(DEFAULT_PRIVILEGED_SINKS) > 0
+
+
+# ---------------------------------------------------------------------------
+# authorize_once flow + sticky-trip invariant
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizeOnceFlow:
+    def test_authorize_once_clears_one_call(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+
+        # First privileged call: blocked.
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+        # Grant a one-shot; next call admits without raising.
+        ctx.authorize_once("send_email")
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+    def test_gate_re_locks_after_one_shot_consumed(self) -> None:
+        """Sticky-trip: the next privileged call after the consumed
+        one-shot is blocked again. The harness must mint a fresh
+        ``authorize_once`` for each privileged action."""
+        gate = ActionContradictionGate(signal_field_key="x")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+        ctx.authorize_once("send_email")
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+        # Re-locked.
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+    def test_grant_for_one_tool_does_not_clear_other(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+        ctx.authorize_once("send_email")
+        # Other privileged sink stays blocked.
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="transfer_funds", session_key="ag")
+
+
+# ---------------------------------------------------------------------------
+# warn vs block + reset
+# ---------------------------------------------------------------------------
+
+
+class TestActionModes:
+    def test_warn_mode_does_not_raise(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x", action="warn")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+        # Must not raise — admits with a log.
+        gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+
+    def test_reset_clears_per_session_state(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+        with pytest.raises(ActionContradictionViolation):
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert gate.is_tripped("ag") is True
+        gate.reset("ag")
+        assert gate.is_tripped("ag") is False
+
+    def test_reset_all_drops_every_session(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        for key in ("a", "b", "c"):
+            ctx = AirlockContext(agent_id=key, metadata={"x": True})
+            with pytest.raises(ActionContradictionViolation):
+                gate.check_action(context=ctx, tool_name="send_email", session_key=key)
+        gate.reset()
+        for key in ("a", "b", "c"):
+            assert gate.is_tripped(key) is False
+
+
+# ---------------------------------------------------------------------------
+# Exception payload — for the existing handle_policy_violation chain
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionPayload:
+    def test_violation_subclasses_policy_violation(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+        with pytest.raises(ActionContradictionViolation) as exc:
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        assert isinstance(exc.value, PolicyViolation)
+
+    def test_violation_carries_audit_payload(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+        with pytest.raises(ActionContradictionViolation) as exc:
+            gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+        details = exc.value.details
+        assert details["guard"] == "action_contradiction_gate"
+        assert details["tool_name"] == "send_email"
+        assert details["detector_kind"] == "signal_field"
+        assert details["session_key"] == "ag"
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_check_action_consistent_sticky_flag(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="x")
+        results: list[bool] = []
+
+        def worker() -> None:
+            ctx = AirlockContext(agent_id="ag", metadata={"x": True})
+            try:
+                gate.check_action(context=ctx, tool_name="send_email", session_key="ag")
+                results.append(False)  # admitted
+            except ActionContradictionViolation:
+                results.append(True)  # blocked
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All 20 must have been blocked — no race window admits a call.
+        assert results.count(True) == 20
+        assert gate.is_tripped("ag") is True
+
+
+# ---------------------------------------------------------------------------
+# SecurityPolicy + @Airlock end-to-end (off-by-default invariant)
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityPolicyIntegration:
+    def test_default_policy_has_no_gate(self) -> None:
+        """v0.8.14 callers see no behavior change."""
+        assert SecurityPolicy().action_contradiction_gate is None
+
+    def test_existing_presets_unaffected(self) -> None:
+        from agent_airlock import (
+            PERMISSIVE_POLICY,
+            READ_ONLY_POLICY,
+            STRICT_POLICY,
+        )
+
+        for p in (PERMISSIVE_POLICY, READ_ONLY_POLICY, STRICT_POLICY):
+            assert p.action_contradiction_gate is None
+
+    def test_airlock_seam_blocks_privileged_sink_on_contradiction(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="evidence_contradiction")
+        policy = SecurityPolicy(action_contradiction_gate=gate)
+
+        @Airlock(policy=policy)
+        def send_email(_ctx: _Wrapper, to: str, body: str) -> str:
+            return f"sent to {to}"
+
+        wrapper = _Wrapper(
+            context=_Inner(
+                agent_id="ag-rag",
+                metadata={"evidence_contradiction": True},
+            )
+        )
+        blocked = send_email(wrapper, to="x@x", body="exfil")
+        assert isinstance(blocked, dict)
+        assert blocked.get("status") == "blocked"
+        assert "send_email" in blocked.get("error", "")
+
+    def test_airlock_seam_admits_non_sink_under_contradiction(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="evidence_contradiction")
+        policy = SecurityPolicy(action_contradiction_gate=gate)
+
+        @Airlock(policy=policy)
+        def read_kb(_ctx: _Wrapper, query: str) -> str:
+            return f"results: {query}"
+
+        wrapper = _Wrapper(
+            context=_Inner(
+                agent_id="ag-rag",
+                metadata={"evidence_contradiction": True},
+            )
+        )
+        # Non-sink — admitted even with tripped state.
+        result = read_kb(wrapper, query="alpha")
+        assert result == "results: alpha"
+
+    def test_airlock_seam_admits_clean_session(self) -> None:
+        gate = ActionContradictionGate(signal_field_key="evidence_contradiction")
+        policy = SecurityPolicy(action_contradiction_gate=gate)
+
+        @Airlock(policy=policy)
+        def send_email(_ctx: _Wrapper, to: str, body: str) -> str:
+            return f"sent to {to}"
+
+        wrapper = _Wrapper(
+            context=_Inner(
+                agent_id="ag-clean",
+                metadata={"evidence_contradiction": False},
+            )
+        )
+        # No contradiction → admitted.
+        assert send_email(wrapper, to="ok@ok", body="hi") == "sent to ok@ok"


### PR DESCRIPTION
## Summary

Adds **`ActionContradictionGate`** — an opt-in, off-by-default policy hook that gates privileged / irreversible actions when the session has signalled acknowledged-contradiction evidence.

Closes the *detecting is not resolving* monitoring-control gap reported by Yu et al., [*Detecting Is Not Resolving: The Monitoring Control Gap in Retrieval Augmented LLMs*](https://arxiv.org/abs/2605.27157) (arXiv:2605.27157, 2026):

> Models exhibit a monitoring-control gap: they readily acknowledge contradictory evidence, yet this awareness fails to constrain their final recommendations.

The paper localises the deficit at action selection. This module is the action-time control: when a configured detector signals contradictory evidence AND the dispatched tool is a privileged sink, the gate raises `ActionContradictionViolation` (a `PolicyViolation` subclass, so the existing `handle_policy_violation` chain picks it up unchanged) unless the harness has issued an explicit allow.

## Discrepancies from the brief — surfaced before coding

| # | Brief | Reality | What I did |
|---|---|---|---|
| **A** | Suggested name `action_contradiction_gate` | Matches existing convention (`sequence_guard`) | Used `ActionContradictionGate` class + `action_contradiction_gate` policy field |
| **B** | Bump "one patch level" | Current `0.8.14` (drift between pyproject + `__init__.py` was fixed in #77) | Bumped **`0.8.14 → 0.8.15`** in both files |
| **C** | "Push to main (solo-maintainer)" | Last 6 features all PR-gated (#70/#71/#72/#76/#77/this) | PR workflow (consistent) |
| **D** | "Reference arXiv:2605.27157" | Verified real — Zhe Yu et al., abstract quote nails the brief | Cited verbatim in module docstring + CHANGELOG + README |
| **E** | "Detector pluggable… off by default" | The existing `SecurityPolicy` additive-optional-field pattern is the diff-compatible primitive | Field defaults to `None`; even when wired, **inert until at least one detector slot is configured** — non-RAG flows pay zero false-positive tax |

## Anti-duplicate, anti-pivot ✓

- `rg -inE 'def .*(contradict|conflict|consisten|action_gate|evidence)'` across `src/agent_airlock/` returned **zero hits**. Genuinely new coverage.
- The gate **reuses** existing primitives — `AirlockContext.authorize_once(tool_name)` (the v0.8.6 explicit-allow path), `PolicyViolation` (the existing error-handler chain), `fnmatch.fnmatch` (the matcher `SecurityPolicy.check_tool_allowed` already uses). **No new explicit-allow mechanism invented.**
- **Off-by-default** preserves v0.8.14 behavior exactly for any caller that doesn't construct the gate.

## How the gate works

### Three pluggable, orthogonal detectors (any one trips)

| Detector | Triggers when | Operator semantics |
|---|---|---|
| **`signal_field_key`** | `metadata[key] is True` (strict bool) | the unambiguous boolean-flag shape — RAG pipeline flips this on after seeing a conflict |
| **`marker_regex`** | value at same key **is a string** AND `regex.search(value)` matches | operator's narrative marker — reads only operator-supplied marker strings, **never** the model's full reasoning trace |
| **`predicate`** | `predicate(context)` returns `True` | fully pluggable; predicate that raises is **swallowed** (logged as `predicate_error`; treated as no-vote so a buggy predicate cannot break enforcement) |

The three detector slots are **orthogonal on the same metadata key** by design: `signal_field` is the bool-only case, `marker_regex` is the string case, and `predicate` is the catch-all — so an operator who uses one well-known key for either a flag OR a marker string gets an unambiguous `detector_kind` in the audit verdict.

### Privileged-sink glob set (deny-by-default targets)

Default canonical set covers:
- **Send / publish / dispatch:** `send_*`, `publish_*`, `post_to_*`, `webhook_*`, `dispatch_*`
- **Export / share / upload:** `export_*`, `share_*`, `upload_*`
- **State-mutating commits / transfers:** `commit_*`, `transfer_*`, `wire_*`, `pay_*`, `create_payment_*`
- **Irreversible deletes:** `delete_*`, `drop_*`, `destroy_*`, `purge_*`
- **v0.8.14 outbound integrations:** `outlook_*`, `smtp_*`, `salesforce_send_email`, `create_case`, `create_lead`

Operators can narrow via `privileged_sinks=(...)`.

### Explicit-allow + sticky-trip

The "explicit allow" is **the existing `AirlockContext.authorize_once(tool_name)`** — same one-shot grant the v0.8.6 reauth flow uses. After consumption the gate **re-locks**: each privileged action needs a fresh `authorize_once`. Asserted by `test_gate_re_locks_after_one_shot_consumed`.

## Disambiguation

- **Not** `agent_airlock.sequence_guard.SequenceGuard` (v0.8.12) — that flags unusual call **order**.
- **Not** `SecurityPolicy.reauth_on_untrusted_reinvocation` (v0.8.6) — that's **count-driven** on a per-tool counter once any untrusted output has flowed back.
- This gate is **signal-driven** and targets a specific **privileged-sink glob set**. The three compose; run all three for layered coverage.

## Wire-in

```python
import re
from agent_airlock import Airlock, SecurityPolicy
from agent_airlock.action_contradiction_gate import ActionContradictionGate

policy = SecurityPolicy(
    action_contradiction_gate=ActionContradictionGate(
        signal_field_key="evidence_contradiction",
        marker_regex=re.compile(r"contradict|conflict|disagree", re.I),
        # predicate=lambda ctx: ctx.metadata.get("conflict_count", 0) > 1,
        action="block",  # or "warn" for staged turn-up
    ),
)
```

The seam runs the gate as **Step 2.6** in `_pre_execution` — right after the v0.8.12 sequence-guard hook (Step 2.5) so a transition-blocked tool never advances the contradiction state.

## Test plan — 53 new tests, all green

- **Construction validation** (3) — action / privileged_sinks non-empty / no-detectors-inert invariant
- **Detectors** (8) — all three trip and don't trip; predicate-raise swallowed; any-detector composition
- **Privileged sinks** (22) — parametrized over the default canonical set, all blocked when tripped
- **Non-privileged tools** (4) — admitted even under tripped state (sticky state preserved for the eventual sink)
- **Operator narrowing** of `privileged_sinks`
- **`authorize_once` flow** (3) — one-shot clears, re-locks, per-tool isolation
- **`warn` vs `block` + reset** (3) — warn admits without raising; reset per-session + global
- **Exception payload** (2) — `PolicyViolation` subclass; audit-friendly `details`
- **Thread safety** (1) — 20 concurrent threads all blocked, sticky flag consistent
- **`SecurityPolicy` + `@Airlock` end-to-end** (5) — default-None policies + PERMISSIVE/READ_ONLY/STRICT presets unaffected; privileged sink blocked via positional-context-wrapper pattern; non-sink admitted; clean session admits

## Smoke against the installed wheel

```
Successfully built agent_airlock-0.8.15-py3-none-any.whl
$ <venv>/bin/python -c <SMOKE>
OK: privileged sink BLOCKED under simulated contradiction trace
OK: non-sink ADMITTED under same contradiction state
OK: clean session admits the privileged tool
```

The smoke (`scripts/smoke_action_contradiction_gate.py`):

1. Builds the wheel.
2. Creates a fresh venv with **no extras** — confirms zero new runtime deps.
3. Installs the wheel.
4. Asserts `__version__ == "0.8.15"` on the *installed* package.
5. Applies the gate via `signal_field_key="evidence_contradiction"` to a dummy `send_email` tool decorated with `@Airlock`.
6. Passes a positional `RunContextWrapper`-shaped wrapper carrying `metadata={"evidence_contradiction": True}` — the simulated "acknowledged contradiction" trace.
7. Asserts the dummy tool returns `status=blocked`; re-runs with a non-sink and asserts admit; re-runs with the contradiction signal OFF and asserts admit.

## Gate results (local)

| Gate | Result |
|---|---|
| `ruff check src/ tests/` | ✅ All checks passed |
| `ruff format --check` | ✅ 333 files clean |
| `bandit -r src/agent_airlock/` | ✅ exit 0 |
| `mypy src/` net delta | ✅ **8 → 8** baseline; new module is mypy-clean |
| `pytest tests/` | ✅ **2802 pass**, 33 skipped (+53 new). One perf-P99 flake on the elicitation guard's `test_p99_under_1_5ms` — **passes 3/3 in isolation AND on baseline**, hardware-dependent, unrelated |
| Coverage (CI gate 80) | ✅ **84.13%** |
| Coverage (pyproject gate 82) | ✅ 84.13% > 82 |
| Smoke (`scripts/smoke_action_contradiction_gate.py`) | ✅ |
| `make check-changelog-release` | ✅ `[Unreleased]` has release notes |

## Anti-pivot summary

- ✅ **Observability-AND-policy only.** No proxy/gateway pivot. No new validator invented.
- ✅ **Deny-by-default posture extended**, not relaxed.
- ✅ **Off-by-default** preserves v0.8.14 behavior exactly for non-RAG flows.
- ✅ **Zero new runtime deps.** Pydantic-only core stays intact.
- ✅ **Reuses existing primitives** — `AirlockContext.authorize_once`, `PolicyViolation`, `fnmatch`.
- ✅ **Reads operator-controlled signals only** — never the model's own claim that it has or has not noticed a contradiction (the paper's whole point is that those claims do not gate behavior).

## Reference

- Yu, Z., Xing, W., Ye, C., Teng, X., Yang, B., Lin, C. & Han, M. *Detecting Is Not Resolving: The Monitoring Control Gap in Retrieval Augmented LLMs.* [arXiv:2605.27157](https://arxiv.org/abs/2605.27157) (2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
