### PR TITLE
fix: remove placeholder CVE ids from preset registry (add CI guard); docs: type-checker/contract-layer wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ _Nothing unreleased — every entry below is a tagged release._
 
 ---
 
+## [0.8.36] - 2026-06-23 — "Placeholder-CVE CI guard + type-checker/contract-layer wedge"
+
+### Fixed
+
+- **fix: remove placeholder CVE ids from preset registry (add CI guard)**
+
+  Replaced the one synthetic placeholder id in the repo — `CVE-2026-99999`
+  (a `tests/cli/test_egress_bench_since.py` date-filter fixture, source
+  `example.com`) — with a real disclosed CVE (`CVE-2025-59528`, Flowise) and
+  its NVD URL. The preset registry itself (`policy_presets.py`) was already
+  free of placeholder / reserved / example ids; this adds a regression guard so
+  it stays that way. New `tests/test_no_placeholder_cves.py` scans the registry
+  source for every `CVE-…` id and fails on placeholder sequence numbers
+  (`99999` / `00000` / `12345` …), non-numeric stubs (`CVE-XXXX-…`), or any id
+  not matching the canonical `CVE-YYYY-NNNN` shape — and asserts the known-real
+  anchors are present so the guard can't silently pass on an empty match set.
+  (Structural invariant only — live nvd.nist.gov resolution is not a
+  deterministic offline unit test.)
+
+### Changed
+
+- **docs: lead with the type-checker / contract-layer wedge**
+
+  README hero and the PyPI/`pyproject` description now lead with *"A
+  type-checker and contract layer for AI agent tool calls — deny-by-default,
+  in-process, zero-dep."* Wording only — the `@Airlock` decorator surface, the
+  deny-by-default posture, and the Pydantic-only / zero-runtime-dep core claim
+  are all unchanged.
+
+---
+
 ## [0.8.35] - 2026-06-22 — "ToolPrivBench-style least-privilege block-rate benchmark"
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=700&size=28&duration=3000&pause=1000&color=00D4FF&center=true&vCenter=true&multiline=true&repeat=true&width=700&height=100&lines=%F0%9F%9B%A1%EF%B8%8F+Agent-Airlock;Your+AI+Agent+Just+Tried+rm+-rf+%2F.+We+Stopped+It." alt="Agent-Airlock Typing Animation" />
 </a>
 
-### A type-checker for AI tool calls
+### A type-checker and contract layer for AI agent tool calls — deny-by-default, in-process, zero-dep
 
 **Strict validation, ghost-argument stripping, and self-healing retries — one decorator, any agent or MCP server.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-airlock"
-version = "0.8.35"
-description = "A type-checker for AI tool calls — strict argument validation, ghost-argument stripping, and self-healing retries for MCP servers and agent frameworks."
+version = "0.8.36"
+description = "A type-checker and contract layer for AI agent tool calls — deny-by-default, in-process, zero-dep. Strict argument validation, ghost-argument stripping, and self-healing retries for MCP servers and agent frameworks."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"

--- a/src/agent_airlock/__init__.py
+++ b/src/agent_airlock/__init__.py
@@ -680,7 +680,7 @@ from .vaccine import (
 )
 from .validator import GhostArgumentError
 
-__version__ = "0.8.35"
+__version__ = "0.8.36"
 
 __all__ = [
     # Core

--- a/tests/cli/test_egress_bench_since.py
+++ b/tests/cli/test_egress_bench_since.py
@@ -55,7 +55,14 @@ def tmp_fixture_dir(tmp_path: Path) -> Path:
         d / "fresh_cve.json",
         {
             "disclosed_at": "2026-04-24",
-            "cves": [{"id": "CVE-2026-99999", "source": "https://example.com"}],
+            # Real disclosed CVE used as fixture data (no placeholder ids in-repo).
+            # CVE-2025-59528 — Flowise custom-tool RCE. https://nvd.nist.gov/vuln/detail/CVE-2025-59528
+            "cves": [
+                {
+                    "id": "CVE-2025-59528",
+                    "source": "https://nvd.nist.gov/vuln/detail/CVE-2025-59528",
+                }
+            ],
         },
     )
     return d

