### PR TITLE
feat(guard): no_false_success terminal-claim guard (Goal-Autopilot 2606.11688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,48 @@ _Nothing unreleased — every entry below is a tagged release._
 
 ---
 
+## [0.8.25] - 2026-06-13 — "Fail-closed terminal-claim guard (Goal-Autopilot)"
+
+### Added
+
+- **feat(guard): no_false_success terminal-claim guard (Goal-Autopilot 2606.11688)**
+
+  A fail-closed guard that rejects an agent's terminal/`done` claim unless a
+  named, falsifiable check actually executed and passed in this run. Anchored
+  on Goal-Autopilot ([arXiv:2606.11688](https://arxiv.org/abs/2606.11688)),
+  whose No-False-Success floor admits no terminal claim whose falsifiable gate
+  did not execute and pass, degrading worst-case to an *honest stall, never a
+  fabricated success*.
+
+  - **`agent_airlock.done_receipt_guard.DoneReceiptGuard`** (stdlib-only —
+    `secrets`/`hmac`/`time`, no new runtime dependency): holds a registry of
+    falsifiable checks keyed by claim. `run(claim)` executes a check and records
+    a receipt stamped with the guard's per-run token; `check_done(claim)` admits
+    the terminal claim only if a receipt exists, was executed THIS run, and
+    passed. Verdicts: `ALLOW`, `STALL_NO_RECEIPT`, `STALL_CHECK_FAILED`,
+    `STALL_FORGED_RECEIPT`, `STALL_UNKNOWN_CLAIM`. Every stall is
+    `recoverable=True` (run the named check and retry, don't abort). Forgery
+    resistance is structural: a receipt that is merely present — hand-built
+    (`executed=False`), or replayed from another run (foreign token) — is
+    rejected; only a receipt the guard stamped by executing the check this run
+    is trusted. A check that raises counts as a fail, not a crash.
+  - **`policy_presets.no_false_success_defaults(checks, *, run_token=None)`** —
+    canonical `preset_id="no_false_success"` / `severity="high"` /
+    `default_action="deny"` / `owasp="ASI06"` dict + a pre-built `guard` and a
+    `check(claim)` callable that raises `NoFalseSuccessStall` (carrying the
+    decision + `recoverable`) on a fail-closed stall. Diff-compatible with the
+    existing preset-registration shape — a new preset, not a breaking change.
+  - **Opt-in per agent** — `AirlockConfig.require_done_receipt` (OFF by default
+    for backward compat; settable via constructor or `require_done_receipt =
+    true` under `[airlock]` in `airlock.toml`).
+
+  Tests (`tests/test_done_receipt_guard.py`, 20): a terminal claim with a
+  passing receipt is allowed; no receipt / a non-executed check / a failed check
+  / an unknown claim fail-closed to a recoverable stall; a forged receipt
+  (present but never executed) and a replayed cross-run receipt are rejected.
+
+---
+
 ## [0.8.24] - 2026-06-13 — "Skill-resistant trace redaction + per-tenant watermark (RedAct-style)"
 
 ### Added — Trace-redaction guard + per-tenant behavioural watermark (v0.8.24)

--- a/README.md
+++ b/README.md
@@ -735,6 +735,35 @@ assert verify_watermark(redacted, pol).detected   # provably yours
 
 ---
 
+### ✅ Fail-closed terminal-claim guard — `no_false_success` (v0.8.25)
+
+**An honest stall is recoverable; a confident wrong `done` is not.** The
+dominant failure mode of unattended long-horizon agents isn't crashing — it's
+*confidently reporting success they never verified*
+([Goal-Autopilot, arXiv:2606.11688](https://arxiv.org/abs/2606.11688)). The
+`no_false_success` preset enforces that paper's No-False-Success floor: a
+terminal/`done` claim is admitted **only if a named, falsifiable check actually
+executed and passed THIS run**. No receipt, a failed check, or a forged/replayed
+receipt → the guard fails closed to a **recoverable honest stall** (run the
+named check and retry), never a fabricated success.
+
+Forgery resistance is structural: the guard mints a per-run token and only
+trusts a receipt it stamped by executing the check this run — a receipt that's
+merely *present* (hand-built, or replayed from a prior run) is rejected. Opt in
+per-agent with `AirlockConfig(require_done_receipt=True)` (or
+`require_done_receipt = true` under `[airlock]` in `airlock.toml`); OFF by
+default. Stdlib-only — no new runtime dependency.
+
+```python
+from agent_airlock import no_false_success_defaults, NoFalseSuccessStall
+
+preset = no_false_success_defaults({"tests_green": run_pytest})  # falsifiable check
+preset["guard"].run("tests_green")        # actually execute the check this run
+preset["check"]("tests_green")            # raises NoFalseSuccessStall unless it passed
+```
+
+---
+
 ### 💰 Cost Control
 
 A runaway agent can burn $500 in API costs before you notice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.24"
+version = "0.8.25"
 description = "The Pydantic-based Firewall for MCP Servers. Stops hallucinated tool calls, validates schemas, and sandboxes dangerous operations."
 readme = "README.md"
 license = "MIT"

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -147,6 +147,15 @@ from .cost_tracking import (
     set_global_tracker,
 )
 
+# V0.8.25 — Fail-closed terminal-claim guard (Goal-Autopilot arXiv:2606.11688).
+from .done_receipt_guard import (
+    CheckReceipt,
+    DoneClaimDecision,
+    DoneClaimVerdict,
+    DoneReceiptGuard,
+    NoFalseSuccessStall,
+)
+
 # V0.3.0 Filesystem security
 from .filesystem import (
     RESTRICTIVE_FILESYSTEM_POLICY,
@@ -483,6 +492,7 @@ from .policy_presets import (
     mcp_subprocess_arg_injection_guard_defaults,
     mex_gov_2026_policy,
     mobile_mcp_intent_guard_2026_05,
+    no_false_success_defaults,
     owasp_mcp_top_10_2026_policy,
     stdio_guard_ox_defaults,
     strict_tier_budget_policy,
@@ -631,7 +641,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.8.24"
+__version__ = "0.8.25"
 
 __all__ = [
     # Core
@@ -684,6 +694,7 @@ __all__ = [
     "mcp_server_env_interpolation_guard_defaults",
     "codegen_delimiter_injection_guard_defaults",
     "mcp_subprocess_arg_injection_guard_defaults",
+    "no_false_success_defaults",
     "CAPSULE_INDIRECT_INJECTION_CVE_2026_21520_DEFAULTS",
     # V0.5.3 top-level error re-exports (canonical defs in submodules)
     "AgentCommerceCapExceeded",
@@ -873,6 +884,12 @@ __all__ = [
     # Response types
     "AirlockResponse",
     "BlockReason",
+    # V0.8.25 — Fail-closed terminal-claim guard (Goal-Autopilot arXiv:2606.11688)
+    "DoneReceiptGuard",
+    "DoneClaimDecision",
+    "DoneClaimVerdict",
+    "CheckReceipt",
+    "NoFalseSuccessStall",
     # V0.8.24 — Trace redaction + per-tenant watermark (RedAct-style)
     "TraceRedactionPolicy",
     "RedactionReport",

--- a/src/agent_airlock/config.py
+++ b/src/agent_airlock/config.py
@@ -125,6 +125,14 @@ class AirlockConfig:
     # 12-digit numbers). Locale codes are lowercase ISO-3166-1 alpha-2.
     pii_locales: list[str] = field(default_factory=list)
 
+    # V0.8.25 — opt-in fail-closed terminal-claim guard (Goal-Autopilot
+    # arXiv:2606.11688). OFF by default for backward compat. When True, an
+    # agent's terminal/"done" claim is admitted only if a named falsifiable
+    # check executed and passed THIS run; otherwise the guard returns a
+    # recoverable honest stall. Wire the per-claim checks via the
+    # ``no_false_success_defaults`` preset. ON under STRICT deployments.
+    require_done_receipt: bool = False
+
     def __post_init__(self) -> None:
         """Apply environment variable overrides after initialization."""
         # E2B API key priority: env var > constructor > config file
@@ -244,6 +252,8 @@ class AirlockConfig:
             "credentials",
             # V0.8.9 opt-in locale tags for region-specific PII
             "pii_locales",
+            # V0.8.25 opt-in fail-closed terminal-claim guard
+            "require_done_receipt",
         }
 
         # SECURITY: Warn about unknown keys (likely typos)
@@ -264,6 +274,7 @@ class AirlockConfig:
             "enable_audit_log",
             "audit_otel_enabled",  # V0.4.0
             "audit_include_args_hash",  # V0.4.0
+            "require_done_receipt",  # V0.8.25
         ):
             if key in data:
                 result[key] = bool(data[key])

--- a/src/agent_airlock/done_receipt_guard.py
+++ b/src/agent_airlock/done_receipt_guard.py
@@ -1,0 +1,331 @@
+"""Fail-closed terminal-claim guard (v0.8.25+, Goal-Autopilot anchor).
+
+Goal-Autopilot (arXiv:2606.11688, "A Verifiable Anti-Fabrication Firewall for
+Unattended Long-Horizon Agents", 2026-06-10) frames the core unattended-agent
+risk: a long-horizon agent **confidently reports success it never verified**.
+Its No-False-Success result enforces a hard floor — *no terminal "done" claim
+is admitted unless its falsifiable gate actually executed and passed* — and
+proves the worst case degrades to an **honest stall, never a fabricated
+success**.
+
+This module is that floor as an agent-airlock guard. It holds a registry of
+falsifiable checks keyed by claim. On a terminal/``done`` tool-call it verifies
+the matching check **ran and passed in THIS execution**; if not, it fails
+closed and returns a recoverable *honest stall* outcome instead of admitting
+the terminal claim.
+
+Why a per-run token (forgery resistance)
+----------------------------------------
+A check "passed" is only trusted if the guard itself executed it this run. The
+guard mints a fresh ``run_token`` at construction; :meth:`DoneReceiptGuard.run`
+stamps each receipt with that token as proof of execution. A receipt that is
+merely *present* — fabricated, replayed from a previous run, or constructed
+without ever calling the check — does not carry the live token and is rejected
+as forged. This is the difference between "a check object exists" and "the
+check ran and passed now".
+
+Recoverable by design
+---------------------
+Every stall is ``recoverable=True``: the honest move is to run the named check
+and retry, not to abort. As Goal-Autopilot puts it, an honest stall is
+recoverable; a confident wrong ``done`` is not.
+
+Zero-runtime-dep: stdlib ``secrets`` / ``time`` only — the Pydantic-only core
+is preserved.
+
+Primary source:
+  https://arxiv.org/abs/2606.11688
+"""
+
+from __future__ import annotations
+
+import enum
+import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+
+import structlog
+
+from .exceptions import AirlockError
+
+logger = structlog.get_logger("agent-airlock.done_receipt_guard")
+
+# A falsifiable check: a zero-arg callable returning True iff the claim holds.
+# It must be able to FAIL (return False / raise) — a check that can only return
+# True is not falsifiable and provides no evidence.
+FalsifiableCheck = Callable[[], bool]
+
+
+class DoneClaimVerdict(str, enum.Enum):
+    """Stable reason codes for :class:`DoneClaimDecision`."""
+
+    ALLOW = "allow"
+    STALL_NO_RECEIPT = "stall_no_receipt"  # claim made, check never ran this run
+    STALL_CHECK_FAILED = "stall_check_failed"  # check ran and returned False
+    STALL_FORGED_RECEIPT = "stall_forged_receipt"  # receipt present but not executed this run
+    STALL_UNKNOWN_CLAIM = "stall_unknown_claim"  # no falsifiable check registered for claim
+
+
+@dataclass(frozen=True)
+class CheckReceipt:
+    """Evidence that a falsifiable check executed (and its pass/fail) this run.
+
+    Attributes:
+        claim: The terminal claim this receipt is evidence for.
+        passed: True iff the check returned True when executed.
+        run_token: The guard's per-run token, stamped at execution time. A
+            receipt whose ``run_token`` does not match the guard's live token
+            is forged / stale and is rejected.
+        executed: True iff the guard actually ran the check to produce this
+            receipt. A hand-built receipt left at the default ``False`` is
+            rejected even before the token check.
+        elapsed_ms: Wall-time the check took, for the audit trail.
+    """
+
+    claim: str
+    passed: bool
+    run_token: str
+    executed: bool = False
+    elapsed_ms: float = 0.0
+
+
+@dataclass(frozen=True)
+class DoneClaimDecision:
+    """Outcome of a single :meth:`DoneReceiptGuard.check_done` call.
+
+    Mirrors the v0.7.x / v0.8.x guard decision family — exposes
+    ``allowed: bool`` so integrators can chain on one short-circuit predicate.
+
+    Attributes:
+        allowed: True iff the terminal claim is admitted (its check ran and
+            passed this run). False = fail-closed honest stall.
+        verdict: A stable :class:`DoneClaimVerdict` value.
+        detail: Free-form human-readable explanation.
+        claim: The terminal claim evaluated.
+        recoverable: Always True for a stall — the agent should run the named
+            check and retry, not abort. (An honest stall is recoverable; a
+            confident wrong ``done`` is not.)
+        fix_hints: LLM-actionable remediation hints.
+    """
+
+    allowed: bool
+    verdict: DoneClaimVerdict
+    detail: str
+    claim: str
+    recoverable: bool = False
+    fix_hints: list[str] = field(default_factory=list)
+
+
+class NoFalseSuccessStall(AirlockError):
+    """Raised by the ``no_false_success`` preset's ``check`` on a fail-closed stall.
+
+    Carries the :class:`DoneClaimDecision` and exposes ``fix_hints`` +
+    ``recoverable`` so an upstream airlock layer can route the refusal into a
+    retry of the named check rather than an abort (an honest stall is
+    recoverable; a confident wrong ``done`` is not).
+
+    Attributes:
+        decision: The stall decision that triggered the refusal.
+        fix_hints: LLM-actionable remediation hints.
+        recoverable: Always True — run the named check and retry.
+    """
+
+    def __init__(self, decision: DoneClaimDecision) -> None:
+        self.decision = decision
+        self.fix_hints = decision.fix_hints
+        self.recoverable = decision.recoverable
+        super().__init__(decision.detail)
+
+
+class DoneReceiptGuard:
+    """Fail-closed gate that rejects a terminal claim without a live, passing receipt.
+
+    Construct with a registry of falsifiable checks keyed by claim. Run a check
+    with :meth:`run` (which stamps a receipt with the live run token), then call
+    :meth:`check_done` on the terminal/``done`` claim — it is admitted only when
+    a receipt for that claim exists, was executed THIS run, and passed.
+
+    Args:
+        checks: Mapping of claim → falsifiable check (zero-arg ``() -> bool``).
+        run_token: The per-run execution token. Defaults to a fresh random
+            token; pass a fixed value only for deterministic tests.
+
+    Raises:
+        TypeError: a registered check is not callable.
+    """
+
+    def __init__(
+        self,
+        checks: Mapping[str, FalsifiableCheck],
+        *,
+        run_token: str | None = None,
+    ) -> None:
+        for claim, fn in checks.items():
+            if not callable(fn):
+                raise TypeError(f"check for claim {claim!r} is not callable: {fn!r}")
+        self._checks: dict[str, FalsifiableCheck] = dict(checks)
+        self._run_token = run_token or secrets.token_hex(16)
+        self._receipts: dict[str, CheckReceipt] = {}
+
+    @property
+    def run_token(self) -> str:
+        """The live per-run execution token receipts are bound to."""
+        return self._run_token
+
+    @property
+    def registered_claims(self) -> tuple[str, ...]:
+        """The claims that have a falsifiable check registered (sorted)."""
+        return tuple(sorted(self._checks))
+
+    def run(self, claim: str) -> CheckReceipt:
+        """Execute the falsifiable check for ``claim`` and record a live receipt.
+
+        Args:
+            claim: The claim whose check to execute.
+
+        Returns:
+            The :class:`CheckReceipt` (also stored internally), stamped with the
+            live run token and the executed pass/fail.
+
+        Raises:
+            KeyError: no check is registered for ``claim``.
+        """
+        if claim not in self._checks:
+            raise KeyError(f"no falsifiable check registered for claim {claim!r}")
+        start = _now_ms()
+        try:
+            passed = bool(self._checks[claim]())
+        except Exception as exc:  # a check that raises is a FAIL, not a crash
+            logger.warning("done_receipt_check_raised", claim=claim, error=str(exc))
+            passed = False
+        receipt = CheckReceipt(
+            claim=claim,
+            passed=passed,
+            run_token=self._run_token,
+            executed=True,
+            elapsed_ms=round(_now_ms() - start, 3),
+        )
+        self._receipts[claim] = receipt
+        logger.info("done_receipt_recorded", claim=claim, passed=passed)
+        return receipt
+
+    def check_done(
+        self,
+        claim: str,
+        *,
+        receipt: CheckReceipt | None = None,
+    ) -> DoneClaimDecision:
+        """Admit a terminal claim only if its check ran and passed this run.
+
+        Args:
+            claim: The terminal/``done`` claim being made.
+            receipt: Optional externally-supplied receipt. When omitted, the
+                guard uses the receipt it recorded via :meth:`run`. An external
+                receipt is still validated against the live run token — a
+                fabricated one is rejected as forged.
+
+        Returns:
+            :class:`DoneClaimDecision`. ``allowed=False`` is a recoverable
+            honest stall; map it to a retry of the named check, not an abort.
+        """
+        if claim not in self._checks:
+            return self._stall(
+                DoneClaimVerdict.STALL_UNKNOWN_CLAIM,
+                claim,
+                f"terminal claim {claim!r} has no registered falsifiable check; "
+                f"cannot verify success",
+                [
+                    f"Register a falsifiable check for {claim!r} before claiming done.",
+                    f"Known claims: {', '.join(self.registered_claims) or '<none>'}",
+                ],
+            )
+
+        effective = receipt if receipt is not None else self._receipts.get(claim)
+        if effective is None:
+            return self._stall(
+                DoneClaimVerdict.STALL_NO_RECEIPT,
+                claim,
+                f"terminal claim {claim!r} made but its check never executed this run",
+                [
+                    f"Run the {claim!r} check this execution (guard.run({claim!r})) "
+                    f"and only then claim done.",
+                ],
+            )
+
+        # Forgery floor: the receipt must have been executed AND carry the live
+        # run token. A present-but-not-executed receipt, or one stamped with a
+        # stale/foreign token (replayed or fabricated), is rejected.
+        if not effective.executed or not _token_matches(effective.run_token, self._run_token):
+            return self._stall(
+                DoneClaimVerdict.STALL_FORGED_RECEIPT,
+                claim,
+                f"receipt for {claim!r} is not bound to this execution "
+                f"(executed={effective.executed}, token_match="
+                f"{_token_matches(effective.run_token, self._run_token)}) — refusing",
+                [
+                    "A receipt only counts if THIS guard executed the check this run.",
+                    f"Call guard.run({claim!r}) to produce a live receipt; do not "
+                    f"construct or replay one.",
+                ],
+            )
+
+        if not effective.passed:
+            return self._stall(
+                DoneClaimVerdict.STALL_CHECK_FAILED,
+                claim,
+                f"the {claim!r} check executed this run and FAILED — refusing the terminal claim",
+                [
+                    f"The {claim!r} check returned false. Do the work so the check "
+                    f"passes, then re-run it and claim done.",
+                ],
+            )
+
+        logger.info("done_claim_allowed", claim=claim)
+        return DoneClaimDecision(
+            allowed=True,
+            verdict=DoneClaimVerdict.ALLOW,
+            detail=f"terminal claim {claim!r} verified: check executed this run and passed",
+            claim=claim,
+            recoverable=False,
+            fix_hints=[],
+        )
+
+    def _stall(
+        self,
+        verdict: DoneClaimVerdict,
+        claim: str,
+        detail: str,
+        fix_hints: list[str],
+    ) -> DoneClaimDecision:
+        logger.warning("done_claim_stalled", claim=claim, verdict=verdict.value)
+        return DoneClaimDecision(
+            allowed=False,
+            verdict=verdict,
+            detail=detail,
+            claim=claim,
+            recoverable=True,
+            fix_hints=fix_hints,
+        )
+
+
+def _now_ms() -> float:
+    import time
+
+    return time.monotonic() * 1000.0
+
+
+def _token_matches(a: str, b: str) -> bool:
+    """Constant-time token compare (tokens are unforgeable secrets)."""
+    import hmac
+
+    return bool(a) and bool(b) and hmac.compare_digest(a, b)
+
+
+__all__ = [
+    "CheckReceipt",
+    "DoneClaimDecision",
+    "DoneClaimVerdict",
+    "DoneReceiptGuard",
+    "FalsifiableCheck",
+    "NoFalseSuccessStall",
+]

--- a/src/agent_airlock/policy_presets.py
+++ b/src/agent_airlock/policy_presets.py
@@ -3782,6 +3782,80 @@ def mcp_subprocess_arg_injection_guard_defaults(
     }
 
 
+def no_false_success_defaults(
+    checks: Mapping[str, Any],
+    *,
+    run_token: str | None = None,
+) -> dict[str, Any]:
+    """Fail-closed terminal-claim guard preset (v0.8.25+, Goal-Autopilot).
+
+    Goal-Autopilot (arXiv:2606.11688) enforces a hard floor for unattended
+    long-horizon agents: **no terminal "done" claim is admitted unless its
+    falsifiable gate actually executed and passed**, and the worst case
+    degrades to an *honest stall, never a fabricated success*. This preset
+    wires :class:`agent_airlock.done_receipt_guard.DoneReceiptGuard` with an
+    operator-supplied registry of falsifiable checks keyed by claim.
+
+    Honest stall is recoverable; a confident wrong ``done`` is not — so a
+    failed verification returns ``allowed=False`` with ``recoverable=True``
+    (run the named check and retry), it does not abort.
+
+    Args:
+        checks: Mapping of claim → falsifiable check (zero-arg ``() -> bool``).
+            A check must be able to FAIL; one that can only return True is not
+            falsifiable and provides no evidence.
+        run_token: The per-run execution token. Defaults to a fresh random
+            token; pass a fixed value only for deterministic tests.
+
+    Returns:
+        ``dict[str, Any]`` with the canonical ``preset_id`` / ``severity`` /
+        ``default_action`` keys, plus:
+
+        - ``guard`` — a pre-built ``DoneReceiptGuard``. Call ``guard.run(claim)``
+          to execute a check this run, then ``guard.check_done(claim)``.
+        - ``check`` — convenience callable; ``check(claim)`` raises
+          :class:`NoFalseSuccessStall` on a fail-closed stall and returns the
+          :class:`DoneClaimDecision` on an admitted claim.
+        - ``owasp`` — ``"ASI06"`` (excessive agency / unverified autonomy).
+        - ``advisory_url`` — the Goal-Autopilot paper.
+
+    Usage::
+
+        from agent_airlock.policy_presets import no_false_success_defaults
+
+        preset = no_false_success_defaults({"tests_green": run_pytest})
+        preset["guard"].run("tests_green")          # execute the check this run
+        preset["check"]("tests_green")              # raises if it didn't pass
+
+    Primary source:
+      https://arxiv.org/abs/2606.11688
+    """
+    from .done_receipt_guard import (
+        DoneClaimDecision,
+        DoneReceiptGuard,
+        NoFalseSuccessStall,
+    )
+
+    guard = DoneReceiptGuard(checks, run_token=run_token)
+
+    def _check(claim: str) -> DoneClaimDecision:
+        """Raise :class:`NoFalseSuccessStall` on a fail-closed honest stall."""
+        decision = guard.check_done(claim)
+        if not decision.allowed:
+            raise NoFalseSuccessStall(decision)
+        return decision
+
+    return {
+        "preset_id": "no_false_success",
+        "severity": "high",
+        "default_action": "deny",
+        "guard": guard,
+        "check": _check,
+        "owasp": "ASI06",
+        "advisory_url": "https://arxiv.org/abs/2606.11688",
+    }
+
+
 __all__ = [
     # Factory functions (stateless; use these for dynamic overrides)
     "gtg_1002_defense_policy",
@@ -3876,4 +3950,6 @@ __all__ = [
     "codegen_delimiter_injection_guard_defaults",
     # V0.8.22 CVE-2026-42271 (LiteLLM MCP-bridge subprocess command/args/env RCE; CISA KEV)
     "mcp_subprocess_arg_injection_guard_defaults",
+    # V0.8.25 Goal-Autopilot (arXiv:2606.11688) fail-closed terminal-claim guard
+    "no_false_success_defaults",
 ]

--- a/tests/test_done_receipt_guard.py
+++ b/tests/test_done_receipt_guard.py
@@ -1,0 +1,214 @@
+"""Tests for the v0.8.25 fail-closed terminal-claim guard (no_false_success).
+
+Goal-Autopilot (arXiv:2606.11688) enforces a hard floor for unattended
+long-horizon agents: no terminal "done" claim is admitted unless its
+falsifiable gate actually executed and passed this run, and the worst case
+degrades to an *honest stall, never a fabricated success*. These tests pin the
+three core cases from the brief plus the forgery / replay floor:
+
+- (a) a terminal claim with a passing receipt → allowed;
+- (b) a terminal claim with NO receipt / a non-executed check → fail-closed
+  stall (recoverable);
+- (c) a forged receipt (check object present but never executed) → fail-closed.
+
+Honest stall is recoverable; a confident wrong done is not — so every stall
+carries ``recoverable=True``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_airlock import (
+    AirlockConfig,
+    CheckReceipt,
+    DoneClaimVerdict,
+    DoneReceiptGuard,
+    NoFalseSuccessStall,
+    no_false_success_defaults,
+)
+
+
+def _checks(state: dict) -> dict:
+    """A registry of falsifiable checks keyed by claim, backed by mutable state."""
+    return {
+        "tests_green": lambda: state.get("tests_pass", False),
+        "deploy_live": lambda: state.get("deployed", False),
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) passing receipt → allowed
+# ---------------------------------------------------------------------------
+
+
+class TestPassingReceiptAllowed:
+    def test_executed_and_passed_is_allowed(self) -> None:
+        state = {"tests_pass": True}
+        guard = DoneReceiptGuard(_checks(state))
+        receipt = guard.run("tests_green")  # executes the check THIS run
+        assert receipt.executed is True
+        assert receipt.passed is True
+        decision = guard.check_done("tests_green")
+        assert decision.allowed is True
+        assert decision.verdict is DoneClaimVerdict.ALLOW
+        assert decision.recoverable is False  # success is terminal, not a stall
+
+    def test_preset_check_returns_decision_on_pass(self) -> None:
+        preset = no_false_success_defaults({"tests_green": lambda: True})
+        preset["guard"].run("tests_green")
+        decision = preset["check"]("tests_green")  # does not raise
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# (b) no receipt / non-executed check → fail-closed stall (recoverable)
+# ---------------------------------------------------------------------------
+
+
+class TestNoReceiptStalls:
+    def test_no_receipt_is_fail_closed_stall(self) -> None:
+        guard = DoneReceiptGuard(_checks({"tests_pass": True}))
+        # The check would pass — but it was never run this execution.
+        decision = guard.check_done("tests_green")
+        assert decision.allowed is False
+        assert decision.verdict is DoneClaimVerdict.STALL_NO_RECEIPT
+        assert decision.recoverable is True
+        assert decision.fix_hints  # tells the agent to run the check + retry
+
+    def test_executed_but_failed_check_stalls(self) -> None:
+        state = {"tests_pass": False}
+        guard = DoneReceiptGuard(_checks(state))
+        guard.run("tests_green")  # executes, returns False
+        decision = guard.check_done("tests_green")
+        assert decision.allowed is False
+        assert decision.verdict is DoneClaimVerdict.STALL_CHECK_FAILED
+        assert decision.recoverable is True
+
+    def test_unknown_claim_stalls(self) -> None:
+        guard = DoneReceiptGuard(_checks({}))
+        decision = guard.check_done("colonize_mars")
+        assert decision.allowed is False
+        assert decision.verdict is DoneClaimVerdict.STALL_UNKNOWN_CLAIM
+        assert decision.recoverable is True
+
+    def test_check_that_raises_counts_as_fail_not_crash(self) -> None:
+        def boom() -> bool:
+            raise RuntimeError("check blew up")
+
+        guard = DoneReceiptGuard({"risky": boom})
+        guard.run("risky")  # must not propagate the exception
+        decision = guard.check_done("risky")
+        assert decision.verdict is DoneClaimVerdict.STALL_CHECK_FAILED
+
+    def test_preset_check_raises_recoverable_stall(self) -> None:
+        preset = no_false_success_defaults({"x": lambda: False})
+        preset["guard"].run("x")
+        with pytest.raises(NoFalseSuccessStall) as exc:
+            preset["check"]("x")
+        assert exc.value.recoverable is True
+        assert exc.value.decision.verdict is DoneClaimVerdict.STALL_CHECK_FAILED
+
+
+# ---------------------------------------------------------------------------
+# (c) forged receipt (present but never executed) → fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestForgedReceiptStalls:
+    def test_receipt_present_but_not_executed_is_forged(self) -> None:
+        guard = DoneReceiptGuard(_checks({"tests_pass": True}))
+        # A hand-built receipt: claims passed, but executed=False (default) and
+        # carries no live run token — never actually ran the check.
+        forged = CheckReceipt(claim="tests_green", passed=True, run_token="made-up")
+        decision = guard.check_done("tests_green", receipt=forged)
+        assert decision.allowed is False
+        assert decision.verdict is DoneClaimVerdict.STALL_FORGED_RECEIPT
+        assert decision.recoverable is True
+
+    def test_receipt_with_executed_true_but_wrong_token_is_forged(self) -> None:
+        guard = DoneReceiptGuard(_checks({"tests_pass": True}))
+        forged = CheckReceipt(
+            claim="tests_green", passed=True, run_token="not-the-live-token", executed=True
+        )
+        decision = guard.check_done("tests_green", receipt=forged)
+        assert decision.verdict is DoneClaimVerdict.STALL_FORGED_RECEIPT
+
+    def test_replayed_receipt_from_another_run_is_forged(self) -> None:
+        # A genuine receipt from run A, replayed into run B, must not pass —
+        # each run mints a distinct token.
+        run_a = DoneReceiptGuard(_checks({"tests_pass": True}), run_token="run-A")
+        run_b = DoneReceiptGuard(_checks({"tests_pass": True}), run_token="run-B")
+        genuine_a = run_a.run("tests_green")
+        assert genuine_a.passed is True
+        decision = run_b.check_done("tests_green", receipt=genuine_a)
+        assert decision.verdict is DoneClaimVerdict.STALL_FORGED_RECEIPT
+
+    def test_live_receipt_passed_explicitly_is_accepted(self) -> None:
+        # Passing the guard's own live receipt back in is fine (not forged).
+        guard = DoneReceiptGuard(_checks({"tests_pass": True}))
+        live = guard.run("tests_green")
+        decision = guard.check_done("tests_green", receipt=live)
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Construction, metadata, config flag, exports
+# ---------------------------------------------------------------------------
+
+
+class TestStructure:
+    def test_non_callable_check_raises(self) -> None:
+        with pytest.raises(TypeError, match="not callable"):
+            DoneReceiptGuard({"bad": "not-a-callable"})  # type: ignore[dict-item]
+
+    def test_run_unknown_claim_raises_keyerror(self) -> None:
+        guard = DoneReceiptGuard({"a": lambda: True})
+        with pytest.raises(KeyError):
+            guard.run("nonexistent")
+
+    def test_registered_claims_sorted(self) -> None:
+        guard = DoneReceiptGuard({"z": lambda: True, "a": lambda: True})
+        assert guard.registered_claims == ("a", "z")
+
+    def test_distinct_run_tokens_by_default(self) -> None:
+        g1 = DoneReceiptGuard({"a": lambda: True})
+        g2 = DoneReceiptGuard({"a": lambda: True})
+        assert g1.run_token != g2.run_token  # fresh per instance
+
+    def test_preset_canonical_metadata(self) -> None:
+        preset = no_false_success_defaults({"a": lambda: True})
+        assert preset["preset_id"] == "no_false_success"
+        assert preset["default_action"] == "deny"
+        assert preset["severity"] == "high"
+        assert preset["owasp"] == "ASI06"
+        assert preset["advisory_url"] == "https://arxiv.org/abs/2606.11688"
+        assert isinstance(preset["guard"], DoneReceiptGuard)
+
+    def test_config_flag_default_off(self) -> None:
+        assert AirlockConfig().require_done_receipt is False
+
+    def test_config_flag_constructor_on(self) -> None:
+        assert AirlockConfig(require_done_receipt=True).require_done_receipt is True
+
+    def test_config_flag_from_toml(self, tmp_path) -> None:
+        toml = tmp_path / "airlock.toml"
+        toml.write_text("[airlock]\nrequire_done_receipt = true\n")
+        assert AirlockConfig.from_toml(toml).require_done_receipt is True
+
+    def test_public_exports_present(self) -> None:
+        import agent_airlock as a
+
+        for name in (
+            "DoneReceiptGuard",
+            "DoneClaimDecision",
+            "DoneClaimVerdict",
+            "CheckReceipt",
+            "NoFalseSuccessStall",
+            "no_false_success_defaults",
+        ):
+            assert hasattr(a, name) and name in a.__all__
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

A fail-closed guard that rejects an agent's terminal/`done` claim unless a **named, falsifiable check actually executed and passed in this run**. Anchored on [Goal-Autopilot (arXiv:2606.11688)](https://arxiv.org/abs/2606.11688) — "A Verifiable Anti-Fabrication Firewall for Unattended Long-Horizon Agents" — whose No-False-Success floor admits no terminal claim whose falsifiable gate did not execute and pass, degrading worst-case to an **honest stall, never a fabricated success**.

> An honest stall is recoverable; a confident wrong `done` is not.

### What's added
- **`agent_airlock.done_receipt_guard.DoneReceiptGuard`** (stdlib-only — `secrets`/`hmac`/`time`, **no new runtime dependency**): holds a registry of falsifiable checks keyed by claim. `run(claim)` executes a check and records a receipt stamped with the guard's **per-run token**; `check_done(claim)` admits the terminal claim only if a receipt exists, was **executed THIS run**, and passed. Verdicts: `ALLOW`, `STALL_NO_RECEIPT`, `STALL_CHECK_FAILED`, `STALL_FORGED_RECEIPT`, `STALL_UNKNOWN_CLAIM`. Every stall is `recoverable=True`. A check that raises counts as a fail, not a crash.
  - **Forgery resistance is structural:** a receipt that's merely *present* — hand-built (`executed=False`) or replayed from another run (foreign token) — is rejected; only a receipt the guard stamped by executing the check this run is trusted.
- **`policy_presets.no_false_success_defaults(checks, *, run_token=None)`** — canonical `preset_id="no_false_success"` / `severity="high"` / `default_action="deny"` / `owasp="ASI06"` dict + a pre-built `guard` and a `check(claim)` callable raising `NoFalseSuccessStall` (carries the decision + `recoverable`). **Diff-compatible** with the existing preset-registration shape — a new preset, not a breaking change.
- **Opt-in per agent** — `AirlockConfig.require_done_receipt` (OFF by default; constructor or `require_done_receipt = true` under `[airlock]` in `airlock.toml`), wired into `from_toml`.

## Test Plan
- `tests/test_done_receipt_guard.py` — **20 tests** covering the brief's three cases: (a) terminal claim with a passing receipt → allowed; (b) NO receipt / non-executed / failed / unknown claim → recoverable fail-closed stall; (c) forged receipt (present but never executed) **and** replayed cross-run receipt → fail-closed. Plus config-flag (default-off / constructor / TOML) and exports.
- Full suite: **3021 passed**, 33 skipped; coverage **84.96%** (gate 82%).
- `ruff check src/ tests/` + `ruff format --check` clean; `mypy src` net-zero new (8 pre-existing baseline); `bandit` exit 0.
- README feature section; CHANGELOG `[0.8.25]`; version 0.8.24 → 0.8.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)