### PR TITLE
fix(version): self-report real version + lockstep regression guard (v0.8.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ _Nothing unreleased — every entry below is a tagged release._
 
 ---
 
+## [0.8.27] - 2026-06-21 — "Version self-report fix"
+
+### Fixed
+
+- **fix(version): self-report the real version + lockstep regression guard**
+
+  The 0.8.26 release bumped `pyproject.toml` but not
+  `agent_airlock.__version__`, so the published 0.8.26 wheel reported
+  `import agent_airlock; agent_airlock.__version__ == "0.8.25"`. Both are now
+  pinned to `0.8.27`, and a new regression test
+  (`tests/test_version_consistency.py`) asserts `__version__` equals
+  `pyproject.toml` `[project].version` — a future one-sided bump fails CI here
+  instead of shipping a wheel that lies about its own version. No runtime
+  behavior change.
+
+---
+
 ## [0.8.26] - 2026-06-13 — "Balance-aware codegen break-out + public guard benchmark"
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.26"
+version = "0.8.27"
 description = "A type-checker for AI tool calls — strict argument validation, ghost-argument stripping, and self-healing retries for MCP servers and agent frameworks."
 readme = "README.md"
 license = "MIT"

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -641,7 +641,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.8.25"
+__version__ = "0.8.27"
 
 __all__ = [
     # Core

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,35 @@
+"""Single-source-of-truth guard for the package version.
+
+The 0.8.26 release bumped ``pyproject.toml`` but not
+``agent_airlock.__version__``, so the published 0.8.26 wheel self-reported
+``__version__ == "0.8.25"``. This regression pins the two together: a future
+release that bumps one and forgets the other fails CI here instead of shipping
+a wheel that lies about its own version.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import agent_airlock
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on 3.10
+    import tomli as tomllib
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _pyproject_version() -> str:
+    with _PYPROJECT.open("rb") as fh:
+        return str(tomllib.load(fh)["project"]["version"])
+
+
+class TestVersionConsistency:
+    def test_dunder_version_matches_pyproject(self) -> None:
+        assert agent_airlock.__version__ == _pyproject_version(), (
+            "agent_airlock.__version__ and pyproject.toml [project].version have "
+            "drifted — bump both in lockstep on every release."
+        )


### PR DESCRIPTION
## Summary

The **0.8.26** release bumped `pyproject.toml` but not `agent_airlock.__version__`, so the published 0.8.26 wheel self-reports the wrong version:

```python
>>> import agent_airlock; agent_airlock.__version__
'0.8.25'   # on the 0.8.26 wheel
```

Caught by a clean-venv smoke test against the published wheel. This pins both version sources to **0.8.27** and adds a regression guard so it can't recur.

## Changes

- `src/agent_airlock/__init__.py` — `__version__` `0.8.25` → `0.8.27`
- `pyproject.toml` — `version` `0.8.26` → `0.8.27`
- `tests/test_version_consistency.py` (new) — asserts `agent_airlock.__version__ == pyproject [project].version`; a future one-sided bump now fails CI instead of shipping a wheel that lies about its own version
- `CHANGELOG.md` — `[0.8.27]` section

No runtime behavior change.

## Test Plan

- `pytest tests/` — **3035 passed**, 33 skipped, coverage 84.98% (> 82% gate)
- `tests/test_version_consistency.py` passes; verified it **fails** when the two versions are out of sync
- `ruff check` / `ruff format --check` clean; `mypy src/` unchanged (same pre-existing 8-error baseline as `main`, identical diff)
- Benchmark drift gate: `BENCHMARK.md is up to date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)