### PR TITLE
chore(dev): pin bandit floor to >=1.9.4 to match CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,12 @@ dev = [
     "pytest-benchmark>=4.0",
     "mypy>=1.8",
     "ruff>=0.2",
-    # Security tools
-    "bandit>=1.7",
+    # Security tools. bandit floor pinned to 1.9.4 to match the CI image:
+    # 1.9.x is stricter than 1.8.x (e.g. flags dict keys / vars named like
+    # secrets as B105), so a lower local floor caused "passes locally, fails
+    # CI" skew (hit during the v0.8.17 cycle). Pinning the floor keeps a fresh
+    # `[dev]` install in lockstep with CI.
+    "bandit>=1.9.4",
     "safety>=3.0",
     # SBOM generation
     "cyclonedx-bom>=4.0",


### PR DESCRIPTION
## Summary

Pins the `[dev]` `bandit` floor from `>=1.7` to `>=1.9.4` so a fresh local install stays in lockstep with the CI image. bandit 1.9.x is stricter than 1.8.x (e.g. flags dict keys / variables *named* like secrets as B105), so the lower floor produced "passes locally, fails CI" skew — which bit the v0.8.17 cycle and required installing `bandit==1.9.4` locally to reproduce.

**Dev-tooling only** — not a runtime dependency, no change to the shipped wheel, so **no version bump and no release**. This closes the standing follow-up flagged earlier.

## Test Plan
- `pyproject.toml` remains valid TOML; the installed bandit (1.9.4) satisfies the new floor.
- No runtime/wheel change — `git diff` touches only the `[dev]` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)