--- a/tests/test_no_placeholder_cves.py
+++ b/tests/test_no_placeholder_cves.py
@@ -1,0 +1,82 @@
+"""CI guard: the preset registry must cite only real-shaped CVE ids.
+
+Scans ``policy_presets.py`` (and the canonical ``cves=`` tuples it exposes) for
+every ``CVE-…`` identifier and fails if any matches a placeholder / reserved /
+example pattern (``99999``, ``00000``, ``XXXX``, ``YYYY``, ``12345`` …) or does
+not match the canonical NVD id shape ``CVE-<year>-<digits>``.
+
+This does NOT (and cannot, offline) assert each id resolves on nvd.nist.gov —
+that needs network and is not a deterministic unit test. It enforces the
+structural invariant that catches the failure this guard exists for: a
+placeholder id slipping into the per-CVE regression suite.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_PRESETS = Path(__file__).resolve().parents[1] / "src" / "agent_airlock" / "policy_presets.py"
+
+# Canonical NVD id shape: CVE-YYYY-NNNN (4+ digit sequence).
+_CVE_RE = re.compile(r"CVE-\d{4}-\d{3,7}")
+# Anything CVE-shaped at all, so we also catch non-numeric stubs (CVE-XXXX-...).
+_CVE_LOOSE_RE = re.compile(r"CVE-[0-9A-Za-z]+-[0-9A-Za-z]+")
+
+# Placeholder / reserved / example sequence-number patterns that must never
+# appear as a CVE sequence number in the registry.
+_PLACEHOLDER_SEQS = {"99999", "999999", "00000", "0000", "12345", "11111"}
+_PLACEHOLDER_TOKENS = ("XXXX", "YYYY", "NNNN", "XXX")
+
+
+def _registry_source() -> str:
+    return _PRESETS.read_text(encoding="utf-8")
+
+
+def test_presets_file_exists() -> None:
+    assert _PRESETS.is_file(), f"preset registry not found at {_PRESETS}"
+
+
+def test_no_nonnumeric_placeholder_cve_ids() -> None:
+    src = _registry_source()
+    for token in _PLACEHOLDER_TOKENS:
+        bad = re.findall(rf"CVE-[^\s`'\"]*{token}[^\s`'\"]*", src)
+        assert not bad, f"non-numeric placeholder CVE id(s) in preset registry: {bad}"
+
+
+def test_no_placeholder_sequence_numbers() -> None:
+    src = _registry_source()
+    offenders = [cve for cve in _CVE_RE.findall(src) if cve.split("-")[-1] in _PLACEHOLDER_SEQS]
+    assert not offenders, f"placeholder-sequence CVE id(s) in preset registry: {offenders}"
+
+
+def test_every_cve_id_matches_canonical_shape() -> None:
+    src = _registry_source()
+    loose = set(_CVE_LOOSE_RE.findall(src))
+    canonical = set(_CVE_RE.findall(src))
+    malformed = sorted(loose - canonical)
+    assert not malformed, f"CVE id(s) not matching canonical CVE-YYYY-NNNN shape: {malformed}"
+
+
+def test_registry_actually_cites_real_cves() -> None:
+    # Sanity: the scan finds the known-real anchors, so the guard is not a no-op
+    # against an empty match set.
+    src = _registry_source()
+    found = set(_CVE_RE.findall(src))
+    for known_real in ("CVE-2025-59528", "CVE-2026-30615", "CVE-2026-25592", "CVE-2026-26030"):
+        assert known_real in found, f"expected real anchor CVE {known_real} missing from registry"
+
+
+@pytest.mark.parametrize("placeholder", ["CVE-2026-99999", "CVE-XXXX-0000", "CVE-2026-00000"])
+def test_guard_would_catch_a_placeholder(placeholder: str) -> None:
+    # The guard's own detectors fire on a synthetic placeholder — proves the
+    # patterns are live, not silently passing.
+    seq = placeholder.split("-")[-1]
+    caught = (
+        seq in _PLACEHOLDER_SEQS
+        or any(tok in placeholder for tok in _PLACEHOLDER_TOKENS)
+        or not _CVE_RE.fullmatch(placeholder)
+    )
+    assert caught, f"guard failed to flag placeholder {placeholder}"


### PR DESCRIPTION
Two credibility changes; architecture unchanged.

## A. Placeholder / reserved CVE ids

- **The preset registry was already clean** — all 38 CVE ids in `policy_presets.py` are real-shaped (no `99999`/`00000`/`XXXX`). The only placeholder in the repo was a synthetic **date-filter test fixture**: `CVE-2026-99999` (source `example.com`) in `tests/cli/test_egress_bench_since.py`. Replaced with a real disclosed CVE — **CVE-2025-59528** (Flowise) — and its NVD URL.
- **New CI guard** `tests/test_no_placeholder_cves.py`: scans the registry source for every `CVE-…` id and fails on placeholder sequence numbers (`99999`/`00000`/`12345`/…), non-numeric stubs (`CVE-XXXX-…`), or any id not matching the canonical `CVE-YYYY-NNNN` shape. It also asserts the known-real anchors (`CVE-2025-59528`, `CVE-2026-30615`, `CVE-2026-25592`, `CVE-2026-26030`) are present, so the guard can't silently pass against an empty match set, and includes a parametrized self-test proving its detectors fire on synthetic placeholders.

> Honest scope: this enforces the **structural invariant** (no placeholder/malformed ids). It does **not** assert each id resolves on nvd.nist.gov — that needs network and isn't a deterministic offline unit test.

## B. README positioning (wording, not a pivot)

- README hero + `pyproject`/PyPI `description` now lead with **"A type-checker and contract layer for AI agent tool calls — deny-by-default, in-process, zero-dep."**
- The `@Airlock` decorator content, the **deny-by-default** posture, and the **Pydantic-only / zero-runtime-dep core** claim are all unchanged.

## Test Plan

- Full suite: **3202 passed**; `ruff check` / `ruff format --check` clean; `mypy src/agent_airlock` unchanged (8-error baseline); benchmark drift gate green; version-consistency test passes (0.8.36).
- New guard: 8 tests pass and its detectors fire on synthetic placeholders.
- **Built-wheel SmokeTest** (clean venv, `agent_airlock-0.8.36.whl`): version self-reports `0.8.36`; the preset registry loads (52 active presets); 20 CVE ids sampled from `*_defaults()` factories — **zero placeholders**.

Bump **0.8.35 → 0.8.36**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)